### PR TITLE
feat: introduce AppsyncVTL subclass of VTL

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -18,7 +18,7 @@
       "type": "node",
       "request": "launch",
       "runtimeExecutable": "node",
-      "runtimeArgs": ["--nolazy"],
+      "runtimeArgs": ["--nolazy", "--enable-source-maps"],
       "args": ["./lib/app.js"],
       "outFiles": [
         "${workspaceRoot}/lib/**/*.js",

--- a/src/appsync.ts
+++ b/src/appsync.ts
@@ -1,7 +1,7 @@
 import * as appsync from "@aws-cdk/aws-appsync-alpha";
 import { AppSyncResolverEvent } from "aws-lambda";
 import { CallExpr, Expr } from "./expression";
-import { VTL } from "./vtl";
+import { AppsyncVTL, VTL } from "./vtl";
 import {
   ToAttributeMap,
   ToAttributeValue,
@@ -305,7 +305,9 @@ export class AppsyncResolver<
     ) {
       const templates: string[] = [];
       let template =
-        resolverCount === 0 ? new VTL() : new VTL(VTL.CircuitBreaker);
+        resolverCount === 0
+          ? new AppsyncVTL()
+          : new AppsyncVTL(AppsyncVTL.CircuitBreaker);
       const functions = decl.body.statements
         .map((stmt, i) => {
           const isLastExpr = i + 1 === decl.body.statements.length;
@@ -425,7 +427,7 @@ export class AppsyncResolver<
               const requestMappingTemplateString = template.toVTL();
               templates.push(requestMappingTemplateString);
               templates.push(responseMappingTemplate);
-              template = new VTL(VTL.CircuitBreaker);
+              template = new AppsyncVTL(AppsyncVTL.CircuitBreaker);
               const name = getUniqueName(
                 api,
                 appsyncSafeName(integration.kind)

--- a/src/table.ts
+++ b/src/table.ts
@@ -105,7 +105,7 @@ export class Table<
         const request = vtl.var(
           `{"operation": "GetItem", "version": "2018-05-29"}`
         );
-        vtl.qr(`${request}.put('key', ${input}.get('key'))`);
+        vtl.quiet(`${request}.put('key', ${input}.get('key'))`);
         addIfDefined(vtl, input, request, "consistentRead");
 
         return vtl.json(request);
@@ -149,8 +149,8 @@ export class Table<
         const request = vtl.var(
           `{"operation": "PutItem", "version": "2018-05-29"}`
         );
-        vtl.qr(`${request}.put('key', ${input}.get('key'))`);
-        vtl.qr(
+        vtl.quiet(`${request}.put('key', ${input}.get('key'))`);
+        vtl.quiet(
           `${request}.put('attributeValues', ${input}.get('attributeValues'))`
         );
         addIfDefined(vtl, input, request, "condition");
@@ -193,8 +193,8 @@ export class Table<
         const request = vtl.var(
           `{"operation": "UpdateItem", "version": "2018-05-29"}`
         );
-        vtl.qr(`${request}.put('key', ${input}.get('key'))`);
-        vtl.qr(`${request}.put('update', ${input}.get('update'))`);
+        vtl.quiet(`${request}.put('key', ${input}.get('key'))`);
+        vtl.quiet(`${request}.put('update', ${input}.get('update'))`);
         addIfDefined(vtl, input, request, "condition");
         addIfDefined(vtl, input, request, "_version");
 
@@ -233,7 +233,7 @@ export class Table<
         const request = vtl.var(
           `{"operation": "DeleteItem", "version": "2018-05-29"}`
         );
-        vtl.qr(`${request}.put('key', ${input}.get('key'))`);
+        vtl.quiet(`${request}.put('key', ${input}.get('key'))`);
         addIfDefined(vtl, input, request, "condition");
         addIfDefined(vtl, input, request, "_version");
 
@@ -273,7 +273,7 @@ export class Table<
         const request = vtl.var(
           `{"operation": "Query", "version": "2018-05-29"}`
         );
-        vtl.qr(`${request}.put('query', ${input}.get('query'))`);
+        vtl.quiet(`${request}.put('query', ${input}.get('query'))`);
         addIfDefined(vtl, input, request, "index");
         addIfDefined(vtl, input, request, "nextToken");
         addIfDefined(vtl, input, request, "limit");

--- a/test/appsync.test.ts
+++ b/test/appsync.test.ts
@@ -1,6 +1,6 @@
 import { Stack } from "aws-cdk-lib";
 import { AppsyncResolver, reflect, StepFunction } from "../src";
-import { VTL } from "../src/vtl";
+import { AppsyncVTL } from "../src/vtl";
 import {
   appsyncTestCase,
   appsyncVelocityJsonTestCase,
@@ -23,7 +23,7 @@ describe("step function integration", () => {
     appsyncTestCase(
       func,
       "{}",
-      `${VTL.CircuitBreaker}
+      `${AppsyncVTL.CircuitBreaker}
 #set($v1 = {})
 $util.qr($v1.put('stateMachineArn', '${machine.stateMachineArn}'))
 {
@@ -39,7 +39,7 @@ $util.qr($v1.put('stateMachineArn', '${machine.stateMachineArn}'))
   }
 }`,
       "{}",
-      VTL.CircuitBreaker
+      AppsyncVTL.CircuitBreaker
     );
 
     const templates = getAppSyncTemplates(func);
@@ -188,7 +188,7 @@ $util.qr($v1.put('stateMachineArn', '${machine.stateMachineArn}'))
     appsyncTestCase(
       func,
       "{}",
-      `${VTL.CircuitBreaker}
+      `${AppsyncVTL.CircuitBreaker}
 #set($context.stash.exec = 'exec1')
 {
   "version": "2018-05-29",
@@ -205,7 +205,7 @@ $util.qr($v1.put('stateMachineArn', '${machine.stateMachineArn}'))
   }
 }`,
       "{}",
-      VTL.CircuitBreaker
+      AppsyncVTL.CircuitBreaker
     );
 
     const templates = getAppSyncTemplates(func);
@@ -244,7 +244,7 @@ describe("step function describe execution", () => {
     appsyncTestCase(
       func,
       "{}",
-      `${VTL.CircuitBreaker}
+      `${AppsyncVTL.CircuitBreaker}
 {
   "version": "2018-05-29",
   "method": "POST",
@@ -260,7 +260,7 @@ describe("step function describe execution", () => {
   }
 }`,
       "{}",
-      VTL.CircuitBreaker
+      AppsyncVTL.CircuitBreaker
     );
 
     const templates = getAppSyncTemplates(func);

--- a/test/function.test.ts
+++ b/test/function.test.ts
@@ -2,7 +2,7 @@ import { App, aws_lambda, Stack } from "aws-cdk-lib";
 import "jest";
 import { AppsyncContext, reflect } from "../src";
 import { Function } from "../src";
-import { VTL } from "../src/vtl";
+import { AppsyncVTL } from "../src/vtl";
 import { appsyncTestCase } from "./util";
 
 interface Item {
@@ -34,7 +34,7 @@ test("call function", () =>
     // pipeline's request mapping template
     "{}",
     // function's request mapping template
-    `${VTL.CircuitBreaker}
+    `${AppsyncVTL.CircuitBreaker}
 #set($v1 = {\"version\": \"2018-05-29\", \"operation\": \"Invoke\", \"payload\": $context.arguments})
 $util.toJson($v1)`,
     // function's response mapping template
@@ -43,7 +43,7 @@ $util.toJson($v1)`,
 {}`,
     // response mapping template
     `#if($context.stash.return__flag)
-  #return($context.stash.return__val)
+#return($context.stash.return__val)
 #end`
   ));
 
@@ -61,7 +61,7 @@ test("call function and conditional return", () =>
     // pipeline's request mapping template
     "{}",
     // function's request mapping template
-    `${VTL.CircuitBreaker}
+    `${AppsyncVTL.CircuitBreaker}
 #set($v1 = {\"version\": \"2018-05-29\", \"operation\": \"Invoke\", \"payload\": $context.arguments})
 $util.toJson($v1)`,
     // function's response mapping template
@@ -69,7 +69,7 @@ $util.toJson($v1)`,
 {}`,
     // response mapping template
     `#if($context.stash.return__flag)
-  #return($context.stash.return__val)
+#return($context.stash.return__val)
 #end
 #set($v1 = $context.stash.result.id == 'sam')
 #if($v1)
@@ -91,7 +91,7 @@ test("call function omitting optional arg", () =>
     // pipeline's request mapping template
     "{}",
     // function's request mapping template
-    `${VTL.CircuitBreaker}
+    `${AppsyncVTL.CircuitBreaker}
 #set($v1 = {\"version\": \"2018-05-29\", \"operation\": \"Invoke\", \"payload\": $context.arguments})
 $util.toJson($v1)`,
     // function's response mapping template
@@ -100,7 +100,7 @@ $util.toJson($v1)`,
 {}`,
     // response mapping template
     `#if($context.stash.return__flag)
-  #return($context.stash.return__val)
+#return($context.stash.return__val)
 #end`
   ));
 
@@ -112,7 +112,7 @@ test("call function including optional arg", () =>
     // pipeline's request mapping template
     "{}",
     // function's request mapping template
-    `${VTL.CircuitBreaker}
+    `${AppsyncVTL.CircuitBreaker}
 #set($v1 = {})
 $util.qr($v1.put('arg', $context.arguments.arg))
 $util.qr($v1.put('optional', 'hello'))
@@ -124,7 +124,7 @@ $util.toJson($v2)`,
 {}`,
     // response mapping template
     `#if($context.stash.return__flag)
-  #return($context.stash.return__val)
+#return($context.stash.return__val)
 #end`
   ));
 
@@ -136,7 +136,7 @@ test("call function including with no parameters", () =>
     // pipeline's request mapping template
     "{}",
     // function's request mapping template
-    `${VTL.CircuitBreaker}
+    `${AppsyncVTL.CircuitBreaker}
 #set($v1 = {\"version\": \"2018-05-29\", \"operation\": \"Invoke\", \"payload\": $null})
 $util.toJson($v1)`,
     // function's response mapping template
@@ -145,7 +145,7 @@ $util.toJson($v1)`,
 {}`,
     // response mapping template
     `#if($context.stash.return__flag)
-  #return($context.stash.return__val)
+#return($context.stash.return__val)
 #end`
   ));
 
@@ -157,7 +157,7 @@ test("call function including with void result", () =>
     // pipeline's request mapping template
     "{}",
     // function's request mapping template
-    `${VTL.CircuitBreaker}
+    `${AppsyncVTL.CircuitBreaker}
 #set($v1 = {\"version\": \"2018-05-29\", \"operation\": \"Invoke\", \"payload\": $context.arguments})
 $util.toJson($v1)`,
     // function's response mapping template
@@ -166,6 +166,6 @@ $util.toJson($v1)`,
 {}`,
     // response mapping template
     `#if($context.stash.return__flag)
-  #return($context.stash.return__val)
+#return($context.stash.return__val)
 #end`
   ));

--- a/test/table.test.ts
+++ b/test/table.test.ts
@@ -2,7 +2,7 @@ import { App, aws_dynamodb, Stack } from "aws-cdk-lib";
 import "jest";
 import { $util, AppsyncContext, reflect } from "../src";
 import { Table } from "../src";
-import { VTL } from "../src/vtl";
+import { AppsyncVTL } from "../src/vtl";
 import { appsyncTestCase } from "./util";
 
 interface Item {
@@ -36,7 +36,7 @@ test("get item", () =>
     // pipeline's request mapping template
     "{}",
     // function's request mapping template
-    `${VTL.CircuitBreaker}
+    `${AppsyncVTL.CircuitBreaker}
 #set($v1 = {})
 #set($v2 = {})
 #set($v3 = {})
@@ -55,7 +55,7 @@ $util.toJson($v4)`,
 {}`,
     // response mapping template
     `#if($context.stash.return__flag)
-  #return($context.stash.return__val)
+#return($context.stash.return__val)
 #end`
   ));
 
@@ -74,7 +74,7 @@ test("get item and set consistentRead:true", () =>
     // pipeline's request mapping template
     "{}",
     // function's request mapping template
-    `${VTL.CircuitBreaker}
+    `${AppsyncVTL.CircuitBreaker}
 #set($v1 = {})
 #set($v2 = {})
 #set($v3 = {})
@@ -94,7 +94,7 @@ $util.toJson($v4)`,
 {}`,
     // pipeline's response mapping template
     `#if($context.stash.return__flag)
-  #return($context.stash.return__val)
+#return($context.stash.return__val)
 #end`
   ));
 
@@ -132,7 +132,7 @@ test("put item", () =>
     // pipeline's request mapping template
     "{}",
     // function's request mapping template
-    `${VTL.CircuitBreaker}
+    `${AppsyncVTL.CircuitBreaker}
 #set($v1 = {})
 #set($v2 = {})
 #set($v3 = {})
@@ -171,7 +171,7 @@ $util.toJson($v10)`,
 {}`,
     // pipeline's response mapping template
     `#if($context.stash.return__flag)
-  #return($context.stash.return__val)
+#return($context.stash.return__val)
 #end`
   ));
 
@@ -195,7 +195,7 @@ test("update item", () =>
     // pipeline's request mapping template
     "{}",
     // function's request mapping template
-    `${VTL.CircuitBreaker}
+    `${AppsyncVTL.CircuitBreaker}
 #set($v1 = {})
 #set($v2 = {})
 #set($v3 = {})
@@ -224,7 +224,7 @@ $util.toJson($v6)`,
 {}`,
     // pipeline's response mapping template
     `#if($context.stash.return__flag)
-  #return($context.stash.return__val)
+#return($context.stash.return__val)
 #end`
   ));
 
@@ -248,7 +248,7 @@ test("delete item", () =>
     // pipeline's request mapping template
     "{}",
     // function's request mapping template
-    `${VTL.CircuitBreaker}
+    `${AppsyncVTL.CircuitBreaker}
 #set($v1 = {})
 #set($v2 = {})
 #set($v3 = {})
@@ -276,7 +276,7 @@ $util.toJson($v6)`,
 {}`,
     // pipeline's response mapping template
     `#if($context.stash.return__flag)
-  #return($context.stash.return__val)
+#return($context.stash.return__val)
 #end`
   ));
 
@@ -299,7 +299,7 @@ test("query", () =>
     // pipeline's request mapping template
     "{}",
     // function's request mapping template
-    `${VTL.CircuitBreaker}
+    `${AppsyncVTL.CircuitBreaker}
 #set($v1 = {})
 #set($v2 = {})
 $util.qr($v2.put('expression', 'id = :id and #name = :val'))
@@ -338,6 +338,6 @@ $util.toJson($v5)`,
 {}`,
     // pipeline's response mapping template
     `#if($context.stash.return__flag)
-  #return($context.stash.return__val)
+#return($context.stash.return__val)
 #end`
   ));

--- a/test/vtl.test.ts
+++ b/test/vtl.test.ts
@@ -1,8 +1,7 @@
 import "jest";
-import { $util } from "../src";
-import { AppsyncContext } from "../src";
+import { $util, AppsyncContext } from "../src";
 import { reflect } from "../src/reflect";
-import { returnExpr, appsyncTestCase } from "./util";
+import { appsyncTestCase, returnExpr } from "./util";
 
 const payload = `{
   "version": "2018-05-29",


### PR DESCRIPTION
This refactor is in preparation for APIGW mapping template support. Appsync and APIGW have different VTL engines and I have moved the parts that differ into abstract methods on `VTL`, which is now an abstract class. `AppsyncVTL` behaves the same as `VTL` did, `ApiGatewayVTL` will be introduced in another PR