### PR TITLE
feat: provide link to documentation for compile time error codes

### DIFF
--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -28,7 +28,7 @@
       "name": "build:website",
       "steps": [
         {
-          "exec": "cd ./website && yarn && yarn build"
+          "exec": "npx tsc && cd ./website && yarn && yarn build"
         }
       ]
     },

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -102,7 +102,7 @@ const project = new CustomTypescriptProject({
   ],
   scripts: {
     localstack: "./scripts/localstack",
-    "build:website": "cd ./website && yarn && yarn build",
+    "build:website": "npx tsc && cd ./website && yarn && yarn build",
   },
   peerDeps: [
     `aws-cdk-lib@^${MIN_CDK_VERSION}`,

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -50,6 +50,25 @@
       "env": {
         "TS_NODE_PROJECT": "${workspaceRoot}/test-app/tsconfig.json"
       }
+    },
+    {
+      "name": "compile error-codes.md",
+      "type": "node",
+      "request": "launch",
+      "runtimeExecutable": "node",
+      "runtimeArgs": ["--nolazy"],
+      "args": ["./scripts/compile-error-code-page.js"],
+      "outFiles": [
+        "${workspaceRoot}/lib/**/*.js",
+        "${workspaceRoot}/test-app/lib/**/*.js",
+        "!**/node_modules/**"
+      ],
+      "cwd": "${workspaceRoot}",
+      "internalConsoleOptions": "openOnSessionStart",
+      "skipFiles": ["<node_internals>/**", "node_modules/**"],
+      "env": {
+        "TS_NODE_PROJECT": "${workspaceRoot}/test-app/tsconfig.json"
+      }
     }
   ]
 }

--- a/scripts/compile-error-code-page.js
+++ b/scripts/compile-error-code-page.js
@@ -3,6 +3,10 @@ const { ErrorCodes } = require("../lib/error-code");
 const fs = require("fs");
 const path = require("path");
 
+/**
+ * Generate `functionless.org/docs/error-codes file.
+ */
+
 const errorCodesAPIReference = path.join(
   __dirname,
   "..",
@@ -21,35 +25,31 @@ const errorCodeDocumentationPath = path.join(
   "error-codes.md"
 );
 
-(async function () {
-  let errorCodeMarkdown = (await fs.promises.readFile(errorCodesAPIReference))
-    .toString()
-    .replace("## Variables\n", "# Error Codes\n")
-    .replace(
-      `id: "ErrorCodes"
+let errorCodeMarkdown = fs
+  .readFileSync(errorCodesAPIReference)
+  .toString()
+  .replace("## Variables\n", "# Error Codes\n")
+  .replace(
+    `id: "ErrorCodes"
 title: "Namespace: ErrorCodes"
 sidebar_label: "ErrorCodes"
 sidebar_position: 0
 custom_edit_url: null`,
-      `title: "Error Codes"
+    `title: "Error Codes"
 sidebar_position: 3`
-    )
-    .replace(/• `Const`.*\n/g, "")
-    .replace(/\n\n\n/g, "\n\n")
-    .replace(/\n#### Defined in.*\n\n.*error.*\n/g, "");
+  )
+  .replace(/• `Const`.*\n/g, "")
+  .replace(/\n\n\n/g, "\n\n")
+  .replace(/\n#### Defined in.*\n\n.*error.*\n/g, "");
 
-  for (const [errorId, errorCode] of Object.entries(ErrorCodes)) {
-    //### Cannot\_perform\_arithmetic\_on\_variables\_in\_Step\_Function
-    errorCodeMarkdown = errorCodeMarkdown.replace(
-      `### ${errorId.replace(/_/g, "\\_")}`,
-      `### ${errorCode.messageText}
+for (const [errorId, errorCode] of Object.entries(ErrorCodes)) {
+  //### Cannot\_perform\_arithmetic\_on\_variables\_in\_Step\_Function
+  errorCodeMarkdown = errorCodeMarkdown.replace(
+    `### ${errorId.replace(/_/g, "\\_")}`,
+    `### ${errorCode.messageText}
 
 __Error Code__: Functionless(${errorCode.code})`
-    );
-  }
+  );
+}
 
-  await fs.promises.writeFile(errorCodeDocumentationPath, errorCodeMarkdown);
-})().catch((err) => {
-  console.error(err);
-  process.exit(1);
-});
+fs.writeFileSync(errorCodeDocumentationPath, errorCodeMarkdown);

