### PR TITLE
feat: update resource callbacks to support async and most integrations to return async

### DIFF
--- a/src/appsync.ts
+++ b/src/appsync.ts
@@ -48,7 +48,7 @@ export type ResolverFunction<
   Arguments extends ResolverArguments,
   Result,
   Source
-> = ($context: AppsyncContext<Arguments, Source>) => Result;
+> = ($context: AppsyncContext<Arguments, Source>) => Promise<Result> | Result;
 
 export interface SynthesizedAppsyncResolverProps extends appsync.ResolverProps {
   readonly templates: string[];

--- a/src/aws.ts
+++ b/src/aws.ts
@@ -32,8 +32,7 @@ import {
 } from "./function";
 import { IntegrationInput, makeIntegration } from "./integration";
 import { Table, isTable, AnyTable } from "./table";
-
-import type { AnyFunction } from "./util";
+import type { AnyAsyncFunction } from "./util";
 
 type Item<T extends Table<any, any, any>> = T extends Table<infer I, any, any>
   ? I
@@ -99,7 +98,9 @@ export namespace $AWS {
           >,
           "TableName"
         >
-      ) => DeleteItemOutput<Item<T>, ReturnValue, JsonFormat.AttributeValue>
+      ) => Promise<
+        DeleteItemOutput<Item<T>, ReturnValue, JsonFormat.AttributeValue>
+      >
     >("deleteItem", {
       native: {
         bind: (context, table) => {
@@ -156,14 +157,16 @@ export namespace $AWS {
           >,
           "TableName"
         >
-      ) => GetItemOutput<
-        Item<T>,
-        PartitionKey<T>,
-        RangeKey<T>,
-        Key,
-        AttributesToGet,
-        ProjectionExpression,
-        JsonFormat.AttributeValue
+      ) => Promise<
+        GetItemOutput<
+          Item<T>,
+          PartitionKey<T>,
+          RangeKey<T>,
+          Key,
+          AttributesToGet,
+          ProjectionExpression,
+          JsonFormat.AttributeValue
+        >
       >
     >("getItem", {
       native: {
@@ -241,13 +244,15 @@ export namespace $AWS {
           >,
           "TableName"
         >
-      ) => UpdateItemOutput<
-        Item<T>,
-        PartitionKey<T>,
-        RangeKey<T>,
-        Key,
-        ReturnValue,
-        JsonFormat.AttributeValue
+      ) => Promise<
+        UpdateItemOutput<
+          Item<T>,
+          PartitionKey<T>,
+          RangeKey<T>,
+          Key,
+          ReturnValue,
+          JsonFormat.AttributeValue
+        >
       >
     >("updateItem", {
       native: {
@@ -297,7 +302,7 @@ export namespace $AWS {
           >,
           "TableName"
         >
-      ) => PutItemOutput<I, ReturnValue, JsonFormat.AttributeValue>
+      ) => Promise<PutItemOutput<I, ReturnValue, JsonFormat.AttributeValue>>
     >("putItem", {
       native: {
         bind: (context, table) => {
@@ -347,7 +352,9 @@ export namespace $AWS {
           >,
           "TableName"
         >
-      ) => QueryOutput<Item<T>, AttributesToGet, JsonFormat.AttributeValue>
+      ) => Promise<
+        QueryOutput<Item<T>, AttributesToGet, JsonFormat.AttributeValue>
+      >
     >("query", {
       native: {
         bind: (context, table) => {
@@ -395,7 +402,9 @@ export namespace $AWS {
           >,
           "TableName"
         >
-      ) => ScanOutput<Item<T>, AttributesToGet, JsonFormat.AttributeValue>
+      ) => Promise<
+        ScanOutput<Item<T>, AttributesToGet, JsonFormat.AttributeValue>
+      >
     >("scan", {
       native: {
         bind: (context, table) => {
@@ -435,7 +444,7 @@ export namespace $AWS {
 
     function makeDynamoIntegration<
       Op extends OperationName,
-      F extends AnyFunction
+      F extends AnyAsyncFunction
     >(
       operationName: Op,
       integration: Omit<
@@ -610,7 +619,7 @@ export namespace $AWS {
       "EventBridge.putEvent",
       (
         request: AWS.EventBridge.Types.PutEventsRequest
-      ) => AWS.EventBridge.Types.PutEventsResponse
+      ) => Promise<AWS.EventBridge.Types.PutEventsResponse>
     >({
       kind: "EventBridge.putEvent",
       native: {

--- a/src/event-bridge/event-bus.ts
+++ b/src/event-bridge/event-bus.ts
@@ -122,7 +122,7 @@ export interface IEventBus<E extends Event = Event>
       (
         event: EventBusPutEventInput<E>,
         ...events: EventBusPutEventInput<E>[]
-      ) => void,
+      ) => Promise<void>,
       EventBusTargetIntegration<
         EventBusPutEventInput<E>,
         aws_events_targets.EventBusProps | undefined
@@ -136,7 +136,7 @@ export interface IEventBus<E extends Event = Event>
   readonly __functionBrand: (
     event: EventBusPutEventInput<E>,
     ...events: EventBusPutEventInput<E>[]
-  ) => void;
+  ) => Promise<void>;
 
   /**
    * This static property identifies this class as an EventBus to the TypeScript plugin.
@@ -149,7 +149,7 @@ export interface IEventBus<E extends Event = Event>
   putEvents(
     event: EventBusPutEventInput<E>,
     ...events: EventBusPutEventInput<E>[]
-  ): void;
+  ): Promise<void>;
 
   readonly eventBus: EventBusTargetIntegration<
     E,
@@ -203,7 +203,7 @@ abstract class EventBusBase<E extends Event> implements IEventBus<E> {
   readonly __functionBrand: (
     event: EventBusPutEventInput<E>,
     ...events: EventBusPutEventInput<E>[]
-  ) => void;
+  ) => Promise<void>;
 
   constructor(readonly bus: aws_events.IEventBus) {
     this.eventBusName = bus.eventBusName;

--- a/src/reflect.ts
+++ b/src/reflect.ts
@@ -1,6 +1,6 @@
 import { FunctionDecl } from "./declaration";
 import { Err } from "./error";
-import { AnyFunction } from "./util";
+import { AnyAsyncFunction, AnyFunction } from "./util";
 
 /**
  * A macro (compile-time) function that converts an ArrowFunction or FunctionExpression to a {@link FunctionDecl}.
@@ -28,6 +28,6 @@ import { AnyFunction } from "./util";
  * @param func an in-line ArrowFunction or FunctionExpression. It must be in-line and cannot reference
  *             a variable or a computed function/closure.
  */
-export declare function reflect<F extends AnyFunction>(
+export declare function reflect<F extends AnyFunction | AnyAsyncFunction>(
   func: F
 ): FunctionDecl<F> | Err;

--- a/src/table.ts
+++ b/src/table.ts
@@ -17,7 +17,7 @@ import type { AppSyncVtlIntegration } from "./appsync";
 import { assertNodeKind } from "./assert";
 import { ObjectLiteralExpr } from "./expression";
 import { IntegrationInput, makeIntegration } from "./integration";
-import { AnyFunction } from "./util";
+import { AnyAsyncFunction } from "./util";
 import { VTL } from "./vtl";
 
 export function isTable(a: any): a is AnyTable {
@@ -92,7 +92,7 @@ export class Table<
     >(input: {
       key: Key;
       consistentRead?: boolean;
-    }) => Narrow<Item, AttributeKeyToObject<Key>, JsonFormat.Document>
+    }) => Promise<Narrow<Item, AttributeKeyToObject<Key>, JsonFormat.Document>>
   >("getItem", {
     appSyncVtl: {
       request(call, vtl) {
@@ -136,7 +136,7 @@ export class Table<
       >;
       condition?: DynamoExpression<ConditionExpression>;
       _version?: number;
-    }) => Narrow<Item, AttributeKeyToObject<Key>, JsonFormat.Document>
+    }) => Promise<Narrow<Item, AttributeKeyToObject<Key>, JsonFormat.Document>>
   >("putItem", {
     appSyncVtl: {
       request: (call, vtl) => {
@@ -182,7 +182,7 @@ export class Table<
       update: DynamoExpression<UpdateExpression>;
       condition?: DynamoExpression<ConditionExpression>;
       _version?: number;
-    }) => Narrow<Item, AttributeKeyToObject<Key>, JsonFormat.Document>
+    }) => Promise<Narrow<Item, AttributeKeyToObject<Key>, JsonFormat.Document>>
   >("updateItem", {
     appSyncVtl: {
       request: (call, vtl) => {
@@ -224,7 +224,7 @@ export class Table<
       key: Key;
       condition?: DynamoExpression<ConditionExpression>;
       _version?: number;
-    }) => Narrow<Item, AttributeKeyToObject<Key>, JsonFormat.Document>
+    }) => Promise<Narrow<Item, AttributeKeyToObject<Key>, JsonFormat.Document>>
   >("deleteItem", {
     appSyncVtl: {
       request: (call, vtl) => {
@@ -260,11 +260,11 @@ export class Table<
       scanIndexForward?: boolean;
       consistentRead?: boolean;
       select?: "ALL_ATTRIBUTES" | "ALL_PROJECTED_ATTRIBUTES";
-    }) => {
+    }) => Promise<{
       items: Item[];
       nextToken: string;
       scannedCount: number;
-    }
+    }>
   >("query", {
     appSyncVtl: {
       request: (call, vtl) => {
@@ -290,7 +290,7 @@ export class Table<
     },
   });
 
-  makeTableIntegration<K extends string, F extends AnyFunction>(
+  makeTableIntegration<K extends string, F extends AnyAsyncFunction>(
     methodName: K,
     integration: Omit<
       IntegrationInput<`Table.${K}`, F>,

--- a/src/util.ts
+++ b/src/util.ts
@@ -22,6 +22,7 @@ import {
 import { FunctionlessNode } from "./node";
 
 export type AnyFunction = (...args: any[]) => any;
+export type AnyAsyncFunction = (...args: any[]) => Promise<any>;
 
 export function isInTopLevelScope(expr: FunctionlessNode): boolean {
   if (expr.parent === undefined) {

--- a/test/appsync.test.ts
+++ b/test/appsync.test.ts
@@ -14,10 +14,10 @@ beforeEach(() => {
 
 describe("step function integration", () => {
   test("machine with no parameters", () => {
-    const machine = new StepFunction(stack, "machine", () => {});
+    const machine = new StepFunction(stack, "machine", async () => {});
 
-    const func = reflect(() => {
-      machine({});
+    const func = reflect(async () => {
+      await machine({});
     });
 
     appsyncTestCase(
@@ -70,12 +70,12 @@ $util.qr($v1.put('stateMachineArn', '${machine.stateMachineArn}'))
     const machine = new StepFunction<{ id: string }, void>(
       stack,
       "machine",
-      () => {}
+      async () => {}
     );
 
     const templates = getAppSyncTemplates(
-      reflect(() => {
-        machine({ input: { id: "1" } });
+      reflect(async () => {
+        await machine({ input: { id: "1" } });
       })
     );
 
@@ -106,12 +106,12 @@ $util.qr($v1.put('stateMachineArn', '${machine.stateMachineArn}'))
     const machine = new StepFunction<{ id: string }, void>(
       stack,
       "machine",
-      () => {}
+      async () => {}
     );
 
     const templates = getAppSyncTemplates(
-      reflect((context) => {
-        machine({ input: { id: context.arguments.id } });
+      reflect(async (context) => {
+        await machine({ input: { id: context.arguments.id } });
       })
     );
 
@@ -139,11 +139,11 @@ $util.qr($v1.put('stateMachineArn', '${machine.stateMachineArn}'))
   });
 
   test("machine with name", () => {
-    const machine = new StepFunction(stack, "machine", () => {});
+    const machine = new StepFunction(stack, "machine", async () => {});
 
     const templates = getAppSyncTemplates(
-      reflect((context) => {
-        machine({ name: context.arguments.id });
+      reflect(async (context) => {
+        await machine({ name: context.arguments.id });
       })
     );
 
@@ -171,18 +171,18 @@ $util.qr($v1.put('stateMachineArn', '${machine.stateMachineArn}'))
   });
 
   test("machine with trace header", () => {
-    const machine = new StepFunction(stack, "machine", () => {});
-    new AppsyncResolver<{ id: string }, void>((context) => {
-      machine({ traceHeader: context.arguments.id });
+    const machine = new StepFunction(stack, "machine", async () => {});
+    new AppsyncResolver<{ id: string }, void>(async (context) => {
+      await machine({ traceHeader: context.arguments.id });
     });
   });
 
   test("machine describe exec", () => {
-    const machine = new StepFunction(stack, "machine", () => {});
+    const machine = new StepFunction(stack, "machine", async () => {});
 
-    const func = reflect(() => {
+    const func = reflect(async () => {
       const exec = "exec1";
-      machine.describeExecution(exec);
+      await machine.describeExecution(exec);
     });
 
     appsyncTestCase(
@@ -235,10 +235,10 @@ $util.qr($v1.put('stateMachineArn', '${machine.stateMachineArn}'))
 
 describe("step function describe execution", () => {
   test("machine describe exec string", () => {
-    const machine = new StepFunction(stack, "machine", () => {});
+    const machine = new StepFunction(stack, "machine", async () => {});
 
-    const func = reflect(() => {
-      machine.describeExecution("exec1");
+    const func = reflect(async () => {
+      await machine.describeExecution("exec1");
     });
 
     appsyncTestCase(
@@ -288,9 +288,9 @@ describe("step function describe execution", () => {
   });
 
   test("machine with trace header", () => {
-    const machine = new StepFunction(stack, "machine", () => {});
-    new AppsyncResolver<{ id: string }, void>((context) => {
-      machine({ traceHeader: context.arguments.id });
+    const machine = new StepFunction(stack, "machine", async () => {});
+    new AppsyncResolver<{ id: string }, void>(async (context) => {
+      await machine({ traceHeader: context.arguments.id });
     });
   });
 });

--- a/test/eventbus.localstack.test.ts
+++ b/test/eventbus.localstack.test.ts
@@ -53,8 +53,8 @@ localstackTestSuite("eventBusStack", (testResource) => {
       const putMachine = new StepFunction<{ id: string }, void>(
         parent,
         "machine",
-        (event) => {
-          $AWS.DynamoDB.PutItem({
+        async (event) => {
+          await $AWS.DynamoDB.PutItem({
             Item: {
               id: { S: event.id },
             },

--- a/test/eventbus.test.ts
+++ b/test/eventbus.test.ts
@@ -177,7 +177,7 @@ test("new bus with when map pipe step function", () => {
   const func = new StepFunction<{ source: string }, void>(
     stack,
     "sfn",
-    () => {}
+    async () => {}
   );
 
   const rule = busBus
@@ -201,7 +201,7 @@ test("new bus with when map pipe express step function", () => {
   const func = new ExpressStepFunction<{ source: string }, void>(
     stack,
     "sfn",
-    () => {}
+    async () => {}
   );
 
   const rule = busBus

--- a/test/function.localstack.test.ts
+++ b/test/function.localstack.test.ts
@@ -345,7 +345,7 @@ localstackTestSuite("functionStack", (testResource, _stack, _app) => {
         "function",
         localstackClientConfig,
         async () => {
-          bus.putEvents({
+          await bus.putEvents({
             "detail-type": "detail",
             source: "lambda",
             detail: {},
@@ -369,7 +369,7 @@ localstackTestSuite("functionStack", (testResource, _stack, _app) => {
         "function",
         localstackClientConfig,
         async () => {
-          const result = putEvents({
+          const result = await putEvents({
             Entries: [
               {
                 EventBusName: bus.eventBusArn,
@@ -401,7 +401,7 @@ localstackTestSuite("functionStack", (testResource, _stack, _app) => {
         "function",
         localstackClientConfig,
         async () => {
-          const result = $AWS.EventBridge.putEvents({
+          const result = await $AWS.EventBridge.putEvents({
             Entries: [
               {
                 EventBusName: bus.eventBusArn,
@@ -428,7 +428,7 @@ localstackTestSuite("functionStack", (testResource, _stack, _app) => {
         localstackClientConfig,
         async () => {
           const busbus = bus;
-          busbus.putEvents({
+          await busbus.putEvents({
             "detail-type": "anyDetail",
             source: "anySource",
             detail: {},
@@ -449,7 +449,7 @@ localstackTestSuite("functionStack", (testResource, _stack, _app) => {
         localstackClientConfig,
         async () => {
           const { bus } = buses;
-          bus.putEvents({
+          await bus.putEvents({
             "detail-type": "anyDetail",
             source: "anySource",
             detail: {},
@@ -587,7 +587,7 @@ localstackTestSuite("functionStack", (testResource, _stack, _app) => {
         localstackClientConfig,
         async () => {
           // TODO should be awaited?
-          func1({});
+          await func1({});
           return "started!";
         }
       );
@@ -609,10 +609,10 @@ localstackTestSuite("functionStack", (testResource, _stack, _app) => {
         localstackClientConfig,
         async () => {
           // TODO should be awaited?
-          const result = func1({});
+          const result = await func1({});
           let status = "RUNNING";
           while (true) {
-            const state = func1.describeExecution(result.executionArn);
+            const state = await func1.describeExecution(result.executionArn);
             status = state.status;
             if (status !== "RUNNING") {
               return state.output;
@@ -642,7 +642,7 @@ localstackTestSuite("functionStack", (testResource, _stack, _app) => {
         localstackClientConfig,
         async () => {
           // TODO should be awaited?
-          const result = func1({});
+          const result = await func1({});
           return result.status === "SUCCEEDED" ? result.output : result.error;
         }
       );
@@ -669,13 +669,13 @@ localstackTestSuite("functionStack", (testResource, _stack, _app) => {
         "function",
         localstackClientConfig,
         async () => {
-          putItem({
+          await putItem({
             TableName: table,
             Item: {
               key: { S: "key" },
             },
           });
-          const item = getItem({
+          const item = await getItem({
             TableName: table,
             Key: {
               key: {

--- a/test/function.test.ts
+++ b/test/function.test.ts
@@ -50,8 +50,8 @@ $util.toJson($v1)`,
 
 test("call function and conditional return", () =>
   appsyncTestCase(
-    reflect((context: AppsyncContext<{ arg: string }>) => {
-      const result = fn1(context.arguments);
+    reflect(async (context: AppsyncContext<{ arg: string }>) => {
+      const result = await fn1(context.arguments);
 
       if (result.id === "sam") {
         return true;

--- a/test/table.test.ts
+++ b/test/table.test.ts
@@ -23,15 +23,19 @@ const table = new Table<Item, "id">(
 
 test("get item", () =>
   appsyncTestCase(
-    reflect((context: AppsyncContext<{ id: string }>): Item | undefined => {
-      return table.getItem({
-        key: {
-          id: {
-            S: context.arguments.id,
+    reflect(
+      async (
+        context: AppsyncContext<{ id: string }>
+      ): Promise<Item | undefined> => {
+        return table.getItem({
+          key: {
+            id: {
+              S: context.arguments.id,
+            },
           },
-        },
-      });
-    }),
+        });
+      }
+    ),
     // pipeline's request mapping template
     "{}",
     // function's request mapping template
@@ -60,16 +64,20 @@ $util.toJson($v4)`,
 
 test("get item and set consistentRead:true", () =>
   appsyncTestCase(
-    reflect((context: AppsyncContext<{ id: string }>): Item | undefined => {
-      return table.getItem({
-        key: {
-          id: {
-            S: context.arguments.id,
+    reflect(
+      async (
+        context: AppsyncContext<{ id: string }>
+      ): Promise<Item | undefined> => {
+        return table.getItem({
+          key: {
+            id: {
+              S: context.arguments.id,
+            },
           },
-        },
-        consistentRead: true,
-      });
-    }),
+          consistentRead: true,
+        });
+      }
+    ),
     // pipeline's request mapping template
     "{}",
     // function's request mapping template
@@ -100,9 +108,9 @@ $util.toJson($v4)`,
 test("put item", () =>
   appsyncTestCase(
     reflect(
-      (
+      async (
         context: AppsyncContext<{ id: string; name: number }>
-      ): Item | undefined => {
+      ): Promise<Item | undefined> => {
         return table.putItem({
           key: {
             id: {
@@ -176,21 +184,25 @@ $util.toJson($v10)`,
 
 test("update item", () =>
   appsyncTestCase(
-    reflect((context: AppsyncContext<{ id: string }>): Item | undefined => {
-      return table.updateItem({
-        key: {
-          id: {
-            S: context.arguments.id,
+    reflect(
+      async (
+        context: AppsyncContext<{ id: string }>
+      ): Promise<Item | undefined> => {
+        return table.updateItem({
+          key: {
+            id: {
+              S: context.arguments.id,
+            },
           },
-        },
-        update: {
-          expression: "#name = #name + 1",
-          expressionNames: {
-            "#name": "name",
+          update: {
+            expression: "#name = #name + 1",
+            expressionNames: {
+              "#name": "name",
+            },
           },
-        },
-      });
-    }),
+        });
+      }
+    ),
     // pipeline's request mapping template
     "{}",
     // function's request mapping template
@@ -229,21 +241,25 @@ $util.toJson($v6)`,
 
 test("delete item", () =>
   appsyncTestCase(
-    reflect((context: AppsyncContext<{ id: string }>): Item | undefined => {
-      return table.deleteItem({
-        key: {
-          id: {
-            S: context.arguments.id,
+    reflect(
+      async (
+        context: AppsyncContext<{ id: string }>
+      ): Promise<Item | undefined> => {
+        return table.deleteItem({
+          key: {
+            id: {
+              S: context.arguments.id,
+            },
           },
-        },
-        condition: {
-          expression: "#name = #name + 1",
-          expressionNames: {
-            "#name": "name",
+          condition: {
+            expression: "#name = #name + 1",
+            expressionNames: {
+              "#name": "name",
+            },
           },
-        },
-      });
-    }),
+        });
+      }
+    ),
     // pipeline's request mapping template
     "{}",
     // function's request mapping template
@@ -281,20 +297,26 @@ $util.toJson($v6)`,
 
 test("query", () =>
   appsyncTestCase(
-    reflect((context: AppsyncContext<{ id: string; sort: number }>): Item[] => {
-      return table.query({
-        query: {
-          expression: "id = :id and #name = :val",
-          expressionNames: {
-            "#name": "name",
-          },
-          expressionValues: {
-            ":id": $util.dynamodb.toDynamoDB(context.arguments.id),
-            ":val": $util.dynamodb.toDynamoDB(context.arguments.sort),
-          },
-        },
-      }).items;
-    }),
+    reflect(
+      async (
+        context: AppsyncContext<{ id: string; sort: number }>
+      ): Promise<Item[]> => {
+        return (
+          await table.query({
+            query: {
+              expression: "id = :id and #name = :val",
+              expressionNames: {
+                "#name": "name",
+              },
+              expressionValues: {
+                ":id": $util.dynamodb.toDynamoDB(context.arguments.id),
+                ":val": $util.dynamodb.toDynamoDB(context.arguments.sort),
+              },
+            },
+          })
+        ).items;
+      }
+    ),
     // pipeline's request mapping template
     "{}",
     // function's request mapping template


### PR DESCRIPTION
Closes #105 

Updates Resource Callbacks to support promises. Updates most integrations to return callbacks. 

Why? - Lambda supports the full promise API running in a native function, but was written to mock synchronous calls as most of the integration were synchronous. Step Functions and App Sync didn't support promises and assume all integrations are synchronous. This change allows for the addition of async behavior and allows a user in a lambda function to choose how to use the promise API.

Before

```ts
const bus = new EventBus();

const sfn = new StepFunction(this, 'sfn', (event) => {
    bus.putEvents(event);
})

const sfn = new Function(this, 'sfn', async (event) => {
    bus.putEvents(event);
})
```

After

```ts
const bus = new EventBus();

const sfn = new StepFunction(this, 'sfn', async (event) => {
    await bus.putEvents(event);
})

const sfn = new Function(this, 'sfn', async (event) => {
    await bus.putEvents(event);
    const puts = [1,2,3].map(i => bus.putEvents(event));
    await Promise.All(puts);
})
```

New Validation being added: https://github.com/functionless/functionless/issues/105#issuecomment-1147678100

* [x] Refactor interfaces
* [x] Refactor tests
* [x] Refactor test-app
* [ ] Compiler updates
   * [ ] Errors
* [ ] Step Functions
* [ ] App Sync
* [ ] Lambda
* [ ] Language Server
* [ ] Refactor Docs
* [ ] Refactor inline examples

BREAKING_CHANGE: Most integrations return `Promise`s and will need to be awaited in order to work.
BREAKING_CHANGE: Using `.map` in sfn and appsync (?) which calls integrations will need to use `Promise.all()` to join the concurrent requests.
BREAKING_CHANGE: Using `.map` + `Promise.all` in sfn will use max concurrency while the a map that does not return a promise will continue to use 1 concurrency. Note: Use `$SFN.map` to configure the concurency and other aspects of the `Map` State.