### PR TITLE
chore: more function compile tests

### DIFF
--- a/test/function.test.ts
+++ b/test/function.test.ts
@@ -170,3 +170,13 @@ $util.toJson($v1)`,
   #return($context.stash.return__val)
 #end`
   ));
+
+test("function inline arrow closure", () => {
+  new Function(stack, "inline", async (p: string) => p);
+});
+
+test("function block closure", () => {
+  new Function(stack, "block", async (p: string) => {
+    return p;
+  });
+});


### PR DESCRIPTION
Closes #198 

Tests to show that simple arrow functions work. 

#198 was likely caused by missing ts-patch and fixed by running ts-patch and then making any change to the file.