--- a/scripts/compile-error-code-page.js
+++ b/scripts/compile-error-code-page.js
@@ -1,0 +1,55 @@
+const { ErrorCodes } = require("../lib/error-code");
+
+const fs = require("fs");
+const path = require("path");
+
+const errorCodesAPIReference = path.join(
+  __dirname,
+  "..",
+  "website",
+  "docs",
+  "api",
+  "namespaces",
+  "ErrorCodes.md"
+);
+
+const errorCodeDocumentationPath = path.join(
+  __dirname,
+  "..",
+  "website",
+  "docs",
+  "error-codes.md"
+);
+
+(async function () {
+  let errorCodeMarkdown = (await fs.promises.readFile(errorCodesAPIReference))
+    .toString()
+    .replace("## Variables\n", "# Error Codes\n")
+    .replace(
+      `id: "ErrorCodes"
+title: "Namespace: ErrorCodes"
+sidebar_label: "ErrorCodes"
+sidebar_position: 0
+custom_edit_url: null`,
+      `title: "Error Codes"
+sidebar_position: 3`
+    )
+    .replace(/• `Const`.*\n/g, "")
+    .replace(/\n\n\n/g, "\n\n")
+    .replace(/\n#### Defined in.*\n\n.*error.*\n/g, "");
+
+  for (const [errorId, errorCode] of Object.entries(ErrorCodes)) {
+    //### Cannot\_perform\_arithmetic\_on\_variables\_in\_Step\_Function
+    errorCodeMarkdown = errorCodeMarkdown.replace(
+      `### ${errorId.replace(/_/g, "\\_")}`,
+      `### ${errorCode.messageText}
+
+__Error Code__: Functionless(${errorCode.code})`
+    );
+  }
+
+  await fs.promises.writeFile(errorCodeDocumentationPath, errorCodeMarkdown);
+})().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/error-code.ts
+++ b/src/error-code.ts
@@ -14,6 +14,16 @@ export namespace ErrorCodes {
    * // illegal!
    * new StepFunction(scope, id, (input: { num: number }) => input.number + 1);
    * ```
+   *
+   * To workaround, use a Lambda Function to implement the arithmetic expression. Be aware that this comes with added cost and operational risk.
+   *
+   * ```ts
+   * const add = new Function(scope, "add", (input: { a: number, b: number }) => input.a + input.b);
+   *
+   * new StepFunction(scope, id, async (input: { num: number }) => {
+   *   await add({a: input.number, b: 1});
+   * });
+   * ```
    */
   export const Cannot_perform_arithmetic_on_variables_in_Step_Function: ErrorCode =
     {

--- a/src/error-code.ts
+++ b/src/error-code.ts
@@ -1,0 +1,23 @@
+export interface ErrorCode {
+  code: number;
+  messageText: string;
+}
+
+export namespace ErrorCodes {
+  /**
+   * The computations that [Amazon States Language](https://docs.aws.amazon.com/step-functions/latest/dg/concepts-amazon-states-language.html)
+   * can do is restricted by JSON Path and the limited [Intrinsic Functions](https://docs.aws.amazon.com/step-functions/latest/dg/amazon-states-language-intrinsic-functions.html). Currently, arithmetic expressions are not supported.
+   * ```ts
+   * // ok
+   * new StepFunction(scope, id, () => 1 + 2);
+   *
+   * // illegal!
+   * new StepFunction(scope, id, (input: {num: number}) => input.number + 1);
+   * ```
+   */
+  export const Cannot_perform_arithmetic_on_variables_in_Step_Function: ErrorCode =
+    {
+      code: 100,
+      messageText: "Cannot perform arithmetic on variables in Step Function",
+    };
+}

--- a/src/error-code.ts
+++ b/src/error-code.ts
@@ -12,7 +12,7 @@ export namespace ErrorCodes {
    * new StepFunction(scope, id, () => 1 + 2);
    *
    * // illegal!
-   * new StepFunction(scope, id, (input: {num: number}) => input.number + 1);
+   * new StepFunction(scope, id, (input: { num: number }) => input.number + 1);
    * ```
    */
   export const Cannot_perform_arithmetic_on_variables_in_Step_Function: ErrorCode =

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ export * from "./appsync";
 export * from "./async-synth";
 export * from "./declaration";
 export * from "./error";
+export * from "./error-code";
 export * from "./event-bridge";
 export * from "./expression";
 export { Integration } from "./integration";

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -1,5 +1,6 @@
 import type * as typescript from "typescript";
 import { FunctionlessChecker, isArithmeticToken } from "./checker";
+import { ErrorCode, ErrorCodes } from "./error-code";
 
 /**
  * Validates a TypeScript SourceFile containing Functionless primitives does not
@@ -66,8 +67,7 @@ export function validate(
       return [
         newError(
           node,
-          100,
-          "Cannot perform arithmetic on variables in Step Function"
+          ErrorCodes.Cannot_perform_arithmetic_on_variables_in_Step_Function
         ),
       ];
     }
@@ -76,13 +76,19 @@ export function validate(
 
   function newError(
     invalidNode: typescript.Node,
-    code: number,
-    messageText: string
+    error: ErrorCode,
+    messageText?: string
   ): ts.Diagnostic {
+    const baseUrl = process.env.FUNCTIONLESS_LOCAL
+      ? `http://localhost:3000`
+      : `https://functionless.org`;
+
     return {
       source: "Functionless",
-      code,
-      messageText,
+      code: error.code,
+      messageText: `${messageText ?? error.messageText}
+
+${baseUrl}/docs/error-codes#${error.messageText.replace(/ /g, "-")}"`,
       category: ts.DiagnosticCategory.Error,
       file: invalidNode.getSourceFile(),
       start: invalidNode.pos,

--- a/test/__snapshots__/validate.test.ts.snap
+++ b/test/__snapshots__/validate.test.ts.snap
@@ -3,21 +3,31 @@
 exports[`step-function.ts 1`] = `
 "[96mtest/test-files/step-function.ts[0m:[93m10[0m:[93m65[0m - [91merror[0m[90m Functionless(100): [0mCannot perform arithmetic on variables in Step Function
 
+https://functionless.org/docs/error-codes#Cannot-perform-arithmetic-on-variables-in-Step-Function\\"
+
 [7m10[0m new StepFunction(stack, \\"input.i + 2\\", (input: { i: number }) => input.i + 2);
 [7m  [0m [91m                                                                ~~~~~~~~~~~~[0m
 [96mtest/test-files/step-function.ts[0m:[93m11[0m:[93m65[0m - [91merror[0m[90m Functionless(100): [0mCannot perform arithmetic on variables in Step Function
+
+https://functionless.org/docs/error-codes#Cannot-perform-arithmetic-on-variables-in-Step-Function\\"
 
 [7m11[0m new StepFunction(stack, \\"input.i - 2\\", (input: { i: number }) => input.i - 2);
 [7m  [0m [91m                                                                ~~~~~~~~~~~~[0m
 [96mtest/test-files/step-function.ts[0m:[93m13[0m:[93m65[0m - [91merror[0m[90m Functionless(100): [0mCannot perform arithmetic on variables in Step Function
 
+https://functionless.org/docs/error-codes#Cannot-perform-arithmetic-on-variables-in-Step-Function\\"
+
 [7m13[0m new StepFunction(stack, \\"input.i / 2\\", (input: { i: number }) => input.i / 2);
 [7m  [0m [91m                                                                ~~~~~~~~~~~~[0m
 [96mtest/test-files/step-function.ts[0m:[93m14[0m:[93m62[0m - [91merror[0m[90m Functionless(100): [0mCannot perform arithmetic on variables in Step Function
 
+https://functionless.org/docs/error-codes#Cannot-perform-arithmetic-on-variables-in-Step-Function\\"
+
 [7m14[0m new StepFunction(stack, \\"-input.i\\", (input: { i: number }) => -input.i);
 [7m  [0m [91m                                                             ~~~~~~~~~[0m
 [96mtest/test-files/step-function.ts[0m:[93m19[0m:[93m14[0m - [91merror[0m[90m Functionless(100): [0mCannot perform arithmetic on variables in Step Function
+
+https://functionless.org/docs/error-codes#Cannot-perform-arithmetic-on-variables-in-Step-Function\\"
 
 [7m19[0m     const a = input.i + 1;
 [7m  [0m [91m             ~~~~~~~~~~~~[0m

--- a/website/docs/error-codes.md
+++ b/website/docs/error-codes.md
@@ -1,0 +1,21 @@
+---
+title: "Error Codes"
+sidebar_position: 3
+---
+
+# Error Codes
+
+### Cannot perform arithmetic on variables in Step Function
+
+**Error Code**: Functionless(100)
+
+The computations that [Amazon States Language](https://docs.aws.amazon.com/step-functions/latest/dg/concepts-amazon-states-language.html)
+can do is restricted by JSON Path and the limited [Intrinsic Functions](https://docs.aws.amazon.com/step-functions/latest/dg/amazon-states-language-intrinsic-functions.html). Currently, arithmetic expressions are not supported.
+
+```ts
+// ok
+new StepFunction(scope, id, () => 1 + 2);
+
+// illegal!
+new StepFunction(scope, id, (input: { num: number }) => input.number + 1);
+```

--- a/website/docusaurus.config.js
+++ b/website/docusaurus.config.js
@@ -3,6 +3,7 @@
 
 const lightCodeTheme = require("prism-react-renderer/themes/github");
 const darkCodeTheme = require("prism-react-renderer/themes/dracula");
+const path = require("path");
 
 /** @type {import('@docusaurus/types').Config} */
 const config = {
@@ -21,7 +22,6 @@ const config = {
   plugins: [
     [
       "docusaurus-plugin-typedoc",
-
       // Plugin / TypeDoc options
       {
         entryPoints: ["../src/index.ts"],
@@ -32,6 +32,19 @@ const config = {
         },
       },
     ],
+    function () {
+      return {
+        name: "functionless-error-code-docs",
+        loadContent: () =>
+          // run the compile-error-code-page CLI after typedoc is run by `docusaurus-plugin-typedoc`
+          require(path.join(
+            __dirname,
+            "..",
+            "scripts",
+            "compile-error-code-page"
+          )),
+      };
+    },
   ],
 
   presets: [

--- a/website/package.json
+++ b/website/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",
-    "start": "LOCAL=true; docusaurus start",
+    "start": "FUNCTIONLESS_LOCAL=true; docusaurus start",
     "build": "docusaurus build",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",

--- a/website/package.json
+++ b/website/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "docusaurus": "docusaurus",
-    "start": "docusaurus start",
+    "start": "LOCAL=true; docusaurus start",
     "build": "docusaurus build",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",


### PR DESCRIPTION
Fixes #176 

Adding an `error-code.ts` namespace where we will store all error code constants. Each error code has an ID, `code`, `messageText` and documentation in TypeScript code. 

```ts
export namespace ErrorCodes {
  /**
   * The computations that [Amazon States Language](https://docs.aws.amazon.com/step-functions/latest/dg/concepts-amazon-states-language.html)
   * can do is restricted by JSON Path and the limited [Intrinsic Functions](https://docs.aws.amazon.com/step-functions/latest/dg/amazon-states-language-intrinsic-functions.html). Currently, arithmetic expressions are not supported.
   * ```ts
   * // ok
   * new StepFunction(scope, id, () => 1 + 2);
   *
   * // illegal!
   * new StepFunction(scope, id, (input: {num: number}) => input.number + 1);
   * ```
   */
  export const Cannot_perform_arithmetic_on_variables_in_Step_Function: ErrorCode =
    {
      code: 100,
      messageText: "Cannot perform arithmetic on variables in Step Function",
    };
}
```

TS doc generates a markdown file under `website/docs/api/namespaces/ErrorCodes.md`. This file is not easy to read and hidden away in the file tree, so a script is used to pre-process the file and create `website/docs/error-codes.md` at the top-level of the file tree and in a linkable and easy to read format.

<img width="854" alt="image" src="https://user-images.githubusercontent.com/38672686/171385519-c5346c41-20c1-4228-9d0a-75a8b88254b4.png">

All errors reported by the language service or CLI now provide a link directly to this documentation explaining the error.

<img width="823" alt="image" src="https://user-images.githubusercontent.com/38672686/171385600-e5ff193e-df05-4a0f-81ea-f49efdb1a85b.png">


- [ ] Make the link clickable within VS code (current not sure if this is possible)