### PR TITLE
feat: snapshot tests for step function compiler tests

### DIFF
--- a/test/__snapshots__/step-function.test.ts.snap
+++ b/test/__snapshots__/step-function.test.ts.snap
@@ -203,6 +203,79 @@ Object {
 }
 `;
 
+exports[`call AWS.DynamoDB.GetItem, then Lambda and return LiteralExpr 1`] = `
+Object {
+  "StartAt": "person = $AWS.DynamoDB.GetItem({TableName: personTable, Key: {id: {S: input",
+  "States": Object {
+    "if(person.Item == undefined)": Object {
+      "Choices": Array [
+        Object {
+          "Next": "return undefined",
+          "Or": Array [
+            Object {
+              "IsPresent": false,
+              "Variable": "$.person.Item",
+            },
+            Object {
+              "IsNull": true,
+              "Variable": "$.person.Item",
+            },
+          ],
+        },
+      ],
+      "Default": "score = computeScore({id: person.Item.id.S, name: person.Item.name.S})",
+      "Type": "Choice",
+    },
+    "person = $AWS.DynamoDB.GetItem({TableName: personTable, Key: {id: {S: input": Object {
+      "Next": "if(person.Item == undefined)",
+      "Parameters": Object {
+        "Key": Object {
+          "id": Object {
+            "S.$": "$.id",
+          },
+        },
+        "TableName": "__REPLACED_TOKEN",
+      },
+      "Resource": "arn:aws:states:::aws-sdk:dynamodb:getItem",
+      "ResultPath": "$.person",
+      "Type": "Task",
+    },
+    "return undefined": Object {
+      "End": true,
+      "OutputPath": "$.null",
+      "Parameters": Object {
+        "null": null,
+      },
+      "Type": "Pass",
+    },
+    "return {id: person.Item.id.S, name: person.Item.name.S, score: score}": Object {
+      "End": true,
+      "Parameters": Object {
+        "id.$": "$.person.Item.id.S",
+        "name.$": "$.person.Item.name.S",
+        "score.$": "$.score",
+      },
+      "ResultPath": "$",
+      "Type": "Pass",
+    },
+    "score = computeScore({id: person.Item.id.S, name: person.Item.name.S})": Object {
+      "Next": "return {id: person.Item.id.S, name: person.Item.name.S, score: score}",
+      "Parameters": Object {
+        "FunctionName": "__REPLACED_TOKEN",
+        "Payload": Object {
+          "id.$": "$.person.Item.id.S",
+          "name.$": "$.person.Item.name.S",
+        },
+      },
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "ResultPath": "$.score",
+      "ResultSelector": "$.Payload",
+      "Type": "Task",
+    },
+  },
+}
+`;
+
 exports[`call Lambda Function, store as variable, return variable 1`] = `
 Object {
   "StartAt": "person = getPerson({id: input.id})",
@@ -458,6 +531,47 @@ Object {
 }
 `;
 
+exports[`conditionally call DynamoDB and then void 1`] = `
+Object {
+  "StartAt": "if(input.id == \\"hello\\")",
+  "States": Object {
+    "$AWS.DynamoDB.GetItem({TableName: personTable, Key: {id: {S: input.id}}})": Object {
+      "Next": "return null",
+      "Parameters": Object {
+        "Key": Object {
+          "id": Object {
+            "S.$": "$.id",
+          },
+        },
+        "TableName": "__REPLACED_TOKEN",
+      },
+      "Resource": "arn:aws:states:::aws-sdk:dynamodb:getItem",
+      "ResultPath": null,
+      "Type": "Task",
+    },
+    "if(input.id == \\"hello\\")": Object {
+      "Choices": Array [
+        Object {
+          "Next": "$AWS.DynamoDB.GetItem({TableName: personTable, Key: {id: {S: input.id}}})",
+          "StringEquals": "hello",
+          "Variable": "$.id",
+        },
+      ],
+      "Default": "return null",
+      "Type": "Choice",
+    },
+    "return null": Object {
+      "End": true,
+      "OutputPath": "$.null",
+      "Parameters": Object {
+        "null": null,
+      },
+      "Type": "Pass",
+    },
+  },
+}
+`;
+
 exports[`conditionally return void 1`] = `
 Object {
   "StartAt": "if(input.id == \\"hello\\")",
@@ -652,6 +766,22 @@ Object {
 }
 `;
 
+exports[`empty function 1`] = `
+Object {
+  "StartAt": "return null",
+  "States": Object {
+    "return null": Object {
+      "End": true,
+      "OutputPath": "$.null",
+      "Parameters": Object {
+        "null": null,
+      },
+      "Type": "Pass",
+    },
+  },
+}
+`;
+
 exports[`for i in items, items[i] 1`] = `
 Object {
   "StartAt": "for(i in input.items)",
@@ -693,6 +823,100 @@ Object {
 }
 `;
 
+exports[`for-loop and do nothing 1`] = `
+Object {
+  "StartAt": "for(item of input.items)",
+  "States": Object {
+    "for(item of input.items)": Object {
+      "ItemsPath": "$.items",
+      "Iterator": Object {
+        "StartAt": "a = item",
+        "States": Object {
+          "a = item": Object {
+            "End": true,
+            "OutputPath": "$.result",
+            "Parameters": Object {
+              "result.$": "$.item",
+            },
+            "ResultPath": "$.a",
+            "Type": "Pass",
+          },
+        },
+      },
+      "MaxConcurrency": 1,
+      "Next": "return null",
+      "Parameters": Object {
+        "item.$": "$$.Map.Item.Value",
+      },
+      "ResultPath": null,
+      "Type": "Map",
+    },
+    "return null": Object {
+      "End": true,
+      "OutputPath": "$.null",
+      "Parameters": Object {
+        "null": null,
+      },
+      "Type": "Pass",
+    },
+  },
+}
+`;
+
+exports[`for-loop over a list literal 1`] = `
+Object {
+  "StartAt": "people = [\\"sam\\", \\"brendan\\"]",
+  "States": Object {
+    "for(name of people)": Object {
+      "ItemsPath": "$.people",
+      "Iterator": Object {
+        "StartAt": "computeScore({id: input.id, name: name})",
+        "States": Object {
+          "computeScore({id: input.id, name: name})": Object {
+            "End": true,
+            "Parameters": Object {
+              "FunctionName": "__REPLACED_TOKEN",
+              "Payload": Object {
+                "id.$": "$.id",
+                "name.$": "$.name",
+              },
+            },
+            "Resource": "arn:aws:states:::lambda:invoke",
+            "ResultPath": null,
+            "ResultSelector": "$.Payload",
+            "Type": "Task",
+          },
+        },
+      },
+      "MaxConcurrency": 1,
+      "Next": "return null",
+      "Parameters": Object {
+        "name.$": "$$.Map.Item.Value",
+      },
+      "ResultPath": null,
+      "Type": "Map",
+    },
+    "people = [\\"sam\\", \\"brendan\\"]": Object {
+      "Next": "for(name of people)",
+      "Result": Array [
+        "sam",
+        "brendan",
+      ],
+      "ResultPath": "$.people",
+      "Type": "Pass",
+    },
+    "return null": Object {
+      "End": true,
+      "OutputPath": "$.null",
+      "Parameters": Object {
+        "null": null,
+      },
+      "Type": "Pass",
+    },
+  },
+}
+`;
+
 exports[`for-of { try { task() } catch (err) { if(err) throw } finally { task() } } 1`] = `
 Object {
   "StartAt": "for(item of input.items)",
@@ -702,6 +926,20 @@ Object {
       "Iterator": Object {
         "StartAt": "task(item)",
         "States": Object {
+          "0_catch(err)": Object {
+            "InputPath": "$.err.0_ParsedError",
+            "Next": "if(err.message == \\"you dun' goofed\\")",
+            "ResultPath": "$.err",
+            "Type": "Pass",
+          },
+          "catch(err)": Object {
+            "Next": "0_catch(err)",
+            "Parameters": Object {
+              "0_ParsedError.$": "States.StringToJson($.err.Cause)",
+            },
+            "ResultPath": "$.err",
+            "Type": "Pass",
+          },
           "exit finally": Object {
             "Choices": Array [
               Object {
@@ -713,7 +951,18 @@ Object {
             "Default": "return null",
             "Type": "Choice",
           },
-          "task(item)": Object {
+          "if(err.message == \\"you dun' goofed\\")": Object {
+            "Choices": Array [
+              Object {
+                "Next": "throw new Error(\\"little\\")",
+                "StringEquals": "you dun' goofed",
+                "Variable": "$.err.message",
+              },
+            ],
+            "Default": "task(\\"2\\")",
+            "Type": "Choice",
+          },
+          "task(\\"2\\")": Object {
             "Next": "exit finally",
             "Parameters": Object {
               "FunctionName": "__REPLACED_TOKEN",
@@ -724,10 +973,38 @@ Object {
             "ResultSelector": "$.Payload",
             "Type": "Task",
           },
+          "task(item)": Object {
+            "Catch": Array [
+              Object {
+                "ErrorEquals": Array [
+                  "States.ALL",
+                ],
+                "Next": "catch(err)",
+                "ResultPath": "$.err",
+              },
+            ],
+            "Next": "task(\\"2\\")",
+            "Parameters": Object {
+              "FunctionName": "__REPLACED_TOKEN",
+              "Payload.$": "$.item",
+            },
+            "Resource": "arn:aws:states:::lambda:invoke",
+            "ResultPath": null,
+            "ResultSelector": "$.Payload",
+            "Type": "Task",
+          },
           "throw finally": Object {
             "Cause": "an error was re-thrown from a finally block which is unsupported by Step Functions",
             "Error": "ReThrowFromFinally",
             "Type": "Fail",
+          },
+          "throw new Error(\\"little\\")": Object {
+            "Next": "task(\\"2\\")",
+            "Result": Object {
+              "message": "little",
+            },
+            "ResultPath": "$.0_tmp",
+            "Type": "Pass",
           },
         },
       },
@@ -1376,11 +1653,22 @@ Object {
             "Default": "return task(input.list[0])",
             "Type": "Choice",
           },
-          "return task(item)": Object {
+          "return task(input.list[0])": Object {
             "End": true,
             "Parameters": Object {
               "FunctionName": "__REPLACED_TOKEN",
               "Payload.$": "$.list[0]",
+            },
+            "Resource": "arn:aws:states:::lambda:invoke",
+            "ResultPath": "$",
+            "ResultSelector": "$.Payload",
+            "Type": "Task",
+          },
+          "return task(item)": Object {
+            "End": true,
+            "Parameters": Object {
+              "FunctionName": "__REPLACED_TOKEN",
+              "Payload.$": "$.item",
             },
             "Resource": "arn:aws:states:::lambda:invoke",
             "ResultPath": "$",
@@ -1510,11 +1798,22 @@ Object {
             "Default": "return task(input.list[0])",
             "Type": "Choice",
           },
-          "return task(item)": Object {
+          "return task(input.list[0])": Object {
             "End": true,
             "Parameters": Object {
               "FunctionName": "__REPLACED_TOKEN",
               "Payload.$": "$.list[0]",
+            },
+            "Resource": "arn:aws:states:::lambda:invoke",
+            "ResultPath": "$",
+            "ResultSelector": "$.Payload",
+            "Type": "Task",
+          },
+          "return task(item)": Object {
+            "End": true,
+            "Parameters": Object {
+              "FunctionName": "__REPLACED_TOKEN",
+              "Payload.$": "$.item",
             },
             "Resource": "arn:aws:states:::lambda:invoke",
             "ResultPath": "$",
@@ -1611,7 +1910,7 @@ Object {
               "value.$": "$.id",
             },
             "DetailType": "someEvent",
-            "EventBusName": "\${Token[TOKEN.818]}",
+            "EventBusName": "__REPLACED_TOKEN",
             "Source": "sfnTest",
           },
         ],
@@ -1645,7 +1944,7 @@ Object {
               "value.$": "$.id",
             },
             "DetailType": "someEvent",
-            "EventBusName": "\${Token[TOKEN.844]}",
+            "EventBusName": "__REPLACED_TOKEN",
             "Source": "sfnTest",
           },
           Object {
@@ -1654,7 +1953,7 @@ Object {
               "value.$": "$.id",
             },
             "DetailType": "someOtherEvent",
-            "EventBusName": "\${Token[TOKEN.844]}",
+            "EventBusName": "__REPLACED_TOKEN",
             "Source": "sfnTest",
           },
         ],
@@ -1814,7 +2113,7 @@ Object {
             ],
             "End": true,
             "Parameters": Object {
-              "FunctionName": "\${Token[TOKEN.3742]}",
+              "FunctionName": "__REPLACED_TOKEN",
               "Payload.$": "$.item",
             },
             "Resource": "arn:aws:states:::lambda:invoke",
@@ -1931,7 +2230,7 @@ Object {
             ],
             "End": true,
             "Parameters": Object {
-              "FunctionName": "\${Token[TOKEN.3490]}",
+              "FunctionName": "__REPLACED_TOKEN",
               "Payload.$": "$.item",
             },
             "Resource": "arn:aws:states:::lambda:invoke",
@@ -2051,8 +2350,7 @@ Object {
               ],
               "End": true,
               "Parameters": Object {
-                "FunctionName": "\${Token[TOKEN.3900]}",
-                "Payload": undefined,
+                "FunctionName": "__REPLACED_TOKEN",
               },
               "Resource": "arn:aws:states:::lambda:invoke",
               "ResultPath": "$",
@@ -2087,6 +2385,77 @@ Object {
 }
 `;
 
+exports[`return AWS.DynamoDB.GetItem 1`] = `
+Object {
+  "StartAt": "person = $AWS.DynamoDB.GetItem({TableName: personTable, Key: {id: {S: input",
+  "States": Object {
+    "if(person.Item == undefined)": Object {
+      "Choices": Array [
+        Object {
+          "Next": "return undefined",
+          "Or": Array [
+            Object {
+              "IsPresent": false,
+              "Variable": "$.person.Item",
+            },
+            Object {
+              "IsNull": true,
+              "Variable": "$.person.Item",
+            },
+          ],
+        },
+      ],
+      "Default": "return {id: person.Item.id.S, name: person.Item.name.S}",
+      "Type": "Choice",
+    },
+    "person = $AWS.DynamoDB.GetItem({TableName: personTable, Key: {id: {S: input": Object {
+      "Next": "if(person.Item == undefined)",
+      "Parameters": Object {
+        "Key": Object {
+          "id": Object {
+            "S.$": "$.id",
+          },
+        },
+        "TableName": "__REPLACED_TOKEN",
+      },
+      "Resource": "arn:aws:states:::aws-sdk:dynamodb:getItem",
+      "ResultPath": "$.person",
+      "Type": "Task",
+    },
+    "return undefined": Object {
+      "End": true,
+      "OutputPath": "$.null",
+      "Parameters": Object {
+        "null": null,
+      },
+      "Type": "Pass",
+    },
+    "return {id: person.Item.id.S, name: person.Item.name.S}": Object {
+      "End": true,
+      "Parameters": Object {
+        "id.$": "$.person.Item.id.S",
+        "name.$": "$.person.Item.name.S",
+      },
+      "ResultPath": "$",
+      "Type": "Pass",
+    },
+  },
+}
+`;
+
+exports[`return PropAccessExpr 1`] = `
+Object {
+  "StartAt": "return input.input.id",
+  "States": Object {
+    "return input.input.id": Object {
+      "End": true,
+      "OutputPath": "$.input.id",
+      "Type": "Pass",
+    },
+  },
+}
+`;
+
 exports[`return a single Lambda Function call 1`] = `
 Object {
   "StartAt": "return getPerson({id: input.id})",
@@ -2103,6 +2472,19 @@ Object {
       "ResultPath": "$",
       "ResultSelector": "$.Payload",
       "Type": "Task",
+    },
+  },
+}
+`;
+
+exports[`return identifier 1`] = `
+Object {
+  "StartAt": "return input.id",
+  "States": Object {
+    "return input.id": Object {
+      "End": true,
+      "OutputPath": "$.id",
+      "Type": "Pass",
     },
   },
 }
@@ -2178,6 +2560,19 @@ Object {
 }
 `;
 
+exports[`return optional PropAccessExpr 1`] = `
+Object {
+  "StartAt": "return input.input.id",
+  "States": Object {
+    "return input.input.id": Object {
+      "End": true,
+      "OutputPath": "$.input.id",
+      "Type": "Pass",
+    },
+  },
+}
+`;
+
 exports[`return task({ key: items.filter(*) }) 1`] = `
 Object {
   "StartAt": "return task({equals: input.items.filter(function(item)), and: input.items.f",
@@ -2227,6 +2622,16 @@ Object {
   "StartAt": "0_tmp = task()",
   "States": Object {
     "0_tmp = task()": Object {
+      "Next": "return task(0_tmp)",
+      "Parameters": Object {
+        "FunctionName": "__REPLACED_TOKEN",
+      },
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "ResultPath": "$.0_tmp",
+      "ResultSelector": "$.Payload",
+      "Type": "Task",
+    },
+    "return task(0_tmp)": Object {
       "End": true,
       "Parameters": Object {
         "FunctionName": "__REPLACED_TOKEN",
@@ -2236,6 +2641,22 @@ Object {
       "ResultPath": "$",
       "ResultSelector": "$.Payload",
       "Type": "Task",
+    },
+  },
+}
+`;
+
+exports[`return void 1`] = `
+Object {
+  "StartAt": "return null",
+  "States": Object {
+    "return null": Object {
+      "End": true,
+      "OutputPath": "$.null",
+      "Parameters": Object {
+        "null": null,
+      },
+      "Type": "Pass",
     },
   },
 }
@@ -2318,11 +2739,267 @@ Object {
       },
       "Type": "Pass",
     },
-    "task(null)": Object {
+    "task(\\"hello\\" + \\" world\\")": Object {
+      "Next": "task(\\"hello\\" + 1)",
+      "Parameters": Object {
+        "FunctionName": "__REPLACED_TOKEN",
+        "Payload": "hello world",
+      },
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "ResultPath": null,
+      "ResultSelector": "$.Payload",
+      "Type": "Task",
+    },
+    "task(\\"hello\\" + 1)": Object {
+      "Next": "task(1 + \\"hello\\")",
+      "Parameters": Object {
+        "FunctionName": "__REPLACED_TOKEN",
+        "Payload": "hello1",
+      },
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "ResultPath": null,
+      "ResultSelector": "$.Payload",
+      "Type": "Task",
+    },
+    "task(\\"hello\\" + [\\"world\\"])": Object {
       "Next": "return null",
       "Parameters": Object {
         "FunctionName": "__REPLACED_TOKEN",
         "Payload": "helloworld",
+      },
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "ResultPath": null,
+      "ResultSelector": "$.Payload",
+      "Type": "Task",
+    },
+    "task(\\"hello\\" + null)": Object {
+      "Next": "task([null])",
+      "Parameters": Object {
+        "FunctionName": "__REPLACED_TOKEN",
+        "Payload": "hellonull",
+      },
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "ResultPath": null,
+      "ResultSelector": "$.Payload",
+      "Type": "Task",
+    },
+    "task(\\"hello\\" + true)": Object {
+      "Next": "task(false + \\"hello\\")",
+      "Parameters": Object {
+        "FunctionName": "__REPLACED_TOKEN",
+        "Payload": "hellotrue",
+      },
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "ResultPath": null,
+      "ResultSelector": "$.Payload",
+      "Type": "Task",
+    },
+    "task(\\"hello\\" + {place: \\"world\\"})": Object {
+      "Next": "task(\\"hello\\" + [\\"world\\"])",
+      "Parameters": Object {
+        "FunctionName": "__REPLACED_TOKEN",
+        "Payload": "hello[object Object]",
+      },
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "ResultPath": null,
+      "ResultSelector": "$.Payload",
+      "Type": "Task",
+    },
+    "task(\\"hello\\")": Object {
+      "Next": "task(\\"hello\\" + \\" world\\")",
+      "Parameters": Object {
+        "FunctionName": "__REPLACED_TOKEN",
+        "Payload": "hello",
+      },
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "ResultPath": null,
+      "ResultSelector": "$.Payload",
+      "Type": "Task",
+    },
+    "task(-1)": Object {
+      "Next": "task(-100)",
+      "Parameters": Object {
+        "FunctionName": "__REPLACED_TOKEN",
+        "Payload": -1,
+      },
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "ResultPath": null,
+      "ResultSelector": "$.Payload",
+      "Type": "Task",
+    },
+    "task(-100)": Object {
+      "Next": "task(1 + 2)",
+      "Parameters": Object {
+        "FunctionName": "__REPLACED_TOKEN",
+        "Payload": -100,
+      },
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "ResultPath": null,
+      "ResultSelector": "$.Payload",
+      "Type": "Task",
+    },
+    "task(0)": Object {
+      "Next": "task(-1)",
+      "Parameters": Object {
+        "FunctionName": "__REPLACED_TOKEN",
+        "Payload": 0,
+      },
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "ResultPath": null,
+      "ResultSelector": "$.Payload",
+      "Type": "Task",
+    },
+    "task(1 + \\"hello\\")": Object {
+      "Next": "task(\\"hello\\" + true)",
+      "Parameters": Object {
+        "FunctionName": "__REPLACED_TOKEN",
+        "Payload": "1hello",
+      },
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "ResultPath": null,
+      "ResultSelector": "$.Payload",
+      "Type": "Task",
+    },
+    "task(1 + 2)": Object {
+      "Next": "task(\\"hello\\")",
+      "Parameters": Object {
+        "FunctionName": "__REPLACED_TOKEN",
+        "Payload": 3,
+      },
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "ResultPath": null,
+      "ResultSelector": "$.Payload",
+      "Type": "Task",
+    },
+    "task([-1])": Object {
+      "Next": "task([true])",
+      "Parameters": Object {
+        "FunctionName": "__REPLACED_TOKEN",
+        "Payload": Array [
+          -1,
+        ],
+      },
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "ResultPath": null,
+      "ResultSelector": "$.Payload",
+      "Type": "Task",
+    },
+    "task([1])": Object {
+      "Next": "task([-1])",
+      "Parameters": Object {
+        "FunctionName": "__REPLACED_TOKEN",
+        "Payload": Array [
+          1,
+        ],
+      },
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "ResultPath": null,
+      "ResultSelector": "$.Payload",
+      "Type": "Task",
+    },
+    "task([null])": Object {
+      "Next": "task([1])",
+      "Parameters": Object {
+        "FunctionName": "__REPLACED_TOKEN",
+        "Payload": Array [
+          null,
+        ],
+      },
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "ResultPath": null,
+      "ResultSelector": "$.Payload",
+      "Type": "Task",
+    },
+    "task([true])": Object {
+      "Next": "task([{key: \\"value\\"}])",
+      "Parameters": Object {
+        "FunctionName": "__REPLACED_TOKEN",
+        "Payload": Array [
+          true,
+        ],
+      },
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "ResultPath": null,
+      "ResultSelector": "$.Payload",
+      "Type": "Task",
+    },
+    "task([{key: \\"value\\"}])": Object {
+      "Next": "task({key: \\"value\\"})",
+      "Parameters": Object {
+        "FunctionName": "__REPLACED_TOKEN",
+        "Payload": Array [
+          Object {
+            "key": "value",
+          },
+        ],
+      },
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "ResultPath": null,
+      "ResultSelector": "$.Payload",
+      "Type": "Task",
+    },
+    "task(false + \\"hello\\")": Object {
+      "Next": "task(null + \\"hello\\")",
+      "Parameters": Object {
+        "FunctionName": "__REPLACED_TOKEN",
+        "Payload": "falsehello",
+      },
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "ResultPath": null,
+      "ResultSelector": "$.Payload",
+      "Type": "Task",
+    },
+    "task(false)": Object {
+      "Next": "task(0)",
+      "Parameters": Object {
+        "FunctionName": "__REPLACED_TOKEN",
+        "Payload": false,
+      },
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "ResultPath": null,
+      "ResultSelector": "$.Payload",
+      "Type": "Task",
+    },
+    "task(null + \\"hello\\")": Object {
+      "Next": "task(\\"hello\\" + null)",
+      "Parameters": Object {
+        "FunctionName": "__REPLACED_TOKEN",
+        "Payload": "nullhello",
+      },
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "ResultPath": null,
+      "ResultSelector": "$.Payload",
+      "Type": "Task",
+    },
+    "task(null)": Object {
+      "Next": "task(true)",
+      "Parameters": Object {
+        "FunctionName": "__REPLACED_TOKEN",
+        "Payload": null,
+      },
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "ResultPath": null,
+      "ResultSelector": "$.Payload",
+      "Type": "Task",
+    },
+    "task(true)": Object {
+      "Next": "task(false)",
+      "Parameters": Object {
+        "FunctionName": "__REPLACED_TOKEN",
+        "Payload": true,
+      },
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "ResultPath": null,
+      "ResultSelector": "$.Payload",
+      "Type": "Task",
+    },
+    "task({key: \\"value\\"})": Object {
+      "Next": "task(\\"hello\\" + {place: \\"world\\"})",
+      "Parameters": Object {
+        "FunctionName": "__REPLACED_TOKEN",
+        "Payload": Object {
+          "key": "value",
+        },
       },
       "Resource": "arn:aws:states:::lambda:invoke",
       "ResultPath": null,
@@ -2470,7 +3147,7 @@ Object {
           "return task(item)": Object {
             "End": true,
             "Parameters": Object {
-              "FunctionName": "\${Token[TOKEN.3784]}",
+              "FunctionName": "__REPLACED_TOKEN",
               "Payload.$": "$.item",
             },
             "Resource": "arn:aws:states:::lambda:invoke",
@@ -2520,7 +3197,7 @@ Object {
           "return task(item)": Object {
             "End": true,
             "Parameters": Object {
-              "FunctionName": "\${Token[TOKEN.3532]}",
+              "FunctionName": "__REPLACED_TOKEN",
               "Payload.$": "$.item",
             },
             "Resource": "arn:aws:states:::lambda:invoke",
@@ -2594,7 +3271,7 @@ Object {
           "task(item)": Object {
             "End": true,
             "Parameters": Object {
-              "FunctionName": "\${Token[TOKEN.2544]}",
+              "FunctionName": "__REPLACED_TOKEN",
               "Payload.$": "$.item",
             },
             "Resource": "arn:aws:states:::lambda:invoke",
@@ -2634,7 +3311,7 @@ Object {
     "task(\\"2\\")": Object {
       "Next": "exit finally",
       "Parameters": Object {
-        "FunctionName": "\${Token[TOKEN.2544]}",
+        "FunctionName": "__REPLACED_TOKEN",
         "Payload": "2",
       },
       "Resource": "arn:aws:states:::lambda:invoke",
@@ -2681,7 +3358,7 @@ Object {
           "return task(item)": Object {
             "End": true,
             "Parameters": Object {
-              "FunctionName": "\${Token[TOKEN.3164]}",
+              "FunctionName": "__REPLACED_TOKEN",
               "Payload.$": "$.item",
             },
             "Resource": "arn:aws:states:::lambda:invoke",
@@ -2740,7 +3417,7 @@ Object {
             ],
             "End": true,
             "Parameters": Object {
-              "FunctionName": "\${Token[TOKEN.3206]}",
+              "FunctionName": "__REPLACED_TOKEN",
               "Payload.$": "$.item",
             },
             "Resource": "arn:aws:states:::lambda:invoke",
@@ -2898,7 +3575,7 @@ Object {
           "return task(item)": Object {
             "End": true,
             "Parameters": Object {
-              "FunctionName": "\${Token[TOKEN.2880]}",
+              "FunctionName": "__REPLACED_TOKEN",
               "Payload.$": "$.item",
             },
             "Resource": "arn:aws:states:::lambda:invoke",
@@ -2957,7 +3634,7 @@ Object {
             ],
             "End": true,
             "Parameters": Object {
-              "FunctionName": "\${Token[TOKEN.2922]}",
+              "FunctionName": "__REPLACED_TOKEN",
               "Payload.$": "$.item",
             },
             "Resource": "arn:aws:states:::lambda:invoke",
@@ -3170,7 +3847,7 @@ Object {
       },
       "Type": "Pass",
     },
-    "task()": Object {
+    "task(\\"recover\\")": Object {
       "Next": "exit finally",
       "Parameters": Object {
         "FunctionName": "__REPLACED_TOKEN",
@@ -3181,10 +3858,37 @@ Object {
       "ResultSelector": "$.Payload",
       "Type": "Task",
     },
+    "task()": Object {
+      "Catch": Array [
+        Object {
+          "ErrorEquals": Array [
+            "States.ALL",
+          ],
+          "Next": "throw new Error(\\"cause\\")",
+          "ResultPath": null,
+        },
+      ],
+      "Next": "task(\\"recover\\")",
+      "Parameters": Object {
+        "FunctionName": "__REPLACED_TOKEN",
+      },
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "ResultPath": null,
+      "ResultSelector": "$.Payload",
+      "Type": "Task",
+    },
     "throw finally": Object {
       "Cause": "an error was re-thrown from a finally block which is unsupported by Step Functions",
       "Error": "ReThrowFromFinally",
       "Type": "Fail",
+    },
+    "throw new Error(\\"cause\\")": Object {
+      "Next": "task(\\"recover\\")",
+      "Result": Object {
+        "message": "cause",
+      },
+      "ResultPath": "$.0_tmp",
+      "Type": "Pass",
     },
   },
 }
@@ -3205,6 +3909,17 @@ Object {
       "Default": "return null",
       "Type": "Choice",
     },
+    "if(input.id == \\"sam\\")": Object {
+      "Choices": Array [
+        Object {
+          "Next": "throw new Error(\\"little\\")",
+          "StringEquals": "sam",
+          "Variable": "$.id",
+        },
+      ],
+      "Default": "task(\\"2\\")",
+      "Type": "Choice",
+    },
     "return null": Object {
       "End": true,
       "OutputPath": "$.null",
@@ -3214,6 +3929,26 @@ Object {
       "Type": "Pass",
     },
     "task(\\"1\\")": Object {
+      "Catch": Array [
+        Object {
+          "ErrorEquals": Array [
+            "States.ALL",
+          ],
+          "Next": "if(input.id == \\"sam\\")",
+          "ResultPath": null,
+        },
+      ],
+      "Next": "task(\\"2\\")",
+      "Parameters": Object {
+        "FunctionName": "__REPLACED_TOKEN",
+        "Payload": "1",
+      },
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "ResultPath": null,
+      "ResultSelector": "$.Payload",
+      "Type": "Task",
+    },
+    "task(\\"2\\")": Object {
       "Next": "exit finally",
       "Parameters": Object {
         "FunctionName": "__REPLACED_TOKEN",
@@ -3228,6 +3963,14 @@ Object {
       "Cause": "an error was re-thrown from a finally block which is unsupported by Step Functions",
       "Error": "ReThrowFromFinally",
       "Type": "Fail",
+    },
+    "throw new Error(\\"little\\")": Object {
+      "Next": "task(\\"2\\")",
+      "Result": Object {
+        "message": "little",
+      },
+      "ResultPath": "$.0_tmp",
+      "Type": "Pass",
     },
   },
 }
@@ -3257,6 +4000,46 @@ Object {
       "Type": "Pass",
     },
     "task(\\"1\\")": Object {
+      "Catch": Array [
+        Object {
+          "ErrorEquals": Array [
+            "States.ALL",
+          ],
+          "Next": "task(\\"2\\")",
+          "ResultPath": null,
+        },
+      ],
+      "Next": "task(\\"3\\")",
+      "Parameters": Object {
+        "FunctionName": "__REPLACED_TOKEN",
+        "Payload": "1",
+      },
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "ResultPath": null,
+      "ResultSelector": "$.Payload",
+      "Type": "Task",
+    },
+    "task(\\"2\\")": Object {
+      "Catch": Array [
+        Object {
+          "ErrorEquals": Array [
+            "States.ALL",
+          ],
+          "Next": "task(\\"3\\")",
+          "ResultPath": "$.0_tmp",
+        },
+      ],
+      "Next": "task(\\"3\\")",
+      "Parameters": Object {
+        "FunctionName": "__REPLACED_TOKEN",
+        "Payload": "2",
+      },
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "ResultPath": null,
+      "ResultSelector": "$.Payload",
+      "Type": "Task",
+    },
+    "task(\\"3\\")": Object {
       "Next": "exit finally",
       "Parameters": Object {
         "FunctionName": "__REPLACED_TOKEN",
@@ -3280,6 +4063,20 @@ exports[`try { task() } catch(err) { (maybe) throw } finally { task } 1`] = `
 Object {
   "StartAt": "task(\\"1\\")",
   "States": Object {
+    "0_catch(err)": Object {
+      "InputPath": "$.err.0_ParsedError",
+      "Next": "if(err.message == \\"sam\\")",
+      "ResultPath": "$.err",
+      "Type": "Pass",
+    },
+    "catch(err)": Object {
+      "Next": "0_catch(err)",
+      "Parameters": Object {
+        "0_ParsedError.$": "States.StringToJson($.err.Cause)",
+      },
+      "ResultPath": "$.err",
+      "Type": "Pass",
+    },
     "exit finally": Object {
       "Choices": Array [
         Object {
@@ -3291,6 +4088,17 @@ Object {
       "Default": "return null",
       "Type": "Choice",
     },
+    "if(err.message == \\"sam\\")": Object {
+      "Choices": Array [
+        Object {
+          "Next": "throw new Error(\\"little\\")",
+          "StringEquals": "sam",
+          "Variable": "$.err.message",
+        },
+      ],
+      "Default": "task(\\"2\\")",
+      "Type": "Choice",
+    },
     "return null": Object {
       "End": true,
       "OutputPath": "$.null",
@@ -3300,6 +4108,26 @@ Object {
       "Type": "Pass",
     },
     "task(\\"1\\")": Object {
+      "Catch": Array [
+        Object {
+          "ErrorEquals": Array [
+            "States.ALL",
+          ],
+          "Next": "catch(err)",
+          "ResultPath": "$.err",
+        },
+      ],
+      "Next": "task(\\"2\\")",
+      "Parameters": Object {
+        "FunctionName": "__REPLACED_TOKEN",
+        "Payload": "1",
+      },
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "ResultPath": null,
+      "ResultSelector": "$.Payload",
+      "Type": "Task",
+    },
+    "task(\\"2\\")": Object {
       "Next": "exit finally",
       "Parameters": Object {
         "FunctionName": "__REPLACED_TOKEN",
@@ -3314,6 +4142,14 @@ Object {
       "Cause": "an error was re-thrown from a finally block which is unsupported by Step Functions",
       "Error": "ReThrowFromFinally",
       "Type": "Fail",
+    },
+    "throw new Error(\\"little\\")": Object {
+      "Next": "task(\\"2\\")",
+      "Result": Object {
+        "message": "little",
+      },
+      "ResultPath": "$.0_tmp",
+      "Type": "Pass",
     },
   },
 }
@@ -3404,7 +4240,7 @@ Object {
       ],
       "Next": "return null",
       "Parameters": Object {
-        "FunctionName": "\${Token[TOKEN.1675]}",
+        "FunctionName": "__REPLACED_TOKEN",
         "Payload": Object {
           "id": "id",
           "name": "name",
@@ -3596,7 +4432,7 @@ Object {
       ],
       "Next": "return \\"hello\\"",
       "Parameters": Object {
-        "FunctionName": "\${Token[TOKEN.1833]}",
+        "FunctionName": "__REPLACED_TOKEN",
         "Payload": Object {
           "id": "id",
           "name": "name",
@@ -3638,7 +4474,7 @@ Object {
       ],
       "Next": "return \\"hello\\"",
       "Parameters": Object {
-        "FunctionName": "\${Token[TOKEN.1791]}",
+        "FunctionName": "__REPLACED_TOKEN",
         "Payload": Object {
           "id": "id",
           "name": "name",
@@ -3735,7 +4571,7 @@ Object {
       ],
       "End": true,
       "Parameters": Object {
-        "FunctionName": "\${Token[TOKEN.1991]}",
+        "FunctionName": "__REPLACED_TOKEN",
         "Payload": Object {
           "id.$": "$.id",
           "name": "sam",
@@ -3780,7 +4616,7 @@ Object {
       ],
       "Next": "return \\"hello world\\"",
       "Parameters": Object {
-        "FunctionName": "\${Token[TOKEN.1949]}",
+        "FunctionName": "__REPLACED_TOKEN",
         "Payload": Object {
           "id.$": "$.id",
           "name": "sam",
@@ -4086,7 +4922,7 @@ Object {
       ],
       "Next": "return \\"hello\\"",
       "Parameters": Object {
-        "FunctionName": "\${Token[TOKEN.2218]}",
+        "FunctionName": "__REPLACED_TOKEN",
         "Payload": Object {
           "id": "id",
           "name": "name",
@@ -4310,8 +5146,7 @@ Object {
       ],
       "Next": "while (true)",
       "Parameters": Object {
-        "FunctionName": "\${Token[TOKEN.4342]}",
-        "Payload": undefined,
+        "FunctionName": "__REPLACED_TOKEN",
       },
       "Resource": "arn:aws:states:::lambda:invoke",
       "ResultPath": null,

--- a/test/__snapshots__/step-function.test.ts.snap
+++ b/test/__snapshots__/step-function.test.ts.snap
@@ -1,0 +1,4334 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`$SFN.forEach(list, (item) => task(item)) 1`] = `
+Object {
+  "StartAt": "$SFN.forEach(input.list, function(item))",
+  "States": Object {
+    "$SFN.forEach(input.list, function(item))": Object {
+      "ItemsPath": "$.list",
+      "Iterator": Object {
+        "StartAt": "return task(item)",
+        "States": Object {
+          "return task(item)": Object {
+            "End": true,
+            "Parameters": Object {
+              "FunctionName": "__REPLACED_TOKEN",
+              "Payload.$": "$.item",
+            },
+            "Resource": "arn:aws:states:::lambda:invoke",
+            "ResultPath": "$",
+            "ResultSelector": "$.Payload",
+            "Type": "Task",
+          },
+        },
+      },
+      "Next": "return null",
+      "Parameters": Object {
+        "item.$": "$$.Map.Item.Value",
+      },
+      "ResultPath": null,
+      "Type": "Map",
+    },
+    "return null": Object {
+      "End": true,
+      "OutputPath": "$.null",
+      "Parameters": Object {
+        "null": null,
+      },
+      "Type": "Pass",
+    },
+  },
+}
+`;
+
+exports[`$SFN.map(list, (item) => task(item)) 1`] = `
+Object {
+  "StartAt": "$SFN.map(input.list, function(item))",
+  "States": Object {
+    "$SFN.map(input.list, function(item))": Object {
+      "ItemsPath": "$.list",
+      "Iterator": Object {
+        "StartAt": "return task(item)",
+        "States": Object {
+          "return task(item)": Object {
+            "End": true,
+            "Parameters": Object {
+              "FunctionName": "__REPLACED_TOKEN",
+              "Payload.$": "$.item",
+            },
+            "Resource": "arn:aws:states:::lambda:invoke",
+            "ResultPath": "$",
+            "ResultSelector": "$.Payload",
+            "Type": "Task",
+          },
+        },
+      },
+      "Next": "return null",
+      "Parameters": Object {
+        "item.$": "$$.Map.Item.Value",
+      },
+      "ResultPath": null,
+      "Type": "Map",
+    },
+    "return null": Object {
+      "End": true,
+      "OutputPath": "$.null",
+      "Parameters": Object {
+        "null": null,
+      },
+      "Type": "Pass",
+    },
+  },
+}
+`;
+
+exports[`break from do-while-loop 1`] = `
+Object {
+  "StartAt": "break",
+  "States": Object {
+    "break": Object {
+      "Next": "return null",
+      "Type": "Pass",
+    },
+    "return null": Object {
+      "End": true,
+      "OutputPath": "$.null",
+      "Parameters": Object {
+        "null": null,
+      },
+      "Type": "Pass",
+    },
+    "while (true)": Object {
+      "Choices": Array [
+        Object {
+          "IsPresent": false,
+          "Next": "break",
+          "Variable": "$.0_true",
+        },
+      ],
+      "Default": "return null",
+      "Type": "Choice",
+    },
+  },
+}
+`;
+
+exports[`break from for-loop 1`] = `
+Object {
+  "StartAt": "for(item of input.items)",
+  "States": Object {
+    "for(item of input.items)": Object {
+      "Catch": Array [
+        Object {
+          "ErrorEquals": Array [
+            "Break",
+          ],
+          "Next": "return null",
+          "ResultPath": null,
+        },
+      ],
+      "ItemsPath": "$.items",
+      "Iterator": Object {
+        "StartAt": "if(item == \\"hello\\")",
+        "States": Object {
+          "0_empty_else_if(item == \\"hello\\")": Object {
+            "End": true,
+            "Type": "Pass",
+          },
+          "break": Object {
+            "Error": "Break",
+            "Type": "Fail",
+          },
+          "if(item == \\"hello\\")": Object {
+            "Choices": Array [
+              Object {
+                "Next": "break",
+                "StringEquals": "hello",
+                "Variable": "$.item",
+              },
+            ],
+            "Default": "0_empty_else_if(item == \\"hello\\")",
+            "Type": "Choice",
+          },
+        },
+      },
+      "MaxConcurrency": 1,
+      "Next": "return null",
+      "Parameters": Object {
+        "item.$": "$$.Map.Item.Value",
+      },
+      "ResultPath": null,
+      "Type": "Map",
+    },
+    "return null": Object {
+      "End": true,
+      "OutputPath": "$.null",
+      "Parameters": Object {
+        "null": null,
+      },
+      "Type": "Pass",
+    },
+  },
+}
+`;
+
+exports[`break from while-loop 1`] = `
+Object {
+  "StartAt": "while (true)",
+  "States": Object {
+    "break": Object {
+      "Next": "return null",
+      "Type": "Pass",
+    },
+    "return null": Object {
+      "End": true,
+      "OutputPath": "$.null",
+      "Parameters": Object {
+        "null": null,
+      },
+      "Type": "Pass",
+    },
+    "while (true)": Object {
+      "Choices": Array [
+        Object {
+          "IsPresent": false,
+          "Next": "break",
+          "Variable": "$.0_true",
+        },
+      ],
+      "Default": "return null",
+      "Type": "Choice",
+    },
+  },
+}
+`;
+
+exports[`call Lambda Function, store as variable, return variable 1`] = `
+Object {
+  "StartAt": "person = getPerson({id: input.id})",
+  "States": Object {
+    "person = getPerson({id: input.id})": Object {
+      "Next": "return person",
+      "Parameters": Object {
+        "FunctionName": "__REPLACED_TOKEN",
+        "Payload": Object {
+          "id.$": "$.id",
+        },
+      },
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "ResultPath": "$.person",
+      "ResultSelector": "$.Payload",
+      "Type": "Task",
+    },
+    "return person": Object {
+      "End": true,
+      "OutputPath": "$.person",
+      "Type": "Pass",
+    },
+  },
+}
+`;
+
+exports[`call Step Function describe from another Step Function 1`] = `
+Object {
+  "StartAt": "result = machine1.describeExecution(\\"hello\\")",
+  "States": Object {
+    "result = machine1.describeExecution(\\"hello\\")": Object {
+      "Next": "return result",
+      "Parameters": Object {
+        "ExecutionArn": "hello",
+      },
+      "Resource": "arn:aws:states:::aws-sdk:sfn:describeExecution",
+      "ResultPath": "$.result",
+      "Type": "Task",
+    },
+    "return result": Object {
+      "End": true,
+      "OutputPath": "$.result",
+      "Type": "Pass",
+    },
+  },
+}
+`;
+
+exports[`call Step Function describe from another Step Function from context 1`] = `
+Object {
+  "StartAt": "result = machine1.describeExecution(input.id)",
+  "States": Object {
+    "result = machine1.describeExecution(input.id)": Object {
+      "Next": "return result",
+      "Parameters": Object {
+        "ExecutionArn.$": "$.id",
+      },
+      "Resource": "arn:aws:states:::aws-sdk:sfn:describeExecution",
+      "ResultPath": "$.result",
+      "Type": "Task",
+    },
+    "return result": Object {
+      "End": true,
+      "OutputPath": "$.result",
+      "Type": "Pass",
+    },
+  },
+}
+`;
+
+exports[`call Step Function from another Step Function 1`] = `
+Object {
+  "StartAt": "result = machine1({})",
+  "States": Object {
+    "result = machine1({})": Object {
+      "Next": "return result",
+      "Parameters": Object {
+        "StateMachineArn": "__REPLACED_TOKEN",
+      },
+      "Resource": "arn:aws:states:::aws-sdk:sfn:startSyncExecution",
+      "ResultPath": "$.result",
+      "Type": "Task",
+    },
+    "return result": Object {
+      "End": true,
+      "OutputPath": "$.result",
+      "Type": "Pass",
+    },
+  },
+}
+`;
+
+exports[`call Step Function from another Step Function with dynamic input 1`] = `
+Object {
+  "StartAt": "result = machine1({input: {value: input.value1}})",
+  "States": Object {
+    "result = machine1({input: {value: input.value1}})": Object {
+      "Next": "return result",
+      "Parameters": Object {
+        "Input": Object {
+          "value.$": "$.value1",
+        },
+        "StateMachineArn": "__REPLACED_TOKEN",
+      },
+      "Resource": "arn:aws:states:::aws-sdk:sfn:startSyncExecution",
+      "ResultPath": "$.result",
+      "Type": "Task",
+    },
+    "return result": Object {
+      "End": true,
+      "OutputPath": "$.result",
+      "Type": "Pass",
+    },
+  },
+}
+`;
+
+exports[`call Step Function from another Step Function with dynamic input field input 1`] = `
+Object {
+  "StartAt": "result = machine1({input: input})",
+  "States": Object {
+    "result = machine1({input: input})": Object {
+      "Next": "return result",
+      "Parameters": Object {
+        "Input.$": "$",
+        "StateMachineArn": "__REPLACED_TOKEN",
+      },
+      "Resource": "arn:aws:states:::aws-sdk:sfn:startSyncExecution",
+      "ResultPath": "$.result",
+      "Type": "Task",
+    },
+    "return result": Object {
+      "End": true,
+      "OutputPath": "$.result",
+      "Type": "Pass",
+    },
+  },
+}
+`;
+
+exports[`call Step Function from another Step Function with input 1`] = `
+Object {
+  "StartAt": "result = machine1({input: {value: \\"hello\\"}})",
+  "States": Object {
+    "result = machine1({input: {value: \\"hello\\"}})": Object {
+      "Next": "return result",
+      "Parameters": Object {
+        "Input": Object {
+          "value": "hello",
+        },
+        "StateMachineArn": "__REPLACED_TOKEN",
+      },
+      "Resource": "arn:aws:states:::aws-sdk:sfn:startSyncExecution",
+      "ResultPath": "$.result",
+      "Type": "Task",
+    },
+    "return result": Object {
+      "End": true,
+      "OutputPath": "$.result",
+      "Type": "Pass",
+    },
+  },
+}
+`;
+
+exports[`call Step Function from another Step Function with name and trace 1`] = `
+Object {
+  "StartAt": "result = machine1({name: \\"exec1\\", traceHeader: \\"1\\"})",
+  "States": Object {
+    "result = machine1({name: \\"exec1\\", traceHeader: \\"1\\"})": Object {
+      "Next": "return result",
+      "Parameters": Object {
+        "Name": "exec1",
+        "StateMachineArn": "__REPLACED_TOKEN",
+        "TraceHeader": "1",
+      },
+      "Resource": "arn:aws:states:::aws-sdk:sfn:startSyncExecution",
+      "ResultPath": "$.result",
+      "Type": "Task",
+    },
+    "return result": Object {
+      "End": true,
+      "OutputPath": "$.result",
+      "Type": "Pass",
+    },
+  },
+}
+`;
+
+exports[`call Step Function from another Step Function with name and trace from variables 1`] = `
+Object {
+  "StartAt": "result = machine1({name: input.name, traceHeader: input.header})",
+  "States": Object {
+    "result = machine1({name: input.name, traceHeader: input.header})": Object {
+      "Next": "return result",
+      "Parameters": Object {
+        "Name.$": "$.name",
+        "StateMachineArn": "__REPLACED_TOKEN",
+        "TraceHeader.$": "$.header",
+      },
+      "Resource": "arn:aws:states:::aws-sdk:sfn:startSyncExecution",
+      "ResultPath": "$.result",
+      "Type": "Task",
+    },
+    "return result": Object {
+      "End": true,
+      "OutputPath": "$.result",
+      "Type": "Pass",
+    },
+  },
+}
+`;
+
+exports[`catch and throw Error 1`] = `
+Object {
+  "StartAt": "throw Error(\\"cause\\")",
+  "States": Object {
+    "throw Error(\\"cause\\")": Object {
+      "Next": "throw new CustomError(\\"custom cause\\")",
+      "Result": Object {
+        "message": "cause",
+      },
+      "ResultPath": "$.err",
+      "Type": "Pass",
+    },
+    "throw new CustomError(\\"custom cause\\")": Object {
+      "Cause": "{\\"property\\":\\"custom cause\\"}",
+      "Error": "CustomError",
+      "Type": "Fail",
+    },
+  },
+}
+`;
+
+exports[`catch and throw new Error 1`] = `
+Object {
+  "StartAt": "throw new Error(\\"cause\\")",
+  "States": Object {
+    "throw new CustomError(\\"custom cause\\")": Object {
+      "Cause": "{\\"property\\":\\"custom cause\\"}",
+      "Error": "CustomError",
+      "Type": "Fail",
+    },
+    "throw new Error(\\"cause\\")": Object {
+      "Next": "throw new CustomError(\\"custom cause\\")",
+      "Result": Object {
+        "message": "cause",
+      },
+      "ResultPath": "$.err",
+      "Type": "Pass",
+    },
+  },
+}
+`;
+
+exports[`conditionally return void 1`] = `
+Object {
+  "StartAt": "if(input.id == \\"hello\\")",
+  "States": Object {
+    "if(input.id == \\"hello\\")": Object {
+      "Choices": Array [
+        Object {
+          "Next": "return null",
+          "StringEquals": "hello",
+          "Variable": "$.id",
+        },
+      ],
+      "Default": "return null 1",
+      "Type": "Choice",
+    },
+    "return null": Object {
+      "End": true,
+      "OutputPath": "$.null",
+      "Parameters": Object {
+        "null": null,
+      },
+      "Type": "Pass",
+    },
+    "return null 1": Object {
+      "End": true,
+      "OutputPath": "$.null",
+      "Parameters": Object {
+        "null": null,
+      },
+      "Type": "Pass",
+    },
+  },
+}
+`;
+
+exports[`continue in do..while loop 1`] = `
+Object {
+  "StartAt": "if(input.key == \\"sam\\")",
+  "States": Object {
+    "continue": Object {
+      "Next": "if(input.key == \\"sam\\")",
+      "ResultPath": null,
+      "Type": "Pass",
+    },
+    "if(input.key == \\"sam\\")": Object {
+      "Choices": Array [
+        Object {
+          "Next": "continue",
+          "StringEquals": "sam",
+          "Variable": "$.key",
+        },
+      ],
+      "Default": "task(input.key)",
+      "Type": "Choice",
+    },
+    "return null": Object {
+      "End": true,
+      "OutputPath": "$.null",
+      "Parameters": Object {
+        "null": null,
+      },
+      "Type": "Pass",
+    },
+    "task(input.key)": Object {
+      "Next": "while (true)",
+      "Parameters": Object {
+        "FunctionName": "__REPLACED_TOKEN",
+        "Payload.$": "$.key",
+      },
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "ResultPath": null,
+      "ResultSelector": "$.Payload",
+      "Type": "Task",
+    },
+    "while (true)": Object {
+      "Choices": Array [
+        Object {
+          "IsPresent": false,
+          "Next": "if(input.key == \\"sam\\")",
+          "Variable": "$.0_true",
+        },
+      ],
+      "Default": "return null",
+      "Type": "Choice",
+    },
+  },
+}
+`;
+
+exports[`continue in for loop 1`] = `
+Object {
+  "StartAt": "for(item of input.items)",
+  "States": Object {
+    "for(item of input.items)": Object {
+      "ItemsPath": "$.items",
+      "Iterator": Object {
+        "StartAt": "if(item == \\"hello\\")",
+        "States": Object {
+          "0_empty_else_if(item == \\"hello\\")": Object {
+            "End": true,
+            "Type": "Pass",
+          },
+          "continue": Object {
+            "End": true,
+            "ResultPath": null,
+            "Type": "Pass",
+          },
+          "if(item == \\"hello\\")": Object {
+            "Choices": Array [
+              Object {
+                "Next": "continue",
+                "StringEquals": "hello",
+                "Variable": "$.item",
+              },
+            ],
+            "Default": "0_empty_else_if(item == \\"hello\\")",
+            "Type": "Choice",
+          },
+        },
+      },
+      "MaxConcurrency": 1,
+      "Next": "return null",
+      "Parameters": Object {
+        "item.$": "$$.Map.Item.Value",
+      },
+      "ResultPath": null,
+      "Type": "Map",
+    },
+    "return null": Object {
+      "End": true,
+      "OutputPath": "$.null",
+      "Parameters": Object {
+        "null": null,
+      },
+      "Type": "Pass",
+    },
+  },
+}
+`;
+
+exports[`continue in while loop 1`] = `
+Object {
+  "StartAt": "while (true)",
+  "States": Object {
+    "continue": Object {
+      "Next": "while (true)",
+      "ResultPath": null,
+      "Type": "Pass",
+    },
+    "if(input.key == \\"sam\\")": Object {
+      "Choices": Array [
+        Object {
+          "Next": "continue",
+          "StringEquals": "sam",
+          "Variable": "$.key",
+        },
+      ],
+      "Default": "task(input.key)",
+      "Type": "Choice",
+    },
+    "return null": Object {
+      "End": true,
+      "OutputPath": "$.null",
+      "Parameters": Object {
+        "null": null,
+      },
+      "Type": "Pass",
+    },
+    "task(input.key)": Object {
+      "Next": "while (true)",
+      "Parameters": Object {
+        "FunctionName": "__REPLACED_TOKEN",
+        "Payload.$": "$.key",
+      },
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "ResultPath": null,
+      "ResultSelector": "$.Payload",
+      "Type": "Task",
+    },
+    "while (true)": Object {
+      "Choices": Array [
+        Object {
+          "IsPresent": false,
+          "Next": "if(input.key == \\"sam\\")",
+          "Variable": "$.0_true",
+        },
+      ],
+      "Default": "return null",
+      "Type": "Choice",
+    },
+  },
+}
+`;
+
+exports[`for i in items, items[i] 1`] = `
+Object {
+  "StartAt": "for(i in input.items)",
+  "States": Object {
+    "for(i in input.items)": Object {
+      "ItemsPath": "$.items",
+      "Iterator": Object {
+        "StartAt": "a = items[i]",
+        "States": Object {
+          "a = items[i]": Object {
+            "End": true,
+            "OutputPath": "$.result",
+            "Parameters": Object {
+              "result.$": "$.0_i",
+            },
+            "ResultPath": "$.a",
+            "Type": "Pass",
+          },
+        },
+      },
+      "MaxConcurrency": 1,
+      "Next": "return null",
+      "Parameters": Object {
+        "0_i.$": "$$.Map.Item.Value",
+        "i.$": "$$.Map.Item.Index",
+      },
+      "ResultPath": null,
+      "Type": "Map",
+    },
+    "return null": Object {
+      "End": true,
+      "OutputPath": "$.null",
+      "Parameters": Object {
+        "null": null,
+      },
+      "Type": "Pass",
+    },
+  },
+}
+`;
+
+exports[`for-of { try { task() } catch (err) { if(err) throw } finally { task() } } 1`] = `
+Object {
+  "StartAt": "for(item of input.items)",
+  "States": Object {
+    "for(item of input.items)": Object {
+      "ItemsPath": "$.items",
+      "Iterator": Object {
+        "StartAt": "task(item)",
+        "States": Object {
+          "exit finally": Object {
+            "Choices": Array [
+              Object {
+                "IsPresent": true,
+                "Next": "throw finally",
+                "Variable": "$.0_tmp",
+              },
+            ],
+            "Default": "return null",
+            "Type": "Choice",
+          },
+          "task(item)": Object {
+            "Next": "exit finally",
+            "Parameters": Object {
+              "FunctionName": "__REPLACED_TOKEN",
+              "Payload": "2",
+            },
+            "Resource": "arn:aws:states:::lambda:invoke",
+            "ResultPath": null,
+            "ResultSelector": "$.Payload",
+            "Type": "Task",
+          },
+          "throw finally": Object {
+            "Cause": "an error was re-thrown from a finally block which is unsupported by Step Functions",
+            "Error": "ReThrowFromFinally",
+            "Type": "Fail",
+          },
+        },
+      },
+      "MaxConcurrency": 1,
+      "Next": "return null",
+      "Parameters": Object {
+        "item.$": "$$.Map.Item.Value",
+      },
+      "ResultPath": null,
+      "Type": "Map",
+    },
+    "return null": Object {
+      "End": true,
+      "OutputPath": "$.null",
+      "Parameters": Object {
+        "null": null,
+      },
+      "Type": "Pass",
+    },
+  },
+}
+`;
+
+exports[`if (typeof x !== ??) 1`] = `
+Object {
+  "StartAt": "if(input.id != undefined)",
+  "States": Object {
+    "if(input.id != undefined)": Object {
+      "Choices": Array [
+        Object {
+          "And": Array [
+            Object {
+              "IsPresent": true,
+              "Variable": "$.id",
+            },
+            Object {
+              "IsNull": false,
+              "Variable": "$.id",
+            },
+          ],
+          "Next": "return \\"null\\"",
+        },
+        Object {
+          "IsPresent": true,
+          "Next": "return \\"undefined\\"",
+          "Variable": "$.id",
+        },
+        Object {
+          "Next": "return \\"string\\"",
+          "Or": Array [
+            Object {
+              "IsPresent": false,
+              "Variable": "$.id",
+            },
+            Object {
+              "IsString": false,
+              "Variable": "$.id",
+            },
+          ],
+        },
+        Object {
+          "Next": "return \\"boolean\\"",
+          "Or": Array [
+            Object {
+              "IsPresent": false,
+              "Variable": "$.id",
+            },
+            Object {
+              "IsBoolean": false,
+              "Variable": "$.id",
+            },
+          ],
+        },
+        Object {
+          "Next": "return \\"number\\"",
+          "Or": Array [
+            Object {
+              "IsPresent": false,
+              "Variable": "$.id",
+            },
+            Object {
+              "IsNumeric": false,
+              "Variable": "$.id",
+            },
+          ],
+        },
+        Object {
+          "Next": "return \\"bigint\\"",
+          "Or": Array [
+            Object {
+              "IsPresent": false,
+              "Variable": "$.id",
+            },
+            Object {
+              "IsNumeric": false,
+              "Variable": "$.id",
+            },
+          ],
+        },
+      ],
+      "Default": "return null",
+      "Type": "Choice",
+    },
+    "return \\"bigint\\"": Object {
+      "End": true,
+      "Result": "bigint",
+      "ResultPath": "$",
+      "Type": "Pass",
+    },
+    "return \\"boolean\\"": Object {
+      "End": true,
+      "Result": "boolean",
+      "ResultPath": "$",
+      "Type": "Pass",
+    },
+    "return \\"null\\"": Object {
+      "End": true,
+      "Result": "null",
+      "ResultPath": "$",
+      "Type": "Pass",
+    },
+    "return \\"number\\"": Object {
+      "End": true,
+      "Result": "number",
+      "ResultPath": "$",
+      "Type": "Pass",
+    },
+    "return \\"string\\"": Object {
+      "End": true,
+      "Result": "string",
+      "ResultPath": "$",
+      "Type": "Pass",
+    },
+    "return \\"undefined\\"": Object {
+      "End": true,
+      "Result": "undefined",
+      "ResultPath": "$",
+      "Type": "Pass",
+    },
+    "return null": Object {
+      "End": true,
+      "OutputPath": "$.null",
+      "Parameters": Object {
+        "null": null,
+      },
+      "Type": "Pass",
+    },
+  },
+}
+`;
+
+exports[`if (typeof x === ??) 1`] = `
+Object {
+  "StartAt": "if(input.id == undefined)",
+  "States": Object {
+    "if(input.id == undefined)": Object {
+      "Choices": Array [
+        Object {
+          "Next": "return \\"null\\"",
+          "Or": Array [
+            Object {
+              "IsPresent": false,
+              "Variable": "$.id",
+            },
+            Object {
+              "IsNull": true,
+              "Variable": "$.id",
+            },
+          ],
+        },
+        Object {
+          "IsPresent": false,
+          "Next": "return \\"undefined\\"",
+          "Variable": "$.id",
+        },
+        Object {
+          "And": Array [
+            Object {
+              "IsPresent": true,
+              "Variable": "$.id",
+            },
+            Object {
+              "IsString": true,
+              "Variable": "$.id",
+            },
+          ],
+          "Next": "return \\"string\\"",
+        },
+        Object {
+          "And": Array [
+            Object {
+              "IsPresent": true,
+              "Variable": "$.id",
+            },
+            Object {
+              "IsBoolean": true,
+              "Variable": "$.id",
+            },
+          ],
+          "Next": "return \\"boolean\\"",
+        },
+        Object {
+          "And": Array [
+            Object {
+              "IsPresent": true,
+              "Variable": "$.id",
+            },
+            Object {
+              "IsNumeric": true,
+              "Variable": "$.id",
+            },
+          ],
+          "Next": "return \\"number\\"",
+        },
+        Object {
+          "And": Array [
+            Object {
+              "IsPresent": true,
+              "Variable": "$.id",
+            },
+            Object {
+              "IsNumeric": true,
+              "Variable": "$.id",
+            },
+          ],
+          "Next": "return \\"bigint\\"",
+        },
+      ],
+      "Default": "return null",
+      "Type": "Choice",
+    },
+    "return \\"bigint\\"": Object {
+      "End": true,
+      "Result": "bigint",
+      "ResultPath": "$",
+      "Type": "Pass",
+    },
+    "return \\"boolean\\"": Object {
+      "End": true,
+      "Result": "boolean",
+      "ResultPath": "$",
+      "Type": "Pass",
+    },
+    "return \\"null\\"": Object {
+      "End": true,
+      "Result": "null",
+      "ResultPath": "$",
+      "Type": "Pass",
+    },
+    "return \\"number\\"": Object {
+      "End": true,
+      "Result": "number",
+      "ResultPath": "$",
+      "Type": "Pass",
+    },
+    "return \\"string\\"": Object {
+      "End": true,
+      "Result": "string",
+      "ResultPath": "$",
+      "Type": "Pass",
+    },
+    "return \\"undefined\\"": Object {
+      "End": true,
+      "Result": "undefined",
+      "ResultPath": "$",
+      "Type": "Pass",
+    },
+    "return null": Object {
+      "End": true,
+      "OutputPath": "$.null",
+      "Parameters": Object {
+        "null": null,
+      },
+      "Type": "Pass",
+    },
+  },
+}
+`;
+
+exports[`if-else 1`] = `
+Object {
+  "StartAt": "if(input.id == \\"hello\\")",
+  "States": Object {
+    "if(input.id == \\"hello\\")": Object {
+      "Choices": Array [
+        Object {
+          "Next": "return \\"hello\\"",
+          "StringEquals": "hello",
+          "Variable": "$.id",
+        },
+      ],
+      "Default": "return \\"world\\"",
+      "Type": "Choice",
+    },
+    "return \\"hello\\"": Object {
+      "End": true,
+      "Result": "hello",
+      "ResultPath": "$",
+      "Type": "Pass",
+    },
+    "return \\"world\\"": Object {
+      "End": true,
+      "Result": "world",
+      "ResultPath": "$",
+      "Type": "Pass",
+    },
+  },
+}
+`;
+
+exports[`if-else-if 1`] = `
+Object {
+  "StartAt": "if(input.id == \\"hello\\")",
+  "States": Object {
+    "if(input.id == \\"hello\\")": Object {
+      "Choices": Array [
+        Object {
+          "Next": "return \\"hello\\"",
+          "StringEquals": "hello",
+          "Variable": "$.id",
+        },
+        Object {
+          "Next": "return \\"world\\"",
+          "StringEquals": "world",
+          "Variable": "$.id",
+        },
+      ],
+      "Default": "return null",
+      "Type": "Choice",
+    },
+    "return \\"hello\\"": Object {
+      "End": true,
+      "Result": "hello",
+      "ResultPath": "$",
+      "Type": "Pass",
+    },
+    "return \\"world\\"": Object {
+      "End": true,
+      "Result": "world",
+      "ResultPath": "$",
+      "Type": "Pass",
+    },
+    "return null": Object {
+      "End": true,
+      "OutputPath": "$.null",
+      "Parameters": Object {
+        "null": null,
+      },
+      "Type": "Pass",
+    },
+  },
+}
+`;
+
+exports[`let and set 1`] = `
+Object {
+  "StartAt": "a = null",
+  "States": Object {
+    "a = \\"hello\\"": Object {
+      "Next": "a = \\"hello\\" + \\" world\\"",
+      "Parameters": "hello",
+      "ResultPath": "$.a",
+      "Type": "Pass",
+    },
+    "a = \\"hello\\" + \\" world\\"": Object {
+      "Next": "a = \\"hello\\" + 1",
+      "Parameters": "hello world",
+      "ResultPath": "$.a",
+      "Type": "Pass",
+    },
+    "a = \\"hello\\" + 1": Object {
+      "Next": "a = 1 + \\"hello\\"",
+      "Parameters": "hello1",
+      "ResultPath": "$.a",
+      "Type": "Pass",
+    },
+    "a = \\"hello\\" + [\\"world\\"]": Object {
+      "Next": "return a",
+      "Parameters": "helloworld",
+      "ResultPath": "$.a",
+      "Type": "Pass",
+    },
+    "a = \\"hello\\" + null": Object {
+      "Next": "a = [null]",
+      "Parameters": "hellonull",
+      "ResultPath": "$.a",
+      "Type": "Pass",
+    },
+    "a = \\"hello\\" + true": Object {
+      "Next": "a = false + \\"hello\\"",
+      "Parameters": "hellotrue",
+      "ResultPath": "$.a",
+      "Type": "Pass",
+    },
+    "a = \\"hello\\" + {place: \\"world\\"}": Object {
+      "Next": "a = \\"hello\\" + [\\"world\\"]",
+      "Parameters": "hello[object Object]",
+      "ResultPath": "$.a",
+      "Type": "Pass",
+    },
+    "a = -1": Object {
+      "Next": "a = -100",
+      "Parameters": -1,
+      "ResultPath": "$.a",
+      "Type": "Pass",
+    },
+    "a = -100": Object {
+      "Next": "a = 1 + 2",
+      "Parameters": -100,
+      "ResultPath": "$.a",
+      "Type": "Pass",
+    },
+    "a = 0": Object {
+      "Next": "a = -1",
+      "Parameters": 0,
+      "ResultPath": "$.a",
+      "Type": "Pass",
+    },
+    "a = 1 + \\"hello\\"": Object {
+      "Next": "a = \\"hello\\" + true",
+      "Parameters": "1hello",
+      "ResultPath": "$.a",
+      "Type": "Pass",
+    },
+    "a = 1 + 2": Object {
+      "Next": "a = \\"hello\\"",
+      "Parameters": 3,
+      "ResultPath": "$.a",
+      "Type": "Pass",
+    },
+    "a = [-1]": Object {
+      "Next": "a = [true]",
+      "Parameters": Array [
+        -1,
+      ],
+      "ResultPath": "$.a",
+      "Type": "Pass",
+    },
+    "a = [1]": Object {
+      "Next": "a = [-1]",
+      "Parameters": Array [
+        1,
+      ],
+      "ResultPath": "$.a",
+      "Type": "Pass",
+    },
+    "a = [null]": Object {
+      "Next": "a = [1]",
+      "Parameters": Array [
+        null,
+      ],
+      "ResultPath": "$.a",
+      "Type": "Pass",
+    },
+    "a = [true]": Object {
+      "Next": "a = [{key: \\"value\\"}]",
+      "Parameters": Array [
+        true,
+      ],
+      "ResultPath": "$.a",
+      "Type": "Pass",
+    },
+    "a = [{key: \\"value\\"}]": Object {
+      "Next": "a = {key: \\"value\\"}",
+      "Parameters": Array [
+        Object {
+          "key": "value",
+        },
+      ],
+      "ResultPath": "$.a",
+      "Type": "Pass",
+    },
+    "a = a": Object {
+      "InputPath": "$.a",
+      "Next": "a = \\"hello\\" + {place: \\"world\\"}",
+      "ResultPath": "$.a",
+      "Type": "Pass",
+    },
+    "a = false": Object {
+      "Next": "a = 0",
+      "Parameters": false,
+      "ResultPath": "$.a",
+      "Type": "Pass",
+    },
+    "a = false + \\"hello\\"": Object {
+      "Next": "a = null + \\"hello\\"",
+      "Parameters": "falsehello",
+      "ResultPath": "$.a",
+      "Type": "Pass",
+    },
+    "a = null": Object {
+      "Next": "a = true",
+      "Parameters": Object {
+        "$.a": null,
+        "a.$": "$.a",
+      },
+      "ResultPath": null,
+      "Type": "Pass",
+    },
+    "a = null + \\"hello\\"": Object {
+      "Next": "a = \\"hello\\" + null",
+      "Parameters": "nullhello",
+      "ResultPath": "$.a",
+      "Type": "Pass",
+    },
+    "a = true": Object {
+      "Next": "a = false",
+      "Parameters": true,
+      "ResultPath": "$.a",
+      "Type": "Pass",
+    },
+    "a = {key: \\"value\\"}": Object {
+      "Next": "a = a",
+      "Parameters": Object {
+        "key": "value",
+      },
+      "ResultPath": "$.a",
+      "Type": "Pass",
+    },
+    "return a": Object {
+      "End": true,
+      "OutputPath": "$.a",
+      "Type": "Pass",
+    },
+  },
+}
+`;
+
+exports[`let cond; do { cond = task() } while (cond) 1`] = `
+Object {
+  "StartAt": "cond = task()",
+  "States": Object {
+    "cond = task()": Object {
+      "Next": "while (cond == undefined)",
+      "Parameters": Object {
+        "FunctionName": "__REPLACED_TOKEN",
+      },
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "ResultPath": "$.cond",
+      "ResultSelector": "$.Payload",
+      "Type": "Task",
+    },
+    "return null": Object {
+      "End": true,
+      "OutputPath": "$.null",
+      "Parameters": Object {
+        "null": null,
+      },
+      "Type": "Pass",
+    },
+    "while (cond == undefined)": Object {
+      "Choices": Array [
+        Object {
+          "Next": "cond = task()",
+          "Or": Array [
+            Object {
+              "IsPresent": false,
+              "Variable": "$.cond",
+            },
+            Object {
+              "IsNull": true,
+              "Variable": "$.cond",
+            },
+          ],
+        },
+      ],
+      "Default": "return null",
+      "Type": "Choice",
+    },
+  },
+}
+`;
+
+exports[`list.forEach((item, i) => if (i == 0) task(item)) 1`] = `
+Object {
+  "StartAt": "return input.list.forEach(function(item, i))",
+  "States": Object {
+    "return input.list.forEach(function(item, i))": Object {
+      "End": true,
+      "ItemsPath": "$.list",
+      "Iterator": Object {
+        "StartAt": "if(i == 0)",
+        "States": Object {
+          "if(i == 0)": Object {
+            "Choices": Array [
+              Object {
+                "Next": "return task(item)",
+                "NumericEquals": 0,
+                "Variable": "$.i",
+              },
+            ],
+            "Default": "return null",
+            "Type": "Choice",
+          },
+          "return null": Object {
+            "End": true,
+            "OutputPath": "$.null",
+            "Parameters": Object {
+              "null": null,
+            },
+            "Type": "Pass",
+          },
+          "return task(item)": Object {
+            "End": true,
+            "Parameters": Object {
+              "FunctionName": "__REPLACED_TOKEN",
+              "Payload.$": "$.item",
+            },
+            "Resource": "arn:aws:states:::lambda:invoke",
+            "ResultPath": "$",
+            "ResultSelector": "$.Payload",
+            "Type": "Task",
+          },
+        },
+      },
+      "MaxConcurrency": 1,
+      "Parameters": Object {
+        "i.$": "$$.Map.Item.Index",
+        "item.$": "$$.Map.Item.Value",
+      },
+      "ResultPath": "$",
+      "Type": "Map",
+    },
+  },
+}
+`;
+
+exports[`list.forEach((item, i, list) => if (i == 0) task(item) else task(list[0])) 1`] = `
+Object {
+  "StartAt": "return input.list.forEach(function(item, i))",
+  "States": Object {
+    "return input.list.forEach(function(item, i))": Object {
+      "End": true,
+      "ItemsPath": "$.list",
+      "Iterator": Object {
+        "StartAt": "if(i == 0)",
+        "States": Object {
+          "if(i == 0)": Object {
+            "Choices": Array [
+              Object {
+                "Next": "return task(item)",
+                "NumericEquals": 0,
+                "Variable": "$.i",
+              },
+            ],
+            "Default": "return task(input.list[0])",
+            "Type": "Choice",
+          },
+          "return task(item)": Object {
+            "End": true,
+            "Parameters": Object {
+              "FunctionName": "__REPLACED_TOKEN",
+              "Payload.$": "$.list[0]",
+            },
+            "Resource": "arn:aws:states:::lambda:invoke",
+            "ResultPath": "$",
+            "ResultSelector": "$.Payload",
+            "Type": "Task",
+          },
+        },
+      },
+      "MaxConcurrency": 1,
+      "Parameters": Object {
+        "i.$": "$$.Map.Item.Index",
+        "item.$": "$$.Map.Item.Value",
+      },
+      "ResultPath": "$",
+      "Type": "Map",
+    },
+  },
+}
+`;
+
+exports[`list.forEach(item => task(item)) 1`] = `
+Object {
+  "StartAt": "return input.list.forEach(function(item))",
+  "States": Object {
+    "return input.list.forEach(function(item))": Object {
+      "End": true,
+      "ItemsPath": "$.list",
+      "Iterator": Object {
+        "StartAt": "return task(item)",
+        "States": Object {
+          "return task(item)": Object {
+            "End": true,
+            "Parameters": Object {
+              "FunctionName": "__REPLACED_TOKEN",
+              "Payload.$": "$.item",
+            },
+            "Resource": "arn:aws:states:::lambda:invoke",
+            "ResultPath": "$",
+            "ResultSelector": "$.Payload",
+            "Type": "Task",
+          },
+        },
+      },
+      "MaxConcurrency": 1,
+      "Parameters": Object {
+        "item.$": "$$.Map.Item.Value",
+      },
+      "ResultPath": "$",
+      "Type": "Map",
+    },
+  },
+}
+`;
+
+exports[`list.map((item, i) => if (i == 0) task(item)) 1`] = `
+Object {
+  "StartAt": "return input.list.map(function(item, i))",
+  "States": Object {
+    "return input.list.map(function(item, i))": Object {
+      "End": true,
+      "ItemsPath": "$.list",
+      "Iterator": Object {
+        "StartAt": "if(i == 0)",
+        "States": Object {
+          "if(i == 0)": Object {
+            "Choices": Array [
+              Object {
+                "Next": "return task(item)",
+                "NumericEquals": 0,
+                "Variable": "$.i",
+              },
+            ],
+            "Default": "return null",
+            "Type": "Choice",
+          },
+          "return null": Object {
+            "End": true,
+            "OutputPath": "$.null",
+            "Parameters": Object {
+              "null": null,
+            },
+            "Type": "Pass",
+          },
+          "return task(item)": Object {
+            "End": true,
+            "Parameters": Object {
+              "FunctionName": "__REPLACED_TOKEN",
+              "Payload.$": "$.item",
+            },
+            "Resource": "arn:aws:states:::lambda:invoke",
+            "ResultPath": "$",
+            "ResultSelector": "$.Payload",
+            "Type": "Task",
+          },
+        },
+      },
+      "MaxConcurrency": 1,
+      "Parameters": Object {
+        "i.$": "$$.Map.Item.Index",
+        "item.$": "$$.Map.Item.Value",
+      },
+      "ResultPath": "$",
+      "Type": "Map",
+    },
+  },
+}
+`;
+
+exports[`list.map((item, i, list) => if (i == 0) task(item) else task(list[0])) 1`] = `
+Object {
+  "StartAt": "return input.list.map(function(item, i))",
+  "States": Object {
+    "return input.list.map(function(item, i))": Object {
+      "End": true,
+      "ItemsPath": "$.list",
+      "Iterator": Object {
+        "StartAt": "if(i == 0)",
+        "States": Object {
+          "if(i == 0)": Object {
+            "Choices": Array [
+              Object {
+                "Next": "return task(item)",
+                "NumericEquals": 0,
+                "Variable": "$.i",
+              },
+            ],
+            "Default": "return task(input.list[0])",
+            "Type": "Choice",
+          },
+          "return task(item)": Object {
+            "End": true,
+            "Parameters": Object {
+              "FunctionName": "__REPLACED_TOKEN",
+              "Payload.$": "$.list[0]",
+            },
+            "Resource": "arn:aws:states:::lambda:invoke",
+            "ResultPath": "$",
+            "ResultSelector": "$.Payload",
+            "Type": "Task",
+          },
+        },
+      },
+      "MaxConcurrency": 1,
+      "Parameters": Object {
+        "i.$": "$$.Map.Item.Index",
+        "item.$": "$$.Map.Item.Value",
+      },
+      "ResultPath": "$",
+      "Type": "Map",
+    },
+  },
+}
+`;
+
+exports[`list.map(item => task(item)) 1`] = `
+Object {
+  "StartAt": "return input.list.map(function(item))",
+  "States": Object {
+    "return input.list.map(function(item))": Object {
+      "End": true,
+      "ItemsPath": "$.list",
+      "Iterator": Object {
+        "StartAt": "return task(item)",
+        "States": Object {
+          "return task(item)": Object {
+            "End": true,
+            "Parameters": Object {
+              "FunctionName": "__REPLACED_TOKEN",
+              "Payload.$": "$.item",
+            },
+            "Resource": "arn:aws:states:::lambda:invoke",
+            "ResultPath": "$",
+            "ResultSelector": "$.Payload",
+            "Type": "Task",
+          },
+        },
+      },
+      "MaxConcurrency": 1,
+      "Parameters": Object {
+        "item.$": "$$.Map.Item.Value",
+      },
+      "ResultPath": "$",
+      "Type": "Map",
+    },
+  },
+}
+`;
+
+exports[`nested try-catch 1`] = `
+Object {
+  "StartAt": "throw new Error(\\"error1\\")",
+  "States": Object {
+    "throw new Error(\\"error1\\")": Object {
+      "Next": "throw new Error(\\"error2\\")",
+      "Result": Object {
+        "message": "error1",
+      },
+      "ResultPath": null,
+      "Type": "Pass",
+    },
+    "throw new Error(\\"error2\\")": Object {
+      "Next": "throw new Error(\\"error3\\")",
+      "Result": Object {
+        "message": "error2",
+      },
+      "ResultPath": null,
+      "Type": "Pass",
+    },
+    "throw new Error(\\"error3\\")": Object {
+      "Cause": "{\\"message\\":\\"error3\\"}",
+      "Error": "Error",
+      "Type": "Fail",
+    },
+  },
+}
+`;
+
+exports[`put an event bus event 1`] = `
+Object {
+  "StartAt": "bus.putEvents({detail-type: \\"someEvent\\", source: \\"sfnTest\\", detail: {value:",
+  "States": Object {
+    "bus.putEvents({detail-type: \\"someEvent\\", source: \\"sfnTest\\", detail: {value:": Object {
+      "Next": "return null",
+      "Parameters": Object {
+        "Entries": Array [
+          Object {
+            "Detail": Object {
+              "value.$": "$.id",
+            },
+            "DetailType": "someEvent",
+            "EventBusName": "\${Token[TOKEN.818]}",
+            "Source": "sfnTest",
+          },
+        ],
+      },
+      "Resource": "arn:aws:states:::events:putEvents",
+      "ResultPath": null,
+      "Type": "Task",
+    },
+    "return null": Object {
+      "End": true,
+      "OutputPath": "$.null",
+      "Parameters": Object {
+        "null": null,
+      },
+      "Type": "Pass",
+    },
+  },
+}
+`;
+
+exports[`put multiple event bus events 1`] = `
+Object {
+  "StartAt": "bus.putEvents({detail-type: \\"someEvent\\", source: \\"sfnTest\\", detail: {value:",
+  "States": Object {
+    "bus.putEvents({detail-type: \\"someEvent\\", source: \\"sfnTest\\", detail: {value:": Object {
+      "Next": "return null",
+      "Parameters": Object {
+        "Entries": Array [
+          Object {
+            "Detail": Object {
+              "value.$": "$.id",
+            },
+            "DetailType": "someEvent",
+            "EventBusName": "\${Token[TOKEN.844]}",
+            "Source": "sfnTest",
+          },
+          Object {
+            "Detail": Object {
+              "constant": "hi",
+              "value.$": "$.id",
+            },
+            "DetailType": "someOtherEvent",
+            "EventBusName": "\${Token[TOKEN.844]}",
+            "Source": "sfnTest",
+          },
+        ],
+      },
+      "Resource": "arn:aws:states:::events:putEvents",
+      "ResultPath": null,
+      "Type": "Task",
+    },
+    "return null": Object {
+      "End": true,
+      "OutputPath": "$.null",
+      "Parameters": Object {
+        "null": null,
+      },
+      "Type": "Pass",
+    },
+  },
+}
+`;
+
+exports[`result = $SFN.forEach(list, (item) => task(item)) 1`] = `
+Object {
+  "StartAt": "result = $SFN.forEach(input.list, function(item))",
+  "States": Object {
+    "result = $SFN.forEach(input.list, function(item))": Object {
+      "ItemsPath": "$.list",
+      "Iterator": Object {
+        "StartAt": "return task(item)",
+        "States": Object {
+          "return task(item)": Object {
+            "End": true,
+            "Parameters": Object {
+              "FunctionName": "__REPLACED_TOKEN",
+              "Payload.$": "$.item",
+            },
+            "Resource": "arn:aws:states:::lambda:invoke",
+            "ResultPath": "$",
+            "ResultSelector": "$.Payload",
+            "Type": "Task",
+          },
+        },
+      },
+      "Next": "return result",
+      "Parameters": Object {
+        "item.$": "$$.Map.Item.Value",
+      },
+      "ResultPath": "$.result",
+      "Type": "Map",
+    },
+    "return result": Object {
+      "End": true,
+      "OutputPath": "$.result",
+      "Type": "Pass",
+    },
+  },
+}
+`;
+
+exports[`result = $SFN.map(list, (item) => task(item)) 1`] = `
+Object {
+  "StartAt": "result = $SFN.map(input.list, function(item))",
+  "States": Object {
+    "result = $SFN.map(input.list, function(item))": Object {
+      "ItemsPath": "$.list",
+      "Iterator": Object {
+        "StartAt": "return task(item)",
+        "States": Object {
+          "return task(item)": Object {
+            "End": true,
+            "Parameters": Object {
+              "FunctionName": "__REPLACED_TOKEN",
+              "Payload.$": "$.item",
+            },
+            "Resource": "arn:aws:states:::lambda:invoke",
+            "ResultPath": "$",
+            "ResultSelector": "$.Payload",
+            "Type": "Task",
+          },
+        },
+      },
+      "Next": "return result",
+      "Parameters": Object {
+        "item.$": "$$.Map.Item.Value",
+      },
+      "ResultPath": "$.result",
+      "Type": "Map",
+    },
+    "return result": Object {
+      "End": true,
+      "OutputPath": "$.result",
+      "Type": "Pass",
+    },
+  },
+}
+`;
+
+exports[`return $SFN.forEach(list, (item) => task(item)) 1`] = `
+Object {
+  "StartAt": "return $SFN.forEach(input.list, function(item))",
+  "States": Object {
+    "return $SFN.forEach(input.list, function(item))": Object {
+      "End": true,
+      "ItemsPath": "$.list",
+      "Iterator": Object {
+        "StartAt": "return task(item)",
+        "States": Object {
+          "return task(item)": Object {
+            "End": true,
+            "Parameters": Object {
+              "FunctionName": "__REPLACED_TOKEN",
+              "Payload.$": "$.item",
+            },
+            "Resource": "arn:aws:states:::lambda:invoke",
+            "ResultPath": "$",
+            "ResultSelector": "$.Payload",
+            "Type": "Task",
+          },
+        },
+      },
+      "Parameters": Object {
+        "item.$": "$$.Map.Item.Value",
+      },
+      "ResultPath": "$",
+      "Type": "Map",
+    },
+  },
+}
+`;
+
+exports[`return $SFN.forEach(list, (item) => try { task(item)) } catch { return null } 1`] = `
+Object {
+  "StartAt": "return $SFN.forEach(input.list, function(item))",
+  "States": Object {
+    "return $SFN.forEach(input.list, function(item))": Object {
+      "End": true,
+      "ItemsPath": "$.list",
+      "Iterator": Object {
+        "StartAt": "return task(item)",
+        "States": Object {
+          "return null": Object {
+            "End": true,
+            "OutputPath": "$.null",
+            "Parameters": Object {
+              "null": null,
+            },
+            "Type": "Pass",
+          },
+          "return task(item)": Object {
+            "Catch": Array [
+              Object {
+                "ErrorEquals": Array [
+                  "States.ALL",
+                ],
+                "Next": "return null",
+                "ResultPath": null,
+              },
+            ],
+            "End": true,
+            "Parameters": Object {
+              "FunctionName": "\${Token[TOKEN.3742]}",
+              "Payload.$": "$.item",
+            },
+            "Resource": "arn:aws:states:::lambda:invoke",
+            "ResultPath": "$",
+            "ResultSelector": "$.Payload",
+            "Type": "Task",
+          },
+        },
+      },
+      "Parameters": Object {
+        "item.$": "$$.Map.Item.Value",
+      },
+      "ResultPath": "$",
+      "Type": "Map",
+    },
+  },
+}
+`;
+
+exports[`return $SFN.forEach(list, {maxConcurrency: 2} (item) => task(item)) 1`] = `
+Object {
+  "StartAt": "return $SFN.forEach(input.list, {maxConcurrency: 2}, function(item))",
+  "States": Object {
+    "return $SFN.forEach(input.list, {maxConcurrency: 2}, function(item))": Object {
+      "End": true,
+      "ItemsPath": "$.list",
+      "Iterator": Object {
+        "StartAt": "return task(item)",
+        "States": Object {
+          "return task(item)": Object {
+            "End": true,
+            "Parameters": Object {
+              "FunctionName": "__REPLACED_TOKEN",
+              "Payload.$": "$.item",
+            },
+            "Resource": "arn:aws:states:::lambda:invoke",
+            "ResultPath": "$",
+            "ResultSelector": "$.Payload",
+            "Type": "Task",
+          },
+        },
+      },
+      "MaxConcurrency": 2,
+      "Parameters": Object {
+        "item.$": "$$.Map.Item.Value",
+      },
+      "ResultPath": "$",
+      "Type": "Map",
+    },
+  },
+}
+`;
+
+exports[`return $SFN.map(list, (item) => task(item)) 1`] = `
+Object {
+  "StartAt": "return $SFN.map(input.list, function(item))",
+  "States": Object {
+    "return $SFN.map(input.list, function(item))": Object {
+      "End": true,
+      "ItemsPath": "$.list",
+      "Iterator": Object {
+        "StartAt": "return task(item)",
+        "States": Object {
+          "return task(item)": Object {
+            "End": true,
+            "Parameters": Object {
+              "FunctionName": "__REPLACED_TOKEN",
+              "Payload.$": "$.item",
+            },
+            "Resource": "arn:aws:states:::lambda:invoke",
+            "ResultPath": "$",
+            "ResultSelector": "$.Payload",
+            "Type": "Task",
+          },
+        },
+      },
+      "Parameters": Object {
+        "item.$": "$$.Map.Item.Value",
+      },
+      "ResultPath": "$",
+      "Type": "Map",
+    },
+  },
+}
+`;
+
+exports[`return $SFN.map(list, (item) => try { task(item)) } catch { return null } 1`] = `
+Object {
+  "StartAt": "return $SFN.map(input.list, function(item))",
+  "States": Object {
+    "return $SFN.map(input.list, function(item))": Object {
+      "End": true,
+      "ItemsPath": "$.list",
+      "Iterator": Object {
+        "StartAt": "return task(item)",
+        "States": Object {
+          "return null": Object {
+            "End": true,
+            "OutputPath": "$.null",
+            "Parameters": Object {
+              "null": null,
+            },
+            "Type": "Pass",
+          },
+          "return task(item)": Object {
+            "Catch": Array [
+              Object {
+                "ErrorEquals": Array [
+                  "States.ALL",
+                ],
+                "Next": "return null",
+                "ResultPath": null,
+              },
+            ],
+            "End": true,
+            "Parameters": Object {
+              "FunctionName": "\${Token[TOKEN.3490]}",
+              "Payload.$": "$.item",
+            },
+            "Resource": "arn:aws:states:::lambda:invoke",
+            "ResultPath": "$",
+            "ResultSelector": "$.Payload",
+            "Type": "Task",
+          },
+        },
+      },
+      "Parameters": Object {
+        "item.$": "$$.Map.Item.Value",
+      },
+      "ResultPath": "$",
+      "Type": "Map",
+    },
+  },
+}
+`;
+
+exports[`return $SFN.map(list, {maxConcurrency: 2} (item) => task(item)) 1`] = `
+Object {
+  "StartAt": "return $SFN.map(input.list, {maxConcurrency: 2}, function(item))",
+  "States": Object {
+    "return $SFN.map(input.list, {maxConcurrency: 2}, function(item))": Object {
+      "End": true,
+      "ItemsPath": "$.list",
+      "Iterator": Object {
+        "StartAt": "return task(item)",
+        "States": Object {
+          "return task(item)": Object {
+            "End": true,
+            "Parameters": Object {
+              "FunctionName": "__REPLACED_TOKEN",
+              "Payload.$": "$.item",
+            },
+            "Resource": "arn:aws:states:::lambda:invoke",
+            "ResultPath": "$",
+            "ResultSelector": "$.Payload",
+            "Type": "Task",
+          },
+        },
+      },
+      "MaxConcurrency": 2,
+      "Parameters": Object {
+        "item.$": "$$.Map.Item.Value",
+      },
+      "ResultPath": "$",
+      "Type": "Map",
+    },
+  },
+}
+`;
+
+exports[`return $SFN.parallel(() => "hello", () => "world")) 1`] = `
+Object {
+  "StartAt": "return $SFN.parallel([function(), function()])",
+  "States": Object {
+    "return $SFN.parallel([function(), function()])": Object {
+      "Branches": Array [
+        Object {
+          "StartAt": "return \\"hello\\"",
+          "States": Object {
+            "return \\"hello\\"": Object {
+              "End": true,
+              "Result": "hello",
+              "ResultPath": "$",
+              "Type": "Pass",
+            },
+          },
+        },
+        Object {
+          "StartAt": "return \\"world\\"",
+          "States": Object {
+            "return \\"world\\"": Object {
+              "End": true,
+              "Result": "world",
+              "ResultPath": "$",
+              "Type": "Pass",
+            },
+          },
+        },
+      ],
+      "End": true,
+      "ResultPath": "$",
+      "Type": "Parallel",
+    },
+  },
+}
+`;
+
+exports[`return $SFN.parallel(() => try { task() } catch { return null })) } 1`] = `
+Object {
+  "StartAt": "return $SFN.parallel([function()])",
+  "States": Object {
+    "return $SFN.parallel([function()])": Object {
+      "Branches": Array [
+        Object {
+          "StartAt": "return task()",
+          "States": Object {
+            "return null": Object {
+              "End": true,
+              "OutputPath": "$.null",
+              "Parameters": Object {
+                "null": null,
+              },
+              "Type": "Pass",
+            },
+            "return task()": Object {
+              "Catch": Array [
+                Object {
+                  "ErrorEquals": Array [
+                    "States.ALL",
+                  ],
+                  "Next": "return null",
+                  "ResultPath": null,
+                },
+              ],
+              "End": true,
+              "Parameters": Object {
+                "FunctionName": "\${Token[TOKEN.3900]}",
+                "Payload": undefined,
+              },
+              "Resource": "arn:aws:states:::lambda:invoke",
+              "ResultPath": "$",
+              "ResultSelector": "$.Payload",
+              "Type": "Task",
+            },
+          },
+        },
+      ],
+      "Catch": Array [
+        Object {
+          "ErrorEquals": Array [
+            "States.ALL",
+          ],
+          "Next": "return null 1",
+          "ResultPath": null,
+        },
+      ],
+      "End": true,
+      "ResultPath": "$",
+      "Type": "Parallel",
+    },
+    "return null 1": Object {
+      "End": true,
+      "OutputPath": "$.null",
+      "Parameters": Object {
+        "null": null,
+      },
+      "Type": "Pass",
+    },
+  },
+}
+`;
+
+exports[`return a single Lambda Function call 1`] = `
+Object {
+  "StartAt": "return getPerson({id: input.id})",
+  "States": Object {
+    "return getPerson({id: input.id})": Object {
+      "End": true,
+      "Parameters": Object {
+        "FunctionName": "__REPLACED_TOKEN",
+        "Payload": Object {
+          "id.$": "$.id",
+        },
+      },
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "ResultPath": "$",
+      "ResultSelector": "$.Payload",
+      "Type": "Task",
+    },
+  },
+}
+`;
+
+exports[`return items.slice(-1) 1`] = `
+Object {
+  "StartAt": "return input.items.slice(-1)",
+  "States": Object {
+    "return input.items.slice(-1)": Object {
+      "End": true,
+      "InputPath": "$.items[-1:]",
+      "ResultPath": "$",
+      "Type": "Pass",
+    },
+  },
+}
+`;
+
+exports[`return items.slice(0, -1) 1`] = `
+Object {
+  "StartAt": "return input.items.slice(0, -1)",
+  "States": Object {
+    "return input.items.slice(0, -1)": Object {
+      "End": true,
+      "InputPath": "$.items[0:-1]",
+      "ResultPath": "$",
+      "Type": "Pass",
+    },
+  },
+}
+`;
+
+exports[`return items.slice(1) 1`] = `
+Object {
+  "StartAt": "return input.items.slice(1)",
+  "States": Object {
+    "return input.items.slice(1)": Object {
+      "End": true,
+      "InputPath": "$.items[1:]",
+      "ResultPath": "$",
+      "Type": "Pass",
+    },
+  },
+}
+`;
+
+exports[`return items.slice(1, 3) 1`] = `
+Object {
+  "StartAt": "return input.items.slice(1, 3)",
+  "States": Object {
+    "return input.items.slice(1, 3)": Object {
+      "End": true,
+      "InputPath": "$.items[1:3]",
+      "ResultPath": "$",
+      "Type": "Pass",
+    },
+  },
+}
+`;
+
+exports[`return items.slice(1, undefined) 1`] = `
+Object {
+  "StartAt": "return input.items.slice(1, undefined)",
+  "States": Object {
+    "return input.items.slice(1, undefined)": Object {
+      "End": true,
+      "InputPath": "$.items[1:]",
+      "ResultPath": "$",
+      "Type": "Pass",
+    },
+  },
+}
+`;
+
+exports[`return task({ key: items.filter(*) }) 1`] = `
+Object {
+  "StartAt": "return task({equals: input.items.filter(function(item)), and: input.items.f",
+  "States": Object {
+    "return task({equals: input.items.filter(function(item)), and: input.items.f": Object {
+      "End": true,
+      "Parameters": Object {
+        "FunctionName": "__REPLACED_TOKEN",
+        "Payload": Object {
+          "and.$": "$.items[?(@.str=='hello'&&@.items[0]=='hello')]",
+          "equals.$": "$.items[?(@.str=='hello')]",
+          "or.$": "$.items[?(@.str=='hello'||@.items[0]=='hello')]",
+        },
+      },
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "ResultPath": "$",
+      "ResultSelector": "$.Payload",
+      "Type": "Task",
+    },
+  },
+}
+`;
+
+exports[`return task({key: items.slice(1, 3)}) 1`] = `
+Object {
+  "StartAt": "return task({key: input.items.slice(1, 3)})",
+  "States": Object {
+    "return task({key: input.items.slice(1, 3)})": Object {
+      "End": true,
+      "Parameters": Object {
+        "FunctionName": "__REPLACED_TOKEN",
+        "Payload": Object {
+          "key.$": "$.items[1:3]",
+        },
+      },
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "ResultPath": "$",
+      "ResultSelector": "$.Payload",
+      "Type": "Task",
+    },
+  },
+}
+`;
+
+exports[`return task(task()) 1`] = `
+Object {
+  "StartAt": "0_tmp = task()",
+  "States": Object {
+    "0_tmp = task()": Object {
+      "End": true,
+      "Parameters": Object {
+        "FunctionName": "__REPLACED_TOKEN",
+        "Payload.$": "$.0_tmp",
+      },
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "ResultPath": "$",
+      "ResultSelector": "$.Payload",
+      "Type": "Task",
+    },
+  },
+}
+`;
+
+exports[`single quotes in StringLiteralExpr should be escaped in a JSON Path filter expression 1`] = `
+Object {
+  "StartAt": "return task({escape: input.items.filter(function(item))})",
+  "States": Object {
+    "return task({escape: input.items.filter(function(item))})": Object {
+      "End": true,
+      "Parameters": Object {
+        "FunctionName": "__REPLACED_TOKEN",
+        "Payload": Object {
+          "escape.$": "$.items[?(@.str=='hello\\\\'world')]",
+        },
+      },
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "ResultPath": "$",
+      "ResultSelector": "$.Payload",
+      "Type": "Task",
+    },
+  },
+}
+`;
+
+exports[`spread constant array and object 1`] = `
+Object {
+  "StartAt": "return {array: [0, ...array, 3], object: {key: \\"value\\", ...object}}",
+  "States": Object {
+    "return {array: [0, ...array, 3], object: {key: \\"value\\", ...object}}": Object {
+      "End": true,
+      "Parameters": Object {
+        "array": Array [
+          0,
+          1,
+          2,
+          3,
+        ],
+        "object": Object {
+          "hello": "world",
+          "key": "value",
+        },
+      },
+      "ResultPath": "$",
+      "Type": "Pass",
+    },
+  },
+}
+`;
+
+exports[`task(-1) 1`] = `
+Object {
+  "StartAt": "return task(-1)",
+  "States": Object {
+    "return task(-1)": Object {
+      "End": true,
+      "Parameters": Object {
+        "FunctionName": "__REPLACED_TOKEN",
+        "Payload": -1,
+      },
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "ResultPath": "$",
+      "ResultSelector": "$.Payload",
+      "Type": "Task",
+    },
+  },
+}
+`;
+
+exports[`task(any) 1`] = `
+Object {
+  "StartAt": "task(null)",
+  "States": Object {
+    "return null": Object {
+      "End": true,
+      "OutputPath": "$.null",
+      "Parameters": Object {
+        "null": null,
+      },
+      "Type": "Pass",
+    },
+    "task(null)": Object {
+      "Next": "return null",
+      "Parameters": Object {
+        "FunctionName": "__REPLACED_TOKEN",
+        "Payload": "helloworld",
+      },
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "ResultPath": null,
+      "ResultSelector": "$.Payload",
+      "Type": "Task",
+    },
+  },
+}
+`;
+
+exports[`task(input.list[-1]) 1`] = `
+Object {
+  "StartAt": "return task(input.list[-1])",
+  "States": Object {
+    "return task(input.list[-1])": Object {
+      "End": true,
+      "Parameters": Object {
+        "FunctionName": "__REPLACED_TOKEN",
+        "Payload.$": "$.list[-1]",
+      },
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "ResultPath": "$",
+      "ResultSelector": "$.Payload",
+      "Type": "Task",
+    },
+  },
+}
+`;
+
+exports[`template literal strings 1`] = `
+Object {
+  "StartAt": "return task({key: \`input.obj.str hello input.obj.items[0]\`})",
+  "States": Object {
+    "return task({key: \`input.obj.str hello input.obj.items[0]\`})": Object {
+      "End": true,
+      "Parameters": Object {
+        "FunctionName": "__REPLACED_TOKEN",
+        "Payload": Object {
+          "key.$": "States.Format('{} hello {}',$.obj.str,$.obj.items[0])",
+        },
+      },
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "ResultPath": "$",
+      "ResultSelector": "$.Payload",
+      "Type": "Task",
+    },
+  },
+}
+`;
+
+exports[`throw Error 1`] = `
+Object {
+  "StartAt": "throw Error(\\"cause\\")",
+  "States": Object {
+    "throw Error(\\"cause\\")": Object {
+      "Cause": "{\\"message\\":\\"cause\\"}",
+      "Error": "Error",
+      "Type": "Fail",
+    },
+  },
+}
+`;
+
+exports[`throw in for-of 1`] = `
+Object {
+  "StartAt": "for(item of input.items)",
+  "States": Object {
+    "for(item of input.items)": Object {
+      "ItemsPath": "$.items",
+      "Iterator": Object {
+        "StartAt": "throw new Error(\\"err\\")",
+        "States": Object {
+          "throw new Error(\\"err\\")": Object {
+            "Cause": "{\\"message\\":\\"err\\"}",
+            "Error": "Error",
+            "Type": "Fail",
+          },
+        },
+      },
+      "MaxConcurrency": 1,
+      "Next": "return null",
+      "Parameters": Object {
+        "item.$": "$$.Map.Item.Value",
+      },
+      "ResultPath": null,
+      "Type": "Map",
+    },
+    "return null": Object {
+      "End": true,
+      "OutputPath": "$.null",
+      "Parameters": Object {
+        "null": null,
+      },
+      "Type": "Pass",
+    },
+  },
+}
+`;
+
+exports[`throw new CustomError 1`] = `
+Object {
+  "StartAt": "throw new CustomError(\\"cause\\")",
+  "States": Object {
+    "throw new CustomError(\\"cause\\")": Object {
+      "Cause": "{\\"property\\":\\"cause\\"}",
+      "Error": "CustomError",
+      "Type": "Fail",
+    },
+  },
+}
+`;
+
+exports[`throw new Error 1`] = `
+Object {
+  "StartAt": "throw new Error(\\"cause\\")",
+  "States": Object {
+    "throw new Error(\\"cause\\")": Object {
+      "Cause": "{\\"message\\":\\"cause\\"}",
+      "Error": "Error",
+      "Type": "Fail",
+    },
+  },
+}
+`;
+
+exports[`try { $SFN.forEach(list, (item) => task(item)) } catch { return null } 1`] = `
+Object {
+  "StartAt": "return $SFN.forEach(input.list, function(item))",
+  "States": Object {
+    "return $SFN.forEach(input.list, function(item))": Object {
+      "Catch": Array [
+        Object {
+          "ErrorEquals": Array [
+            "States.ALL",
+          ],
+          "Next": "return null",
+          "ResultPath": null,
+        },
+      ],
+      "End": true,
+      "ItemsPath": "$.list",
+      "Iterator": Object {
+        "StartAt": "return task(item)",
+        "States": Object {
+          "return task(item)": Object {
+            "End": true,
+            "Parameters": Object {
+              "FunctionName": "\${Token[TOKEN.3784]}",
+              "Payload.$": "$.item",
+            },
+            "Resource": "arn:aws:states:::lambda:invoke",
+            "ResultPath": "$",
+            "ResultSelector": "$.Payload",
+            "Type": "Task",
+          },
+        },
+      },
+      "Parameters": Object {
+        "item.$": "$$.Map.Item.Value",
+      },
+      "ResultPath": "$",
+      "Type": "Map",
+    },
+    "return null": Object {
+      "End": true,
+      "OutputPath": "$.null",
+      "Parameters": Object {
+        "null": null,
+      },
+      "Type": "Pass",
+    },
+  },
+}
+`;
+
+exports[`try { $SFN.map(list, (item) => task(item)) } catch { return null } 1`] = `
+Object {
+  "StartAt": "return $SFN.map(input.list, function(item))",
+  "States": Object {
+    "return $SFN.map(input.list, function(item))": Object {
+      "Catch": Array [
+        Object {
+          "ErrorEquals": Array [
+            "States.ALL",
+          ],
+          "Next": "return null",
+          "ResultPath": null,
+        },
+      ],
+      "End": true,
+      "ItemsPath": "$.list",
+      "Iterator": Object {
+        "StartAt": "return task(item)",
+        "States": Object {
+          "return task(item)": Object {
+            "End": true,
+            "Parameters": Object {
+              "FunctionName": "\${Token[TOKEN.3532]}",
+              "Payload.$": "$.item",
+            },
+            "Resource": "arn:aws:states:::lambda:invoke",
+            "ResultPath": "$",
+            "ResultSelector": "$.Payload",
+            "Type": "Task",
+          },
+        },
+      },
+      "Parameters": Object {
+        "item.$": "$$.Map.Item.Value",
+      },
+      "ResultPath": "$",
+      "Type": "Map",
+    },
+    "return null": Object {
+      "End": true,
+      "OutputPath": "$.null",
+      "Parameters": Object {
+        "null": null,
+      },
+      "Type": "Pass",
+    },
+  },
+}
+`;
+
+exports[`try { for-of } catch { (maybe) throw } finally { task } 1`] = `
+Object {
+  "StartAt": "for(item of input.items)",
+  "States": Object {
+    "0_catch(err)": Object {
+      "InputPath": "$.err.0_ParsedError",
+      "Next": "if(err.message == \\"you dun' goofed\\")",
+      "ResultPath": "$.err",
+      "Type": "Pass",
+    },
+    "catch(err)": Object {
+      "Next": "0_catch(err)",
+      "Parameters": Object {
+        "0_ParsedError.$": "States.StringToJson($.err.Cause)",
+      },
+      "ResultPath": "$.err",
+      "Type": "Pass",
+    },
+    "exit finally": Object {
+      "Choices": Array [
+        Object {
+          "IsPresent": true,
+          "Next": "throw finally",
+          "Variable": "$.0_tmp",
+        },
+      ],
+      "Default": "return null",
+      "Type": "Choice",
+    },
+    "for(item of input.items)": Object {
+      "Catch": Array [
+        Object {
+          "ErrorEquals": Array [
+            "States.ALL",
+          ],
+          "Next": "catch(err)",
+          "ResultPath": "$.err",
+        },
+      ],
+      "ItemsPath": "$.items",
+      "Iterator": Object {
+        "StartAt": "task(item)",
+        "States": Object {
+          "task(item)": Object {
+            "End": true,
+            "Parameters": Object {
+              "FunctionName": "\${Token[TOKEN.2544]}",
+              "Payload.$": "$.item",
+            },
+            "Resource": "arn:aws:states:::lambda:invoke",
+            "ResultPath": null,
+            "ResultSelector": "$.Payload",
+            "Type": "Task",
+          },
+        },
+      },
+      "MaxConcurrency": 1,
+      "Next": "task(\\"2\\")",
+      "Parameters": Object {
+        "item.$": "$$.Map.Item.Value",
+      },
+      "ResultPath": null,
+      "Type": "Map",
+    },
+    "if(err.message == \\"you dun' goofed\\")": Object {
+      "Choices": Array [
+        Object {
+          "Next": "throw new Error(\\"little\\")",
+          "StringEquals": "you dun' goofed",
+          "Variable": "$.err.message",
+        },
+      ],
+      "Default": "task(\\"2\\")",
+      "Type": "Choice",
+    },
+    "return null": Object {
+      "End": true,
+      "OutputPath": "$.null",
+      "Parameters": Object {
+        "null": null,
+      },
+      "Type": "Pass",
+    },
+    "task(\\"2\\")": Object {
+      "Next": "exit finally",
+      "Parameters": Object {
+        "FunctionName": "\${Token[TOKEN.2544]}",
+        "Payload": "2",
+      },
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "ResultPath": null,
+      "ResultSelector": "$.Payload",
+      "Type": "Task",
+    },
+    "throw finally": Object {
+      "Cause": "an error was re-thrown from a finally block which is unsupported by Step Functions",
+      "Error": "ReThrowFromFinally",
+      "Type": "Fail",
+    },
+    "throw new Error(\\"little\\")": Object {
+      "Next": "task(\\"2\\")",
+      "Result": Object {
+        "message": "little",
+      },
+      "ResultPath": "$.0_tmp",
+      "Type": "Pass",
+    },
+  },
+}
+`;
+
+exports[`try { list.forEach(item => task(item)) } 1`] = `
+Object {
+  "StartAt": "return input.list.forEach(function(item))",
+  "States": Object {
+    "return input.list.forEach(function(item))": Object {
+      "Catch": Array [
+        Object {
+          "ErrorEquals": Array [
+            "States.ALL",
+          ],
+          "Next": "return null",
+          "ResultPath": null,
+        },
+      ],
+      "End": true,
+      "ItemsPath": "$.list",
+      "Iterator": Object {
+        "StartAt": "return task(item)",
+        "States": Object {
+          "return task(item)": Object {
+            "End": true,
+            "Parameters": Object {
+              "FunctionName": "\${Token[TOKEN.3164]}",
+              "Payload.$": "$.item",
+            },
+            "Resource": "arn:aws:states:::lambda:invoke",
+            "ResultPath": "$",
+            "ResultSelector": "$.Payload",
+            "Type": "Task",
+          },
+        },
+      },
+      "MaxConcurrency": 1,
+      "Parameters": Object {
+        "item.$": "$$.Map.Item.Value",
+      },
+      "ResultPath": "$",
+      "Type": "Map",
+    },
+    "return null": Object {
+      "End": true,
+      "OutputPath": "$.null",
+      "Parameters": Object {
+        "null": null,
+      },
+      "Type": "Pass",
+    },
+  },
+}
+`;
+
+exports[`try { list.forEach(item => task(item)) } 2`] = `
+Object {
+  "StartAt": "return input.list.forEach(function(item))",
+  "States": Object {
+    "return input.list.forEach(function(item))": Object {
+      "End": true,
+      "ItemsPath": "$.list",
+      "Iterator": Object {
+        "StartAt": "return task(item)",
+        "States": Object {
+          "return null": Object {
+            "End": true,
+            "OutputPath": "$.null",
+            "Parameters": Object {
+              "null": null,
+            },
+            "Type": "Pass",
+          },
+          "return task(item)": Object {
+            "Catch": Array [
+              Object {
+                "ErrorEquals": Array [
+                  "States.ALL",
+                ],
+                "Next": "return null",
+                "ResultPath": null,
+              },
+            ],
+            "End": true,
+            "Parameters": Object {
+              "FunctionName": "\${Token[TOKEN.3206]}",
+              "Payload.$": "$.item",
+            },
+            "Resource": "arn:aws:states:::lambda:invoke",
+            "ResultPath": "$",
+            "ResultSelector": "$.Payload",
+            "Type": "Task",
+          },
+        },
+      },
+      "MaxConcurrency": 1,
+      "Parameters": Object {
+        "item.$": "$$.Map.Item.Value",
+      },
+      "ResultPath": "$",
+      "Type": "Map",
+    },
+  },
+}
+`;
+
+exports[`try { list.forEach(item => throw) } 1`] = `
+Object {
+  "StartAt": "return input.list.forEach(function())",
+  "States": Object {
+    "return input.list.forEach(function())": Object {
+      "Catch": Array [
+        Object {
+          "ErrorEquals": Array [
+            "States.ALL",
+          ],
+          "Next": "return null",
+          "ResultPath": null,
+        },
+      ],
+      "End": true,
+      "ItemsPath": "$.list",
+      "Iterator": Object {
+        "StartAt": "throw new Error(\\"cause\\")",
+        "States": Object {
+          "throw new Error(\\"cause\\")": Object {
+            "Cause": "{\\"message\\":\\"cause\\"}",
+            "Error": "Error",
+            "Type": "Fail",
+          },
+        },
+      },
+      "MaxConcurrency": 1,
+      "Parameters": Object {},
+      "ResultPath": "$",
+      "Type": "Map",
+    },
+    "return null": Object {
+      "End": true,
+      "OutputPath": "$.null",
+      "Parameters": Object {
+        "null": null,
+      },
+      "Type": "Pass",
+    },
+  },
+}
+`;
+
+exports[`try { list.forEach(item => throw) } catch (err) 1`] = `
+Object {
+  "StartAt": "return input.list.forEach(function())",
+  "States": Object {
+    "0_catch(err)": Object {
+      "InputPath": "$.err.0_ParsedError",
+      "Next": "if(err.message == \\"cause\\")",
+      "ResultPath": "$.err",
+      "Type": "Pass",
+    },
+    "catch(err)": Object {
+      "Next": "0_catch(err)",
+      "Parameters": Object {
+        "0_ParsedError.$": "States.StringToJson($.err.Cause)",
+      },
+      "ResultPath": "$.err",
+      "Type": "Pass",
+    },
+    "if(err.message == \\"cause\\")": Object {
+      "Choices": Array [
+        Object {
+          "Next": "return 0",
+          "StringEquals": "cause",
+          "Variable": "$.err.message",
+        },
+      ],
+      "Default": "return 1",
+      "Type": "Choice",
+    },
+    "return 0": Object {
+      "End": true,
+      "Result": 0,
+      "ResultPath": "$",
+      "Type": "Pass",
+    },
+    "return 1": Object {
+      "End": true,
+      "Result": 1,
+      "ResultPath": "$",
+      "Type": "Pass",
+    },
+    "return input.list.forEach(function())": Object {
+      "Catch": Array [
+        Object {
+          "ErrorEquals": Array [
+            "States.ALL",
+          ],
+          "Next": "catch(err)",
+          "ResultPath": "$.err",
+        },
+      ],
+      "End": true,
+      "ItemsPath": "$.list",
+      "Iterator": Object {
+        "StartAt": "throw new Error(\\"cause\\")",
+        "States": Object {
+          "throw new Error(\\"cause\\")": Object {
+            "Cause": "{\\"message\\":\\"cause\\"}",
+            "Error": "Error",
+            "Type": "Fail",
+          },
+        },
+      },
+      "MaxConcurrency": 1,
+      "Parameters": Object {},
+      "ResultPath": "$",
+      "Type": "Map",
+    },
+  },
+}
+`;
+
+exports[`try { list.map(item => task(item)) } 1`] = `
+Object {
+  "StartAt": "return input.list.map(function(item))",
+  "States": Object {
+    "return input.list.map(function(item))": Object {
+      "Catch": Array [
+        Object {
+          "ErrorEquals": Array [
+            "States.ALL",
+          ],
+          "Next": "return null",
+          "ResultPath": null,
+        },
+      ],
+      "End": true,
+      "ItemsPath": "$.list",
+      "Iterator": Object {
+        "StartAt": "return task(item)",
+        "States": Object {
+          "return task(item)": Object {
+            "End": true,
+            "Parameters": Object {
+              "FunctionName": "\${Token[TOKEN.2880]}",
+              "Payload.$": "$.item",
+            },
+            "Resource": "arn:aws:states:::lambda:invoke",
+            "ResultPath": "$",
+            "ResultSelector": "$.Payload",
+            "Type": "Task",
+          },
+        },
+      },
+      "MaxConcurrency": 1,
+      "Parameters": Object {
+        "item.$": "$$.Map.Item.Value",
+      },
+      "ResultPath": "$",
+      "Type": "Map",
+    },
+    "return null": Object {
+      "End": true,
+      "OutputPath": "$.null",
+      "Parameters": Object {
+        "null": null,
+      },
+      "Type": "Pass",
+    },
+  },
+}
+`;
+
+exports[`try { list.map(item => task(item)) } 2`] = `
+Object {
+  "StartAt": "return input.list.map(function(item))",
+  "States": Object {
+    "return input.list.map(function(item))": Object {
+      "End": true,
+      "ItemsPath": "$.list",
+      "Iterator": Object {
+        "StartAt": "return task(item)",
+        "States": Object {
+          "return null": Object {
+            "End": true,
+            "OutputPath": "$.null",
+            "Parameters": Object {
+              "null": null,
+            },
+            "Type": "Pass",
+          },
+          "return task(item)": Object {
+            "Catch": Array [
+              Object {
+                "ErrorEquals": Array [
+                  "States.ALL",
+                ],
+                "Next": "return null",
+                "ResultPath": null,
+              },
+            ],
+            "End": true,
+            "Parameters": Object {
+              "FunctionName": "\${Token[TOKEN.2922]}",
+              "Payload.$": "$.item",
+            },
+            "Resource": "arn:aws:states:::lambda:invoke",
+            "ResultPath": "$",
+            "ResultSelector": "$.Payload",
+            "Type": "Task",
+          },
+        },
+      },
+      "MaxConcurrency": 1,
+      "Parameters": Object {
+        "item.$": "$$.Map.Item.Value",
+      },
+      "ResultPath": "$",
+      "Type": "Map",
+    },
+  },
+}
+`;
+
+exports[`try { list.map(item => throw) } 1`] = `
+Object {
+  "StartAt": "return input.list.map(function())",
+  "States": Object {
+    "return input.list.map(function())": Object {
+      "Catch": Array [
+        Object {
+          "ErrorEquals": Array [
+            "States.ALL",
+          ],
+          "Next": "return null",
+          "ResultPath": null,
+        },
+      ],
+      "End": true,
+      "ItemsPath": "$.list",
+      "Iterator": Object {
+        "StartAt": "throw new Error(\\"cause\\")",
+        "States": Object {
+          "throw new Error(\\"cause\\")": Object {
+            "Cause": "{\\"message\\":\\"cause\\"}",
+            "Error": "Error",
+            "Type": "Fail",
+          },
+        },
+      },
+      "MaxConcurrency": 1,
+      "Parameters": Object {},
+      "ResultPath": "$",
+      "Type": "Map",
+    },
+    "return null": Object {
+      "End": true,
+      "OutputPath": "$.null",
+      "Parameters": Object {
+        "null": null,
+      },
+      "Type": "Pass",
+    },
+  },
+}
+`;
+
+exports[`try { list.map(item => throw) } catch (err) 1`] = `
+Object {
+  "StartAt": "return input.list.map(function())",
+  "States": Object {
+    "0_catch(err)": Object {
+      "InputPath": "$.err.0_ParsedError",
+      "Next": "if(err.message == \\"cause\\")",
+      "ResultPath": "$.err",
+      "Type": "Pass",
+    },
+    "catch(err)": Object {
+      "Next": "0_catch(err)",
+      "Parameters": Object {
+        "0_ParsedError.$": "States.StringToJson($.err.Cause)",
+      },
+      "ResultPath": "$.err",
+      "Type": "Pass",
+    },
+    "if(err.message == \\"cause\\")": Object {
+      "Choices": Array [
+        Object {
+          "Next": "return 0",
+          "StringEquals": "cause",
+          "Variable": "$.err.message",
+        },
+      ],
+      "Default": "return 1",
+      "Type": "Choice",
+    },
+    "return 0": Object {
+      "End": true,
+      "Result": 0,
+      "ResultPath": "$",
+      "Type": "Pass",
+    },
+    "return 1": Object {
+      "End": true,
+      "Result": 1,
+      "ResultPath": "$",
+      "Type": "Pass",
+    },
+    "return input.list.map(function())": Object {
+      "Catch": Array [
+        Object {
+          "ErrorEquals": Array [
+            "States.ALL",
+          ],
+          "Next": "catch(err)",
+          "ResultPath": "$.err",
+        },
+      ],
+      "End": true,
+      "ItemsPath": "$.list",
+      "Iterator": Object {
+        "StartAt": "throw new Error(\\"cause\\")",
+        "States": Object {
+          "throw new Error(\\"cause\\")": Object {
+            "Cause": "{\\"message\\":\\"cause\\"}",
+            "Error": "Error",
+            "Type": "Fail",
+          },
+        },
+      },
+      "MaxConcurrency": 1,
+      "Parameters": Object {},
+      "ResultPath": "$",
+      "Type": "Map",
+    },
+  },
+}
+`;
+
+exports[`try { return $SFN.parallel(() => "hello", () => "world")) } catch { return null } 1`] = `
+Object {
+  "StartAt": "return $SFN.parallel([function(), function()])",
+  "States": Object {
+    "return $SFN.parallel([function(), function()])": Object {
+      "Branches": Array [
+        Object {
+          "StartAt": "return \\"hello\\"",
+          "States": Object {
+            "return \\"hello\\"": Object {
+              "End": true,
+              "Result": "hello",
+              "ResultPath": "$",
+              "Type": "Pass",
+            },
+          },
+        },
+        Object {
+          "StartAt": "return \\"world\\"",
+          "States": Object {
+            "return \\"world\\"": Object {
+              "End": true,
+              "Result": "world",
+              "ResultPath": "$",
+              "Type": "Pass",
+            },
+          },
+        },
+      ],
+      "Catch": Array [
+        Object {
+          "ErrorEquals": Array [
+            "States.ALL",
+          ],
+          "Next": "return null",
+          "ResultPath": null,
+        },
+      ],
+      "End": true,
+      "ResultPath": "$",
+      "Type": "Parallel",
+    },
+    "return null": Object {
+      "End": true,
+      "OutputPath": "$.null",
+      "Parameters": Object {
+        "null": null,
+      },
+      "Type": "Pass",
+    },
+  },
+}
+`;
+
+exports[`try { task } catch { throw } finally { task() } 1`] = `
+Object {
+  "StartAt": "task()",
+  "States": Object {
+    "exit finally": Object {
+      "Choices": Array [
+        Object {
+          "IsPresent": true,
+          "Next": "throw finally",
+          "Variable": "$.0_tmp",
+        },
+      ],
+      "Default": "return null",
+      "Type": "Choice",
+    },
+    "return null": Object {
+      "End": true,
+      "OutputPath": "$.null",
+      "Parameters": Object {
+        "null": null,
+      },
+      "Type": "Pass",
+    },
+    "task()": Object {
+      "Next": "exit finally",
+      "Parameters": Object {
+        "FunctionName": "__REPLACED_TOKEN",
+        "Payload": "recover",
+      },
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "ResultPath": null,
+      "ResultSelector": "$.Payload",
+      "Type": "Task",
+    },
+    "throw finally": Object {
+      "Cause": "an error was re-thrown from a finally block which is unsupported by Step Functions",
+      "Error": "ReThrowFromFinally",
+      "Type": "Fail",
+    },
+  },
+}
+`;
+
+exports[`try { task() } catch { (maybe) throw } finally { task } 1`] = `
+Object {
+  "StartAt": "task(\\"1\\")",
+  "States": Object {
+    "exit finally": Object {
+      "Choices": Array [
+        Object {
+          "IsPresent": true,
+          "Next": "throw finally",
+          "Variable": "$.0_tmp",
+        },
+      ],
+      "Default": "return null",
+      "Type": "Choice",
+    },
+    "return null": Object {
+      "End": true,
+      "OutputPath": "$.null",
+      "Parameters": Object {
+        "null": null,
+      },
+      "Type": "Pass",
+    },
+    "task(\\"1\\")": Object {
+      "Next": "exit finally",
+      "Parameters": Object {
+        "FunctionName": "__REPLACED_TOKEN",
+        "Payload": "2",
+      },
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "ResultPath": null,
+      "ResultSelector": "$.Payload",
+      "Type": "Task",
+    },
+    "throw finally": Object {
+      "Cause": "an error was re-thrown from a finally block which is unsupported by Step Functions",
+      "Error": "ReThrowFromFinally",
+      "Type": "Fail",
+    },
+  },
+}
+`;
+
+exports[`try { task() } catch { task() } finally { task() } 1`] = `
+Object {
+  "StartAt": "task(\\"1\\")",
+  "States": Object {
+    "exit finally": Object {
+      "Choices": Array [
+        Object {
+          "IsPresent": true,
+          "Next": "throw finally",
+          "Variable": "$.0_tmp",
+        },
+      ],
+      "Default": "return null",
+      "Type": "Choice",
+    },
+    "return null": Object {
+      "End": true,
+      "OutputPath": "$.null",
+      "Parameters": Object {
+        "null": null,
+      },
+      "Type": "Pass",
+    },
+    "task(\\"1\\")": Object {
+      "Next": "exit finally",
+      "Parameters": Object {
+        "FunctionName": "__REPLACED_TOKEN",
+        "Payload": "3",
+      },
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "ResultPath": null,
+      "ResultSelector": "$.Payload",
+      "Type": "Task",
+    },
+    "throw finally": Object {
+      "Cause": "an error was re-thrown from a finally block which is unsupported by Step Functions",
+      "Error": "ReThrowFromFinally",
+      "Type": "Fail",
+    },
+  },
+}
+`;
+
+exports[`try { task() } catch(err) { (maybe) throw } finally { task } 1`] = `
+Object {
+  "StartAt": "task(\\"1\\")",
+  "States": Object {
+    "exit finally": Object {
+      "Choices": Array [
+        Object {
+          "IsPresent": true,
+          "Next": "throw finally",
+          "Variable": "$.0_tmp",
+        },
+      ],
+      "Default": "return null",
+      "Type": "Choice",
+    },
+    "return null": Object {
+      "End": true,
+      "OutputPath": "$.null",
+      "Parameters": Object {
+        "null": null,
+      },
+      "Type": "Pass",
+    },
+    "task(\\"1\\")": Object {
+      "Next": "exit finally",
+      "Parameters": Object {
+        "FunctionName": "__REPLACED_TOKEN",
+        "Payload": "2",
+      },
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "ResultPath": null,
+      "ResultSelector": "$.Payload",
+      "Type": "Task",
+    },
+    "throw finally": Object {
+      "Cause": "an error was re-thrown from a finally block which is unsupported by Step Functions",
+      "Error": "ReThrowFromFinally",
+      "Type": "Fail",
+    },
+  },
+}
+`;
+
+exports[`try { throw } catch { (maybe) throw } finally { task } 1`] = `
+Object {
+  "StartAt": "throw new Error(\\"go\\")",
+  "States": Object {
+    "exit finally": Object {
+      "Choices": Array [
+        Object {
+          "IsPresent": true,
+          "Next": "throw finally",
+          "Variable": "$.0_tmp",
+        },
+      ],
+      "Default": "return null",
+      "Type": "Choice",
+    },
+    "if(input.id == \\"sam\\")": Object {
+      "Choices": Array [
+        Object {
+          "Next": "throw new Error(\\"little\\")",
+          "StringEquals": "sam",
+          "Variable": "$.id",
+        },
+      ],
+      "Default": "task()",
+      "Type": "Choice",
+    },
+    "return null": Object {
+      "End": true,
+      "OutputPath": "$.null",
+      "Parameters": Object {
+        "null": null,
+      },
+      "Type": "Pass",
+    },
+    "task()": Object {
+      "Next": "exit finally",
+      "Parameters": Object {
+        "FunctionName": "__REPLACED_TOKEN",
+      },
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "ResultPath": null,
+      "ResultSelector": "$.Payload",
+      "Type": "Task",
+    },
+    "throw finally": Object {
+      "Cause": "an error was re-thrown from a finally block which is unsupported by Step Functions",
+      "Error": "ReThrowFromFinally",
+      "Type": "Fail",
+    },
+    "throw new Error(\\"go\\")": Object {
+      "Next": "if(input.id == \\"sam\\")",
+      "Result": Object {
+        "message": "go",
+      },
+      "ResultPath": null,
+      "Type": "Pass",
+    },
+    "throw new Error(\\"little\\")": Object {
+      "Next": "task()",
+      "Result": Object {
+        "message": "little",
+      },
+      "ResultPath": "$.0_tmp",
+      "Type": "Pass",
+    },
+  },
+}
+`;
+
+exports[`try, task, empty catch 1`] = `
+Object {
+  "StartAt": "computeScore({id: \\"id\\", name: \\"name\\"})",
+  "States": Object {
+    "computeScore({id: \\"id\\", name: \\"name\\"})": Object {
+      "Catch": Array [
+        Object {
+          "ErrorEquals": Array [
+            "States.ALL",
+          ],
+          "Next": "return null",
+          "ResultPath": null,
+        },
+      ],
+      "Next": "return null",
+      "Parameters": Object {
+        "FunctionName": "\${Token[TOKEN.1675]}",
+        "Payload": Object {
+          "id": "id",
+          "name": "name",
+        },
+      },
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "ResultPath": null,
+      "ResultSelector": "$.Payload",
+      "Type": "Task",
+    },
+    "return null": Object {
+      "End": true,
+      "OutputPath": "$.null",
+      "Parameters": Object {
+        "null": null,
+      },
+      "Type": "Pass",
+    },
+  },
+}
+`;
+
+exports[`try, throw Error('error'), empty catch 1`] = `
+Object {
+  "StartAt": "throw Error(\\"cause\\")",
+  "States": Object {
+    "return null": Object {
+      "End": true,
+      "OutputPath": "$.null",
+      "Parameters": Object {
+        "null": null,
+      },
+      "Type": "Pass",
+    },
+    "throw Error(\\"cause\\")": Object {
+      "Next": "return null",
+      "Result": Object {
+        "message": "cause",
+      },
+      "ResultPath": null,
+      "Type": "Pass",
+    },
+  },
+}
+`;
+
+exports[`try, throw, catch, throw, finally, return 1`] = `
+Object {
+  "StartAt": "throw new Error(\\"go\\")",
+  "States": Object {
+    "return \\"rock-star\\"": Object {
+      "End": true,
+      "Result": "rock-star",
+      "ResultPath": "$",
+      "Type": "Pass",
+    },
+    "throw new Error(\\"go\\")": Object {
+      "Next": "throw new Error(\\"little\\")",
+      "Result": Object {
+        "message": "go",
+      },
+      "ResultPath": null,
+      "Type": "Pass",
+    },
+    "throw new Error(\\"little\\")": Object {
+      "Next": "return \\"rock-star\\"",
+      "Result": Object {
+        "message": "little",
+      },
+      "ResultPath": null,
+      "Type": "Pass",
+    },
+  },
+}
+`;
+
+exports[`try, throw, empty catch 1`] = `
+Object {
+  "StartAt": "throw new CustomError(\\"cause\\")",
+  "States": Object {
+    "return null": Object {
+      "End": true,
+      "OutputPath": "$.null",
+      "Parameters": Object {
+        "null": null,
+      },
+      "Type": "Pass",
+    },
+    "throw new CustomError(\\"cause\\")": Object {
+      "Next": "return null",
+      "Result": Object {
+        "property": "cause",
+      },
+      "ResultPath": null,
+      "Type": "Pass",
+    },
+  },
+}
+`;
+
+exports[`try, throw, finally 1`] = `
+Object {
+  "StartAt": "throw new Error(\\"cause\\")",
+  "States": Object {
+    "return \\"hello\\"": Object {
+      "End": true,
+      "Result": "hello",
+      "ResultPath": "$",
+      "Type": "Pass",
+    },
+    "throw new Error(\\"cause\\")": Object {
+      "Next": "return \\"hello\\"",
+      "Result": Object {
+        "message": "cause",
+      },
+      "ResultPath": null,
+      "Type": "Pass",
+    },
+  },
+}
+`;
+
+exports[`try-catch with guaranteed throw new Error 1`] = `
+Object {
+  "StartAt": "throw new Error(\\"cause\\")",
+  "States": Object {
+    "if(err.message == \\"cause\\")": Object {
+      "Choices": Array [
+        Object {
+          "Next": "return \\"hello\\"",
+          "StringEquals": "cause",
+          "Variable": "$.err.message",
+        },
+      ],
+      "Default": "return \\"world\\"",
+      "Type": "Choice",
+    },
+    "return \\"hello\\"": Object {
+      "End": true,
+      "Result": "hello",
+      "ResultPath": "$",
+      "Type": "Pass",
+    },
+    "return \\"world\\"": Object {
+      "End": true,
+      "Result": "world",
+      "ResultPath": "$",
+      "Type": "Pass",
+    },
+    "throw new Error(\\"cause\\")": Object {
+      "Next": "if(err.message == \\"cause\\")",
+      "Result": Object {
+        "message": "cause",
+      },
+      "ResultPath": "$.err",
+      "Type": "Pass",
+    },
+  },
+}
+`;
+
+exports[`try-catch with inner return and a catch variable 1`] = `
+Object {
+  "StartAt": "computeScore({id: \\"id\\", name: \\"name\\"})",
+  "States": Object {
+    "0_catch(err)": Object {
+      "InputPath": "$.err.0_ParsedError",
+      "Next": "return err.message",
+      "ResultPath": "$.err",
+      "Type": "Pass",
+    },
+    "catch(err)": Object {
+      "Next": "0_catch(err)",
+      "Parameters": Object {
+        "0_ParsedError.$": "States.StringToJson($.err.Cause)",
+      },
+      "ResultPath": "$.err",
+      "Type": "Pass",
+    },
+    "computeScore({id: \\"id\\", name: \\"name\\"})": Object {
+      "Catch": Array [
+        Object {
+          "ErrorEquals": Array [
+            "States.ALL",
+          ],
+          "Next": "catch(err)",
+          "ResultPath": "$.err",
+        },
+      ],
+      "Next": "return \\"hello\\"",
+      "Parameters": Object {
+        "FunctionName": "\${Token[TOKEN.1833]}",
+        "Payload": Object {
+          "id": "id",
+          "name": "name",
+        },
+      },
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "ResultPath": null,
+      "ResultSelector": "$.Payload",
+      "Type": "Task",
+    },
+    "return \\"hello\\"": Object {
+      "End": true,
+      "Result": "hello",
+      "ResultPath": "$",
+      "Type": "Pass",
+    },
+    "return err.message": Object {
+      "End": true,
+      "OutputPath": "$.err.message",
+      "Type": "Pass",
+    },
+  },
+}
+`;
+
+exports[`try-catch with inner return and no catch variable 1`] = `
+Object {
+  "StartAt": "computeScore({id: \\"id\\", name: \\"name\\"})",
+  "States": Object {
+    "computeScore({id: \\"id\\", name: \\"name\\"})": Object {
+      "Catch": Array [
+        Object {
+          "ErrorEquals": Array [
+            "States.ALL",
+          ],
+          "Next": "return \\"world\\"",
+          "ResultPath": null,
+        },
+      ],
+      "Next": "return \\"hello\\"",
+      "Parameters": Object {
+        "FunctionName": "\${Token[TOKEN.1791]}",
+        "Payload": Object {
+          "id": "id",
+          "name": "name",
+        },
+      },
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "ResultPath": null,
+      "ResultSelector": "$.Payload",
+      "Type": "Task",
+    },
+    "return \\"hello\\"": Object {
+      "End": true,
+      "Result": "hello",
+      "ResultPath": "$",
+      "Type": "Pass",
+    },
+    "return \\"world\\"": Object {
+      "End": true,
+      "Result": "world",
+      "ResultPath": "$",
+      "Type": "Pass",
+    },
+  },
+}
+`;
+
+exports[`try-catch with optional return of task 1`] = `
+Object {
+  "StartAt": "if(input.id == \\"hello\\")",
+  "States": Object {
+    "0_catch(err)": Object {
+      "InputPath": "$.err.0_ParsedError",
+      "Next": "if(err.message == \\"cause\\")",
+      "ResultPath": "$.err",
+      "Type": "Pass",
+    },
+    "catch(err)": Object {
+      "Next": "0_catch(err)",
+      "Parameters": Object {
+        "0_ParsedError.$": "States.StringToJson($.err.Cause)",
+      },
+      "ResultPath": "$.err",
+      "Type": "Pass",
+    },
+    "if(err.message == \\"cause\\")": Object {
+      "Choices": Array [
+        Object {
+          "Next": "return \\"hello\\"",
+          "StringEquals": "cause",
+          "Variable": "$.err.message",
+        },
+      ],
+      "Default": "return \\"world\\"",
+      "Type": "Choice",
+    },
+    "if(input.id == \\"hello\\")": Object {
+      "Choices": Array [
+        Object {
+          "Next": "return computeScore({id: input.id, name: \\"sam\\"})",
+          "StringEquals": "hello",
+          "Variable": "$.id",
+        },
+      ],
+      "Default": "return \\"hello world\\"",
+      "Type": "Choice",
+    },
+    "return \\"hello world\\"": Object {
+      "End": true,
+      "Result": "hello world",
+      "ResultPath": "$",
+      "Type": "Pass",
+    },
+    "return \\"hello\\"": Object {
+      "End": true,
+      "Result": "hello",
+      "ResultPath": "$",
+      "Type": "Pass",
+    },
+    "return \\"world\\"": Object {
+      "End": true,
+      "Result": "world",
+      "ResultPath": "$",
+      "Type": "Pass",
+    },
+    "return computeScore({id: input.id, name: \\"sam\\"})": Object {
+      "Catch": Array [
+        Object {
+          "ErrorEquals": Array [
+            "States.ALL",
+          ],
+          "Next": "catch(err)",
+          "ResultPath": "$.err",
+        },
+      ],
+      "End": true,
+      "Parameters": Object {
+        "FunctionName": "\${Token[TOKEN.1991]}",
+        "Payload": Object {
+          "id.$": "$.id",
+          "name": "sam",
+        },
+      },
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "ResultPath": "$",
+      "ResultSelector": "$.Payload",
+      "Type": "Task",
+    },
+  },
+}
+`;
+
+exports[`try-catch with optional task 1`] = `
+Object {
+  "StartAt": "if(input.id == \\"hello\\")",
+  "States": Object {
+    "0_catch(err)": Object {
+      "InputPath": "$.err.0_ParsedError",
+      "Next": "if(err.message == \\"cause\\")",
+      "ResultPath": "$.err",
+      "Type": "Pass",
+    },
+    "catch(err)": Object {
+      "Next": "0_catch(err)",
+      "Parameters": Object {
+        "0_ParsedError.$": "States.StringToJson($.err.Cause)",
+      },
+      "ResultPath": "$.err",
+      "Type": "Pass",
+    },
+    "computeScore({id: input.id, name: \\"sam\\"})": Object {
+      "Catch": Array [
+        Object {
+          "ErrorEquals": Array [
+            "States.ALL",
+          ],
+          "Next": "catch(err)",
+          "ResultPath": "$.err",
+        },
+      ],
+      "Next": "return \\"hello world\\"",
+      "Parameters": Object {
+        "FunctionName": "\${Token[TOKEN.1949]}",
+        "Payload": Object {
+          "id.$": "$.id",
+          "name": "sam",
+        },
+      },
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "ResultPath": null,
+      "ResultSelector": "$.Payload",
+      "Type": "Task",
+    },
+    "if(err.message == \\"cause\\")": Object {
+      "Choices": Array [
+        Object {
+          "Next": "return \\"hello\\"",
+          "StringEquals": "cause",
+          "Variable": "$.err.message",
+        },
+      ],
+      "Default": "return \\"world\\"",
+      "Type": "Choice",
+    },
+    "if(input.id == \\"hello\\")": Object {
+      "Choices": Array [
+        Object {
+          "Next": "computeScore({id: input.id, name: \\"sam\\"})",
+          "StringEquals": "hello",
+          "Variable": "$.id",
+        },
+      ],
+      "Default": "return \\"hello world\\"",
+      "Type": "Choice",
+    },
+    "return \\"hello world\\"": Object {
+      "End": true,
+      "Result": "hello world",
+      "ResultPath": "$",
+      "Type": "Pass",
+    },
+    "return \\"hello\\"": Object {
+      "End": true,
+      "Result": "hello",
+      "ResultPath": "$",
+      "Type": "Pass",
+    },
+    "return \\"world\\"": Object {
+      "End": true,
+      "Result": "world",
+      "ResultPath": "$",
+      "Type": "Pass",
+    },
+  },
+}
+`;
+
+exports[`try-catch with optional throw of an Error 1`] = `
+Object {
+  "StartAt": "if(input.id == \\"hello\\")",
+  "States": Object {
+    "if(err.message == \\"cause\\")": Object {
+      "Choices": Array [
+        Object {
+          "Next": "return \\"hello\\"",
+          "StringEquals": "cause",
+          "Variable": "$.err.message",
+        },
+      ],
+      "Default": "return \\"world\\"",
+      "Type": "Choice",
+    },
+    "if(input.id == \\"hello\\")": Object {
+      "Choices": Array [
+        Object {
+          "Next": "throw new Error(\\"cause\\")",
+          "StringEquals": "hello",
+          "Variable": "$.id",
+        },
+      ],
+      "Default": "return \\"hello world\\"",
+      "Type": "Choice",
+    },
+    "return \\"hello world\\"": Object {
+      "End": true,
+      "Result": "hello world",
+      "ResultPath": "$",
+      "Type": "Pass",
+    },
+    "return \\"hello\\"": Object {
+      "End": true,
+      "Result": "hello",
+      "ResultPath": "$",
+      "Type": "Pass",
+    },
+    "return \\"world\\"": Object {
+      "End": true,
+      "Result": "world",
+      "ResultPath": "$",
+      "Type": "Pass",
+    },
+    "throw new Error(\\"cause\\")": Object {
+      "Next": "if(err.message == \\"cause\\")",
+      "Result": Object {
+        "message": "cause",
+      },
+      "ResultPath": "$.err",
+      "Type": "Pass",
+    },
+  },
+}
+`;
+
+exports[`try-catch, err variable, contains for-of, throw Error 1`] = `
+Object {
+  "StartAt": "for(item of input.items)",
+  "States": Object {
+    "0_catch(err)": Object {
+      "InputPath": "$.err.0_ParsedError",
+      "Next": "return err.message",
+      "ResultPath": "$.err",
+      "Type": "Pass",
+    },
+    "catch(err)": Object {
+      "Next": "0_catch(err)",
+      "Parameters": Object {
+        "0_ParsedError.$": "States.StringToJson($.err.Cause)",
+      },
+      "ResultPath": "$.err",
+      "Type": "Pass",
+    },
+    "for(item of input.items)": Object {
+      "Catch": Array [
+        Object {
+          "ErrorEquals": Array [
+            "States.ALL",
+          ],
+          "Next": "catch(err)",
+          "ResultPath": "$.err",
+        },
+      ],
+      "ItemsPath": "$.items",
+      "Iterator": Object {
+        "StartAt": "throw Error(\\"err\\")",
+        "States": Object {
+          "throw Error(\\"err\\")": Object {
+            "Cause": "{\\"message\\":\\"err\\"}",
+            "Error": "Error",
+            "Type": "Fail",
+          },
+        },
+      },
+      "MaxConcurrency": 1,
+      "Next": "return null",
+      "Parameters": Object {
+        "item.$": "$$.Map.Item.Value",
+      },
+      "ResultPath": null,
+      "Type": "Map",
+    },
+    "return err.message": Object {
+      "End": true,
+      "OutputPath": "$.err.message",
+      "Type": "Pass",
+    },
+    "return null": Object {
+      "End": true,
+      "OutputPath": "$.null",
+      "Parameters": Object {
+        "null": null,
+      },
+      "Type": "Pass",
+    },
+  },
+}
+`;
+
+exports[`try-catch, err variable, contains for-of, throw new Error 1`] = `
+Object {
+  "StartAt": "for(item of input.items)",
+  "States": Object {
+    "0_catch(err)": Object {
+      "InputPath": "$.err.0_ParsedError",
+      "Next": "return err.message",
+      "ResultPath": "$.err",
+      "Type": "Pass",
+    },
+    "catch(err)": Object {
+      "Next": "0_catch(err)",
+      "Parameters": Object {
+        "0_ParsedError.$": "States.StringToJson($.err.Cause)",
+      },
+      "ResultPath": "$.err",
+      "Type": "Pass",
+    },
+    "for(item of input.items)": Object {
+      "Catch": Array [
+        Object {
+          "ErrorEquals": Array [
+            "States.ALL",
+          ],
+          "Next": "catch(err)",
+          "ResultPath": "$.err",
+        },
+      ],
+      "ItemsPath": "$.items",
+      "Iterator": Object {
+        "StartAt": "throw new Error(\\"err\\")",
+        "States": Object {
+          "throw new Error(\\"err\\")": Object {
+            "Cause": "{\\"message\\":\\"err\\"}",
+            "Error": "Error",
+            "Type": "Fail",
+          },
+        },
+      },
+      "MaxConcurrency": 1,
+      "Next": "return null",
+      "Parameters": Object {
+        "item.$": "$$.Map.Item.Value",
+      },
+      "ResultPath": null,
+      "Type": "Map",
+    },
+    "return err.message": Object {
+      "End": true,
+      "OutputPath": "$.err.message",
+      "Type": "Pass",
+    },
+    "return null": Object {
+      "End": true,
+      "OutputPath": "$.null",
+      "Parameters": Object {
+        "null": null,
+      },
+      "Type": "Pass",
+    },
+  },
+}
+`;
+
+exports[`try-catch, no variable, contains for-of, throw 1`] = `
+Object {
+  "StartAt": "for(item of input.items)",
+  "States": Object {
+    "for(item of input.items)": Object {
+      "Catch": Array [
+        Object {
+          "ErrorEquals": Array [
+            "States.ALL",
+          ],
+          "Next": "return \\"hello\\"",
+          "ResultPath": null,
+        },
+      ],
+      "ItemsPath": "$.items",
+      "Iterator": Object {
+        "StartAt": "throw new Error(\\"err\\")",
+        "States": Object {
+          "throw new Error(\\"err\\")": Object {
+            "Cause": "{\\"message\\":\\"err\\"}",
+            "Error": "Error",
+            "Type": "Fail",
+          },
+        },
+      },
+      "MaxConcurrency": 1,
+      "Next": "return null",
+      "Parameters": Object {
+        "item.$": "$$.Map.Item.Value",
+      },
+      "ResultPath": null,
+      "Type": "Map",
+    },
+    "return \\"hello\\"": Object {
+      "End": true,
+      "Result": "hello",
+      "ResultPath": "$",
+      "Type": "Pass",
+    },
+    "return null": Object {
+      "End": true,
+      "OutputPath": "$.null",
+      "Parameters": Object {
+        "null": null,
+      },
+      "Type": "Pass",
+    },
+  },
+}
+`;
+
+exports[`try-catch-finally 1`] = `
+Object {
+  "StartAt": "computeScore({id: \\"id\\", name: \\"name\\"})",
+  "States": Object {
+    "computeScore({id: \\"id\\", name: \\"name\\"})": Object {
+      "Catch": Array [
+        Object {
+          "ErrorEquals": Array [
+            "States.ALL",
+          ],
+          "Next": "return \\"hello\\"",
+          "ResultPath": null,
+        },
+      ],
+      "Next": "return \\"hello\\"",
+      "Parameters": Object {
+        "FunctionName": "\${Token[TOKEN.2218]}",
+        "Payload": Object {
+          "id": "id",
+          "name": "name",
+        },
+      },
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "ResultPath": null,
+      "ResultSelector": "$.Payload",
+      "Type": "Task",
+    },
+    "return \\"hello\\"": Object {
+      "End": true,
+      "Result": "hello",
+      "ResultPath": "$",
+      "Type": "Pass",
+    },
+  },
+}
+`;
+
+exports[`waitFor literal number of seconds 1`] = `
+Object {
+  "StartAt": "$SFN.waitFor(1)",
+  "States": Object {
+    "$SFN.waitFor(1)": Object {
+      "Next": "return null",
+      "Seconds": 1,
+      "Type": "Wait",
+    },
+    "return null": Object {
+      "End": true,
+      "OutputPath": "$.null",
+      "Parameters": Object {
+        "null": null,
+      },
+      "Type": "Pass",
+    },
+  },
+}
+`;
+
+exports[`waitFor literal timestamp 1`] = `
+Object {
+  "StartAt": "$SFN.waitUntil(\\"2022-08-01T00:00:00Z\\")",
+  "States": Object {
+    "$SFN.waitUntil(\\"2022-08-01T00:00:00Z\\")": Object {
+      "Next": "return null",
+      "Timestamp": "2022-08-01T00:00:00Z",
+      "Type": "Wait",
+    },
+    "return null": Object {
+      "End": true,
+      "OutputPath": "$.null",
+      "Parameters": Object {
+        "null": null,
+      },
+      "Type": "Pass",
+    },
+  },
+}
+`;
+
+exports[`waitFor reference number of seconds 1`] = `
+Object {
+  "StartAt": "$SFN.waitFor(input.seconds)",
+  "States": Object {
+    "$SFN.waitFor(input.seconds)": Object {
+      "Next": "return null",
+      "SecondsPath": "$.seconds",
+      "Type": "Wait",
+    },
+    "return null": Object {
+      "End": true,
+      "OutputPath": "$.null",
+      "Parameters": Object {
+        "null": null,
+      },
+      "Type": "Pass",
+    },
+  },
+}
+`;
+
+exports[`waitUntil reference timestamp 1`] = `
+Object {
+  "StartAt": "$SFN.waitUntil(input.until)",
+  "States": Object {
+    "$SFN.waitUntil(input.until)": Object {
+      "Next": "return null",
+      "TimestampPath": "$.until",
+      "Type": "Wait",
+    },
+    "return null": Object {
+      "End": true,
+      "OutputPath": "$.null",
+      "Parameters": Object {
+        "null": null,
+      },
+      "Type": "Pass",
+    },
+  },
+}
+`;
+
+exports[`while (cond) { cond = task() } 1`] = `
+Object {
+  "StartAt": "while (cond == undefined)",
+  "States": Object {
+    "cond = task()": Object {
+      "Next": "while (cond == undefined)",
+      "Parameters": Object {
+        "FunctionName": "__REPLACED_TOKEN",
+      },
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "ResultPath": "$.cond",
+      "ResultSelector": "$.Payload",
+      "Type": "Task",
+    },
+    "return null": Object {
+      "End": true,
+      "OutputPath": "$.null",
+      "Parameters": Object {
+        "null": null,
+      },
+      "Type": "Pass",
+    },
+    "while (cond == undefined)": Object {
+      "Choices": Array [
+        Object {
+          "Next": "cond = task()",
+          "Or": Array [
+            Object {
+              "IsPresent": false,
+              "Variable": "$.cond",
+            },
+            Object {
+              "IsNull": true,
+              "Variable": "$.cond",
+            },
+          ],
+        },
+      ],
+      "Default": "return null",
+      "Type": "Choice",
+    },
+  },
+}
+`;
+
+exports[`while (cond); cond = task() 1`] = `
+Object {
+  "StartAt": "while (cond == undefined)",
+  "States": Object {
+    "cond = task()": Object {
+      "Next": "while (cond == undefined)",
+      "Parameters": Object {
+        "FunctionName": "__REPLACED_TOKEN",
+      },
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "ResultPath": "$.cond",
+      "ResultSelector": "$.Payload",
+      "Type": "Task",
+    },
+    "return null": Object {
+      "End": true,
+      "OutputPath": "$.null",
+      "Parameters": Object {
+        "null": null,
+      },
+      "Type": "Pass",
+    },
+    "while (cond == undefined)": Object {
+      "Choices": Array [
+        Object {
+          "Next": "cond = task()",
+          "Or": Array [
+            Object {
+              "IsPresent": false,
+              "Variable": "$.cond",
+            },
+            Object {
+              "IsNull": true,
+              "Variable": "$.cond",
+            },
+          ],
+        },
+      ],
+      "Default": "return null",
+      "Type": "Choice",
+    },
+  },
+}
+`;
+
+exports[`while(true) { try { } catch { wait } 1`] = `
+Object {
+  "StartAt": "while (true)",
+  "States": Object {
+    "$SFN.waitFor(1)": Object {
+      "Next": "while (true)",
+      "Seconds": 1,
+      "Type": "Wait",
+    },
+    "return null": Object {
+      "End": true,
+      "OutputPath": "$.null",
+      "Parameters": Object {
+        "null": null,
+      },
+      "Type": "Pass",
+    },
+    "task()": Object {
+      "Catch": Array [
+        Object {
+          "ErrorEquals": Array [
+            "States.ALL",
+          ],
+          "Next": "$SFN.waitFor(1)",
+          "ResultPath": null,
+        },
+      ],
+      "Next": "while (true)",
+      "Parameters": Object {
+        "FunctionName": "\${Token[TOKEN.4342]}",
+        "Payload": undefined,
+      },
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "ResultPath": null,
+      "ResultSelector": "$.Payload",
+      "Type": "Task",
+    },
+    "while (true)": Object {
+      "Choices": Array [
+        Object {
+          "IsPresent": false,
+          "Next": "task()",
+          "Variable": "$.0_true",
+        },
+      ],
+      "Default": "return null",
+      "Type": "Choice",
+    },
+  },
+}
+`;

--- a/test/step-function.test.ts
+++ b/test/step-function.test.ts
@@ -12,6 +12,12 @@ import {
 import { StateMachine, States } from "../src/asl";
 import { initStepFunctionApp, Person } from "./util";
 
+const normalizeDefinition = (definition: StateMachine<States>): any => {
+  return JSON.parse(
+    JSON.stringify(definition).replace(/\$\{Token\[.*\]\}/g, "__REPLACED_TOKEN")
+  );
+};
+
 test("empty function", () => {
   const { stack } = initStepFunctionApp();
   const definition = new ExpressStepFunction(stack, "fn", () => {}).definition;
@@ -117,17 +123,7 @@ test("return items.slice(1)", () => {
     }
   ).definition;
 
-  expect(definition).toEqual({
-    StartAt: "return input.items.slice(1)",
-    States: {
-      "return input.items.slice(1)": {
-        End: true,
-        InputPath: "$.items[1:]",
-        ResultPath: "$",
-        Type: "Pass",
-      },
-    },
-  });
+  expect(normalizeDefinition(definition)).toMatchSnapshot();
 });
 
 test("return items.slice(1, undefined)", () => {
@@ -140,17 +136,7 @@ test("return items.slice(1, undefined)", () => {
     }
   ).definition;
 
-  expect(definition).toEqual({
-    StartAt: "return input.items.slice(1, undefined)",
-    States: {
-      "return input.items.slice(1, undefined)": {
-        End: true,
-        InputPath: "$.items[1:]",
-        ResultPath: "$",
-        Type: "Pass",
-      },
-    },
-  });
+  expect(normalizeDefinition(definition)).toMatchSnapshot();
 });
 
 test("return items.slice(-1)", () => {
@@ -163,17 +149,7 @@ test("return items.slice(-1)", () => {
     }
   ).definition;
 
-  expect(definition).toEqual({
-    StartAt: "return input.items.slice(-1)",
-    States: {
-      "return input.items.slice(-1)": {
-        End: true,
-        InputPath: "$.items[-1:]",
-        ResultPath: "$",
-        Type: "Pass",
-      },
-    },
-  });
+  expect(normalizeDefinition(definition)).toMatchSnapshot();
 });
 
 test("return items.slice(0, -1)", () => {
@@ -186,17 +162,7 @@ test("return items.slice(0, -1)", () => {
     }
   ).definition;
 
-  expect(definition).toEqual({
-    StartAt: "return input.items.slice(0, -1)",
-    States: {
-      "return input.items.slice(0, -1)": {
-        End: true,
-        InputPath: "$.items[0:-1]",
-        ResultPath: "$",
-        Type: "Pass",
-      },
-    },
-  });
+  expect(normalizeDefinition(definition)).toMatchSnapshot();
 });
 
 test("return items.slice(1, 3)", () => {
@@ -209,17 +175,7 @@ test("return items.slice(1, 3)", () => {
     }
   ).definition;
 
-  expect(definition).toEqual({
-    StartAt: "return input.items.slice(1, 3)",
-    States: {
-      "return input.items.slice(1, 3)": {
-        End: true,
-        InputPath: "$.items[1:3]",
-        ResultPath: "$",
-        Type: "Pass",
-      },
-    },
-  });
+  expect(normalizeDefinition(definition)).toMatchSnapshot();
 });
 
 test("return task({key: items.slice(1, 3)})", () => {
@@ -231,24 +187,7 @@ test("return task({key: items.slice(1, 3)})", () => {
     return task({ key: input.items.slice(1, 3) });
   }).definition;
 
-  expect(definition).toEqual({
-    StartAt: "return task({key: input.items.slice(1, 3)})",
-    States: {
-      "return task({key: input.items.slice(1, 3)})": {
-        Type: "Task",
-        End: true,
-        Resource: "arn:aws:states:::lambda:invoke",
-        ResultSelector: "$.Payload",
-        Parameters: {
-          FunctionName: task.resource.functionName,
-          Payload: {
-            "key.$": "$.items[1:3]",
-          },
-        },
-        ResultPath: "$",
-      },
-    },
-  });
+  expect(normalizeDefinition(definition)).toMatchSnapshot();
 });
 
 test("let and set", () => {
@@ -288,169 +227,7 @@ test("let and set", () => {
     return a;
   }).definition;
 
-  expect(definition).toEqual({
-    StartAt: "a = null",
-    States: {
-      "a = null": {
-        Next: "a = true",
-        Parameters: {
-          "$.a": null,
-          "a.$": "$.a",
-        },
-        ResultPath: null,
-        Type: "Pass",
-      },
-      "a = true": {
-        Next: "a = false",
-        Parameters: true,
-        ResultPath: "$.a",
-        Type: "Pass",
-      },
-      "a = false": {
-        Next: "a = 0",
-        Parameters: false,
-        ResultPath: "$.a",
-        Type: "Pass",
-      },
-      "a = 0": {
-        Next: "a = -1",
-        Parameters: 0,
-        ResultPath: "$.a",
-        Type: "Pass",
-      },
-      "a = -1": {
-        Next: "a = -100",
-        Parameters: -1,
-        ResultPath: "$.a",
-        Type: "Pass",
-      },
-      "a = -100": {
-        Next: "a = 1 + 2",
-        Parameters: -100,
-        ResultPath: "$.a",
-        Type: "Pass",
-      },
-      "a = 1 + 2": {
-        Next: 'a = "hello"',
-        Parameters: 3,
-        ResultPath: "$.a",
-        Type: "Pass",
-      },
-      'a = "hello"': {
-        Next: 'a = "hello" + " world"',
-        Parameters: "hello",
-        ResultPath: "$.a",
-        Type: "Pass",
-      },
-      'a = "hello" + " world"': {
-        Next: 'a = "hello" + 1',
-        Parameters: "hello world",
-        ResultPath: "$.a",
-        Type: "Pass",
-      },
-      'a = "hello" + 1': {
-        Next: 'a = 1 + "hello"',
-        Parameters: "hello1",
-        ResultPath: "$.a",
-        Type: "Pass",
-      },
-      'a = 1 + "hello"': {
-        Next: 'a = "hello" + true',
-        Parameters: "1hello",
-        ResultPath: "$.a",
-        Type: "Pass",
-      },
-      'a = "hello" + true': {
-        Next: 'a = false + "hello"',
-        Parameters: "hellotrue",
-        ResultPath: "$.a",
-        Type: "Pass",
-      },
-      'a = false + "hello"': {
-        Next: 'a = null + "hello"',
-        Parameters: "falsehello",
-        ResultPath: "$.a",
-        Type: "Pass",
-      },
-      'a = null + "hello"': {
-        Next: 'a = "hello" + null',
-        Parameters: "nullhello",
-        ResultPath: "$.a",
-        Type: "Pass",
-      },
-      'a = "hello" + null': {
-        Next: "a = [null]",
-        Parameters: "hellonull",
-        ResultPath: "$.a",
-        Type: "Pass",
-      },
-      "a = [null]": {
-        Next: "a = [1]",
-        Parameters: [null],
-        ResultPath: "$.a",
-        Type: "Pass",
-      },
-      "a = [1]": {
-        Next: "a = [-1]",
-        Parameters: [1],
-        ResultPath: "$.a",
-        Type: "Pass",
-      },
-      "a = [-1]": {
-        Next: "a = [true]",
-        Parameters: [-1],
-        ResultPath: "$.a",
-        Type: "Pass",
-      },
-      "a = [true]": {
-        Next: 'a = [{key: "value"}]',
-        Parameters: [true],
-        ResultPath: "$.a",
-        Type: "Pass",
-      },
-      'a = [{key: "value"}]': {
-        Next: 'a = {key: "value"}',
-        Parameters: [
-          {
-            key: "value",
-          },
-        ],
-        ResultPath: "$.a",
-        Type: "Pass",
-      },
-      'a = {key: "value"}': {
-        Next: "a = a",
-        Parameters: {
-          key: "value",
-        },
-        ResultPath: "$.a",
-        Type: "Pass",
-      },
-      "a = a": {
-        InputPath: "$.a",
-        Next: 'a = "hello" + {place: "world"}',
-        ResultPath: "$.a",
-        Type: "Pass",
-      },
-      'a = "hello" + {place: "world"}': {
-        Next: 'a = "hello" + ["world"]',
-        Parameters: "hello[object Object]",
-        ResultPath: "$.a",
-        Type: "Pass",
-      },
-      'a = "hello" + ["world"]': {
-        Next: "return a",
-        Parameters: "helloworld",
-        ResultPath: "$.a",
-        Type: "Pass",
-      },
-      "return a": {
-        End: true,
-        OutputPath: "$.a",
-        Type: "Pass",
-      },
-    },
-  });
+  expect(normalizeDefinition(definition)).toMatchSnapshot();
 });
 
 test("task(any)", () => {
@@ -487,278 +264,7 @@ test("task(any)", () => {
     task("hello" + ["world"]);
   }).definition;
 
-  expect(definition).toEqual({
-    StartAt: "task(null)",
-    States: {
-      "return null": {
-        End: true,
-        OutputPath: "$.null",
-        Parameters: {
-          null: null,
-        },
-        Type: "Pass",
-      },
-      'task("hello" + " world")': {
-        Next: 'task("hello" + 1)',
-        Parameters: {
-          FunctionName: task.resource.functionName,
-          Payload: "hello world",
-        },
-        Resource: "arn:aws:states:::lambda:invoke",
-        ResultPath: null,
-        ResultSelector: "$.Payload",
-        Type: "Task",
-      },
-      'task("hello" + 1)': {
-        Next: 'task(1 + "hello")',
-        Parameters: {
-          FunctionName: task.resource.functionName,
-          Payload: "hello1",
-        },
-        Resource: "arn:aws:states:::lambda:invoke",
-        ResultPath: null,
-        ResultSelector: "$.Payload",
-        Type: "Task",
-      },
-      'task("hello" + null)': {
-        Next: "task([null])",
-        Parameters: {
-          FunctionName: task.resource.functionName,
-          Payload: "hellonull",
-        },
-        Resource: "arn:aws:states:::lambda:invoke",
-        ResultPath: null,
-        ResultSelector: "$.Payload",
-        Type: "Task",
-      },
-      'task("hello" + true)': {
-        Next: 'task(false + "hello")',
-        Parameters: {
-          FunctionName: task.resource.functionName,
-          Payload: "hellotrue",
-        },
-        Resource: "arn:aws:states:::lambda:invoke",
-        ResultPath: null,
-        ResultSelector: "$.Payload",
-        Type: "Task",
-      },
-      'task("hello")': {
-        Next: 'task("hello" + " world")',
-        Parameters: {
-          FunctionName: task.resource.functionName,
-          Payload: "hello",
-        },
-        Resource: "arn:aws:states:::lambda:invoke",
-        ResultPath: null,
-        ResultSelector: "$.Payload",
-        Type: "Task",
-      },
-      "task(-1)": {
-        Next: "task(-100)",
-        Parameters: {
-          FunctionName: task.resource.functionName,
-          Payload: -1,
-        },
-        Resource: "arn:aws:states:::lambda:invoke",
-        ResultPath: null,
-        ResultSelector: "$.Payload",
-        Type: "Task",
-      },
-      "task(-100)": {
-        Next: "task(1 + 2)",
-        Parameters: {
-          FunctionName: task.resource.functionName,
-          Payload: -100,
-        },
-        Resource: "arn:aws:states:::lambda:invoke",
-        ResultPath: null,
-        ResultSelector: "$.Payload",
-        Type: "Task",
-      },
-      "task(0)": {
-        Next: "task(-1)",
-        Parameters: {
-          FunctionName: task.resource.functionName,
-          Payload: 0,
-        },
-        Resource: "arn:aws:states:::lambda:invoke",
-        ResultPath: null,
-        ResultSelector: "$.Payload",
-        Type: "Task",
-      },
-      'task(1 + "hello")': {
-        Next: 'task("hello" + true)',
-        Parameters: {
-          FunctionName: task.resource.functionName,
-          Payload: "1hello",
-        },
-        Resource: "arn:aws:states:::lambda:invoke",
-        ResultPath: null,
-        ResultSelector: "$.Payload",
-        Type: "Task",
-      },
-      "task(1 + 2)": {
-        Next: 'task("hello")',
-        Parameters: {
-          FunctionName: task.resource.functionName,
-          Payload: 3,
-        },
-        Resource: "arn:aws:states:::lambda:invoke",
-        ResultPath: null,
-        ResultSelector: "$.Payload",
-        Type: "Task",
-      },
-      "task([-1])": {
-        Next: "task([true])",
-        Parameters: {
-          FunctionName: task.resource.functionName,
-          Payload: [-1],
-        },
-        Resource: "arn:aws:states:::lambda:invoke",
-        ResultPath: null,
-        ResultSelector: "$.Payload",
-        Type: "Task",
-      },
-      "task([1])": {
-        Next: "task([-1])",
-        Parameters: {
-          FunctionName: task.resource.functionName,
-          Payload: [1],
-        },
-        Resource: "arn:aws:states:::lambda:invoke",
-        ResultPath: null,
-        ResultSelector: "$.Payload",
-        Type: "Task",
-      },
-      "task([null])": {
-        Next: "task([1])",
-        Parameters: {
-          FunctionName: task.resource.functionName,
-          Payload: [null],
-        },
-        Resource: "arn:aws:states:::lambda:invoke",
-        ResultPath: null,
-        ResultSelector: "$.Payload",
-        Type: "Task",
-      },
-      "task([true])": {
-        Next: 'task([{key: "value"}])',
-        Parameters: {
-          FunctionName: task.resource.functionName,
-          Payload: [true],
-        },
-        Resource: "arn:aws:states:::lambda:invoke",
-        ResultPath: null,
-        ResultSelector: "$.Payload",
-        Type: "Task",
-      },
-      'task([{key: "value"}])': {
-        Next: 'task({key: "value"})',
-        Parameters: {
-          FunctionName: task.resource.functionName,
-          Payload: [
-            {
-              key: "value",
-            },
-          ],
-        },
-        Resource: "arn:aws:states:::lambda:invoke",
-        ResultPath: null,
-        ResultSelector: "$.Payload",
-        Type: "Task",
-      },
-      'task(false + "hello")': {
-        Next: 'task(null + "hello")',
-        Parameters: {
-          FunctionName: task.resource.functionName,
-          Payload: "falsehello",
-        },
-        Resource: "arn:aws:states:::lambda:invoke",
-        ResultPath: null,
-        ResultSelector: "$.Payload",
-        Type: "Task",
-      },
-      "task(false)": {
-        Next: "task(0)",
-        Parameters: {
-          FunctionName: task.resource.functionName,
-          Payload: false,
-        },
-        Resource: "arn:aws:states:::lambda:invoke",
-        ResultPath: null,
-        ResultSelector: "$.Payload",
-        Type: "Task",
-      },
-      'task(null + "hello")': {
-        Next: 'task("hello" + null)',
-        Parameters: {
-          FunctionName: task.resource.functionName,
-          Payload: "nullhello",
-        },
-        Resource: "arn:aws:states:::lambda:invoke",
-        ResultPath: null,
-        ResultSelector: "$.Payload",
-        Type: "Task",
-      },
-      "task(null)": {
-        Next: "task(true)",
-        Parameters: {
-          FunctionName: task.resource.functionName,
-          Payload: null,
-        },
-        Resource: "arn:aws:states:::lambda:invoke",
-        ResultPath: null,
-        ResultSelector: "$.Payload",
-        Type: "Task",
-      },
-      "task(true)": {
-        Next: "task(false)",
-        Parameters: {
-          FunctionName: task.resource.functionName,
-          Payload: true,
-        },
-        Resource: "arn:aws:states:::lambda:invoke",
-        ResultPath: null,
-        ResultSelector: "$.Payload",
-        Type: "Task",
-      },
-      'task({key: "value"})': {
-        Next: 'task("hello" + {place: "world"})',
-        Parameters: {
-          FunctionName: task.resource.functionName,
-          Payload: {
-            key: "value",
-          },
-        },
-        Resource: "arn:aws:states:::lambda:invoke",
-        ResultPath: null,
-        ResultSelector: "$.Payload",
-        Type: "Task",
-      },
-      'task("hello" + {place: "world"})': {
-        Next: 'task("hello" + ["world"])',
-        Parameters: {
-          FunctionName: task.resource.functionName,
-          Payload: "hello[object Object]",
-        },
-        Resource: "arn:aws:states:::lambda:invoke",
-        ResultPath: null,
-        ResultSelector: "$.Payload",
-        Type: "Task",
-      },
-      'task("hello" + ["world"])': {
-        Next: "return null",
-        Parameters: {
-          FunctionName: task.resource.functionName,
-          Payload: "helloworld",
-        },
-        Resource: "arn:aws:states:::lambda:invoke",
-        ResultPath: null,
-        ResultSelector: "$.Payload",
-        Type: "Task",
-      },
-    },
-  });
+  expect(normalizeDefinition(definition)).toMatchSnapshot();
 });
 
 test("spread constant array and object", () => {
@@ -775,24 +281,7 @@ test("spread constant array and object", () => {
     };
   }).definition;
 
-  expect(definition).toEqual({
-    StartAt:
-      'return {array: [0, ...array, 3], object: {key: "value", ...object}}',
-    States: {
-      'return {array: [0, ...array, 3], object: {key: "value", ...object}}': {
-        End: true,
-        Parameters: {
-          array: [0, 1, 2, 3],
-          object: {
-            hello: "world",
-            key: "value",
-          },
-        },
-        ResultPath: "$",
-        Type: "Pass",
-      },
-    },
-  });
+  expect(normalizeDefinition(definition)).toMatchSnapshot();
 });
 
 test("return void", () => {
@@ -829,38 +318,7 @@ test("conditionally return void", () => {
     }
   ).definition;
 
-  expect(definition).toEqual({
-    StartAt: 'if(input.id == "hello")',
-    States: {
-      'if(input.id == "hello")': {
-        Choices: [
-          {
-            Next: "return null",
-            StringEquals: "hello",
-            Variable: "$.id",
-          },
-        ],
-        Default: "return null 1",
-        Type: "Choice",
-      },
-      "return null": {
-        End: true,
-        OutputPath: "$.null",
-        Parameters: {
-          null: null,
-        },
-        Type: "Pass",
-      },
-      "return null 1": {
-        End: true,
-        OutputPath: "$.null",
-        Parameters: {
-          null: null,
-        },
-        Type: "Pass",
-      },
-    },
-  });
+  expect(normalizeDefinition(definition)).toMatchSnapshot();
 });
 
 test("if-else", () => {
@@ -877,34 +335,7 @@ test("if-else", () => {
     }
   ).definition;
 
-  expect(definition).toEqual({
-    StartAt: 'if(input.id == "hello")',
-    States: {
-      'if(input.id == "hello")': {
-        Choices: [
-          {
-            Next: 'return "hello"',
-            StringEquals: "hello",
-            Variable: "$.id",
-          },
-        ],
-        Default: 'return "world"',
-        Type: "Choice",
-      },
-      'return "world"': {
-        End: true,
-        Result: "world",
-        ResultPath: "$",
-        Type: "Pass",
-      },
-      'return "hello"': {
-        End: true,
-        Result: "hello",
-        ResultPath: "$",
-        Type: "Pass",
-      },
-    },
-  });
+  expect(normalizeDefinition(definition)).toMatchSnapshot();
 });
 
 test("if (typeof x === ??)", () => {
@@ -930,131 +361,7 @@ test("if (typeof x === ??)", () => {
     }
   ).definition;
 
-  expect(definition).toEqual({
-    StartAt: "if(input.id == undefined)",
-    States: {
-      "if(input.id == undefined)": {
-        Choices: [
-          {
-            Next: 'return "null"',
-            Or: [
-              {
-                IsPresent: false,
-                Variable: "$.id",
-              },
-              {
-                IsNull: true,
-                Variable: "$.id",
-              },
-            ],
-          },
-          {
-            IsPresent: false,
-            Next: 'return "undefined"',
-            Variable: "$.id",
-          },
-          {
-            And: [
-              {
-                IsPresent: true,
-                Variable: "$.id",
-              },
-              {
-                IsString: true,
-                Variable: "$.id",
-              },
-            ],
-            Next: 'return "string"',
-          },
-          {
-            And: [
-              {
-                IsPresent: true,
-                Variable: "$.id",
-              },
-              {
-                IsBoolean: true,
-                Variable: "$.id",
-              },
-            ],
-            Next: 'return "boolean"',
-          },
-          {
-            And: [
-              {
-                IsPresent: true,
-                Variable: "$.id",
-              },
-              {
-                IsNumeric: true,
-                Variable: "$.id",
-              },
-            ],
-            Next: 'return "number"',
-          },
-          {
-            And: [
-              {
-                IsPresent: true,
-                Variable: "$.id",
-              },
-              {
-                IsNumeric: true,
-                Variable: "$.id",
-              },
-            ],
-            Next: 'return "bigint"',
-          },
-        ],
-        Default: "return null",
-        Type: "Choice",
-      },
-      'return "bigint"': {
-        End: true,
-        Result: "bigint",
-        ResultPath: "$",
-        Type: "Pass",
-      },
-      'return "boolean"': {
-        End: true,
-        Result: "boolean",
-        ResultPath: "$",
-        Type: "Pass",
-      },
-      'return "null"': {
-        End: true,
-        Result: "null",
-        ResultPath: "$",
-        Type: "Pass",
-      },
-      'return "number"': {
-        End: true,
-        Result: "number",
-        ResultPath: "$",
-        Type: "Pass",
-      },
-      'return "string"': {
-        End: true,
-        Result: "string",
-        ResultPath: "$",
-        Type: "Pass",
-      },
-      'return "undefined"': {
-        End: true,
-        Result: "undefined",
-        ResultPath: "$",
-        Type: "Pass",
-      },
-      "return null": {
-        End: true,
-        OutputPath: "$.null",
-        Parameters: {
-          null: null,
-        },
-        Type: "Pass",
-      },
-    },
-  });
+  expect(normalizeDefinition(definition)).toMatchSnapshot();
 });
 
 let stack: Stack;
@@ -1085,39 +392,7 @@ test("put an event bus event", () => {
     }
   ).definition;
 
-  expect(definition).toEqual({
-    StartAt:
-      'bus.putEvents({detail-type: "someEvent", source: "sfnTest", detail: {value:',
-    States: {
-      'bus.putEvents({detail-type: "someEvent", source: "sfnTest", detail: {value:':
-        {
-          Type: "Task",
-          Resource: "arn:aws:states:::events:putEvents",
-          Next: "return null",
-          Parameters: {
-            Entries: [
-              {
-                Detail: {
-                  "value.$": "$.id",
-                },
-                DetailType: "someEvent",
-                EventBusName: bus.bus.eventBusArn,
-                Source: "sfnTest",
-              },
-            ],
-          },
-          ResultPath: null,
-        },
-      "return null": {
-        End: true,
-        OutputPath: "$.null",
-        Parameters: {
-          null: null,
-        },
-        Type: "Pass",
-      },
-    },
-  });
+  expect(normalizeDefinition(definition)).toMatchSnapshot();
 });
 
 test("put multiple event bus events", () => {
@@ -1153,48 +428,7 @@ test("put multiple event bus events", () => {
     }
   ).definition;
 
-  expect(definition).toEqual({
-    StartAt:
-      'bus.putEvents({detail-type: "someEvent", source: "sfnTest", detail: {value:',
-    States: {
-      'bus.putEvents({detail-type: "someEvent", source: "sfnTest", detail: {value:':
-        {
-          Type: "Task",
-          Resource: "arn:aws:states:::events:putEvents",
-          Next: "return null",
-          Parameters: {
-            Entries: [
-              {
-                Detail: {
-                  "value.$": "$.id",
-                },
-                DetailType: "someEvent",
-                EventBusName: bus.bus.eventBusArn,
-                Source: "sfnTest",
-              },
-              {
-                Detail: {
-                  constant: "hi",
-                  "value.$": "$.id",
-                },
-                DetailType: "someOtherEvent",
-                EventBusName: bus.bus.eventBusArn,
-                Source: "sfnTest",
-              },
-            ],
-          },
-          ResultPath: null,
-        },
-      "return null": {
-        End: true,
-        OutputPath: "$.null",
-        Parameters: {
-          null: null,
-        },
-        Type: "Pass",
-      },
-    },
-  });
+  expect(normalizeDefinition(definition)).toMatchSnapshot();
 });
 
 test("if (typeof x !== ??)", () => {
@@ -1219,131 +453,7 @@ test("if (typeof x !== ??)", () => {
     }
   ).definition;
 
-  expect(definition).toEqual({
-    StartAt: "if(input.id != undefined)",
-    States: {
-      "if(input.id != undefined)": {
-        Choices: [
-          {
-            And: [
-              {
-                IsPresent: true,
-                Variable: "$.id",
-              },
-              {
-                IsNull: false,
-                Variable: "$.id",
-              },
-            ],
-            Next: 'return "null"',
-          },
-          {
-            IsPresent: true,
-            Next: 'return "undefined"',
-            Variable: "$.id",
-          },
-          {
-            Next: 'return "string"',
-            Or: [
-              {
-                IsPresent: false,
-                Variable: "$.id",
-              },
-              {
-                IsString: false,
-                Variable: "$.id",
-              },
-            ],
-          },
-          {
-            Next: 'return "boolean"',
-            Or: [
-              {
-                IsPresent: false,
-                Variable: "$.id",
-              },
-              {
-                IsBoolean: false,
-                Variable: "$.id",
-              },
-            ],
-          },
-          {
-            Next: 'return "number"',
-            Or: [
-              {
-                IsPresent: false,
-                Variable: "$.id",
-              },
-              {
-                IsNumeric: false,
-                Variable: "$.id",
-              },
-            ],
-          },
-          {
-            Next: 'return "bigint"',
-            Or: [
-              {
-                IsPresent: false,
-                Variable: "$.id",
-              },
-              {
-                IsNumeric: false,
-                Variable: "$.id",
-              },
-            ],
-          },
-        ],
-        Default: "return null",
-        Type: "Choice",
-      },
-      'return "bigint"': {
-        End: true,
-        Result: "bigint",
-        ResultPath: "$",
-        Type: "Pass",
-      },
-      'return "boolean"': {
-        End: true,
-        Result: "boolean",
-        ResultPath: "$",
-        Type: "Pass",
-      },
-      'return "null"': {
-        End: true,
-        Result: "null",
-        ResultPath: "$",
-        Type: "Pass",
-      },
-      'return "number"': {
-        End: true,
-        Result: "number",
-        ResultPath: "$",
-        Type: "Pass",
-      },
-      'return "string"': {
-        End: true,
-        Result: "string",
-        ResultPath: "$",
-        Type: "Pass",
-      },
-      'return "undefined"': {
-        End: true,
-        Result: "undefined",
-        ResultPath: "$",
-        Type: "Pass",
-      },
-      "return null": {
-        End: true,
-        OutputPath: "$.null",
-        Parameters: {
-          null: null,
-        },
-        Type: "Pass",
-      },
-    },
-  });
+  expect(normalizeDefinition(definition)).toMatchSnapshot();
 });
 
 test("if-else-if", () => {
@@ -1361,47 +471,7 @@ test("if-else-if", () => {
     }
   ).definition;
 
-  expect(definition).toEqual({
-    StartAt: 'if(input.id == "hello")',
-    States: {
-      'if(input.id == "hello")': {
-        Choices: [
-          {
-            Next: 'return "hello"',
-            StringEquals: "hello",
-            Variable: "$.id",
-          },
-          {
-            Next: 'return "world"',
-            StringEquals: "world",
-            Variable: "$.id",
-          },
-        ],
-        Default: "return null",
-        Type: "Choice",
-      },
-      'return "hello"': {
-        End: true,
-        Result: "hello",
-        ResultPath: "$",
-        Type: "Pass",
-      },
-      'return "world"': {
-        End: true,
-        Result: "world",
-        ResultPath: "$",
-        Type: "Pass",
-      },
-      "return null": {
-        Type: "Pass",
-        End: true,
-        Parameters: {
-          null: null,
-        },
-        OutputPath: "$.null",
-      },
-    },
-  });
+  expect(normalizeDefinition(definition)).toMatchSnapshot();
 });
 
 test("for-loop and do nothing", () => {
@@ -1470,45 +540,7 @@ test("for i in items, items[i]", () => {
     }
   ).definition;
 
-  expect(definition).toEqual({
-    StartAt: "for(i in input.items)",
-    States: {
-      "for(i in input.items)": {
-        ItemsPath: "$.items",
-        Iterator: {
-          StartAt: "a = items[i]",
-          States: {
-            "a = items[i]": {
-              End: true,
-              OutputPath: "$.result",
-              Parameters: {
-                "result.$": "$.0_i",
-              },
-              ResultPath: "$.a",
-              Type: "Pass",
-            },
-          },
-        },
-        MaxConcurrency: 1,
-        Next: "return null",
-        Parameters: {
-          // special prefixed value so that we can index the
-          "0_i.$": "$$.Map.Item.Value",
-          "i.$": "$$.Map.Item.Index",
-        },
-        ResultPath: null,
-        Type: "Map",
-      },
-      "return null": {
-        End: true,
-        OutputPath: "$.null",
-        Parameters: {
-          null: null,
-        },
-        Type: "Pass",
-      },
-    },
-  });
+  expect(normalizeDefinition(definition)).toMatchSnapshot();
 });
 
 test("return a single Lambda Function call", () => {
@@ -1520,24 +552,7 @@ test("return a single Lambda Function call", () => {
     return getPerson({ id: input.id });
   }).definition;
 
-  expect(definition).toEqual({
-    StartAt: "return getPerson({id: input.id})",
-    States: {
-      "return getPerson({id: input.id})": {
-        Type: "Task",
-        Resource: "arn:aws:states:::lambda:invoke",
-        End: true,
-        ResultPath: "$",
-        ResultSelector: "$.Payload",
-        Parameters: {
-          FunctionName: getPerson.resource.functionName,
-          Payload: {
-            "id.$": "$.id",
-          },
-        },
-      },
-    },
-  });
+  expect(normalizeDefinition(definition)).toMatchSnapshot();
 });
 
 test("task(-1)", () => {
@@ -1550,22 +565,7 @@ test("task(-1)", () => {
     }
   ).definition;
 
-  expect(definition).toEqual({
-    StartAt: "return task(-1)",
-    States: {
-      "return task(-1)": {
-        Type: "Task",
-        Resource: "arn:aws:states:::lambda:invoke",
-        End: true,
-        ResultPath: "$",
-        ResultSelector: "$.Payload",
-        Parameters: {
-          FunctionName: task.resource.functionName,
-          Payload: -1,
-        },
-      },
-    },
-  });
+  expect(normalizeDefinition(definition)).toMatchSnapshot();
 });
 
 test("task(input.list[-1])", () => {
@@ -1578,22 +578,7 @@ test("task(input.list[-1])", () => {
     }
   ).definition;
 
-  expect(definition).toEqual({
-    StartAt: "return task(input.list[-1])",
-    States: {
-      "return task(input.list[-1])": {
-        Type: "Task",
-        Resource: "arn:aws:states:::lambda:invoke",
-        End: true,
-        ResultPath: "$",
-        ResultSelector: "$.Payload",
-        Parameters: {
-          FunctionName: task.resource.functionName,
-          "Payload.$": "$.list[-1]",
-        },
-      },
-    },
-  });
+  expect(normalizeDefinition(definition)).toMatchSnapshot();
 });
 
 test("call Lambda Function, store as variable, return variable", () => {
@@ -1606,29 +591,7 @@ test("call Lambda Function, store as variable, return variable", () => {
     return person;
   }).definition;
 
-  expect(definition).toEqual({
-    StartAt: "person = getPerson({id: input.id})",
-    States: {
-      "person = getPerson({id: input.id})": {
-        Type: "Task",
-        Resource: "arn:aws:states:::lambda:invoke",
-        ResultPath: "$.person",
-        ResultSelector: "$.Payload",
-        Parameters: {
-          FunctionName: getPerson.resource.functionName,
-          Payload: {
-            "id.$": "$.id",
-          },
-        },
-        Next: "return person",
-      },
-      "return person": {
-        Type: "Pass",
-        OutputPath: "$.person",
-        End: true,
-      },
-    },
-  });
+  expect(normalizeDefinition(definition)).toMatchSnapshot();
 });
 
 test("return AWS.DynamoDB.GetItem", () => {
@@ -1960,24 +923,7 @@ test("waitFor literal number of seconds", () => {
     $SFN.waitFor(1);
   }).definition;
 
-  expect(definition).toEqual({
-    StartAt: "$SFN.waitFor(1)",
-    States: {
-      "$SFN.waitFor(1)": {
-        Next: "return null",
-        Seconds: 1,
-        Type: "Wait",
-      },
-      "return null": {
-        End: true,
-        OutputPath: "$.null",
-        Parameters: {
-          null: null,
-        },
-        Type: "Pass",
-      },
-    },
-  });
+  expect(normalizeDefinition(definition)).toMatchSnapshot();
 });
 
 test("waitFor reference number of seconds", () => {
@@ -1990,24 +936,7 @@ test("waitFor reference number of seconds", () => {
     $SFN.waitFor(input.seconds);
   }).definition;
 
-  expect(definition).toEqual({
-    StartAt: "$SFN.waitFor(input.seconds)",
-    States: {
-      "$SFN.waitFor(input.seconds)": {
-        Next: "return null",
-        SecondsPath: "$.seconds",
-        Type: "Wait",
-      },
-      "return null": {
-        End: true,
-        OutputPath: "$.null",
-        Parameters: {
-          null: null,
-        },
-        Type: "Pass",
-      },
-    },
-  });
+  expect(normalizeDefinition(definition)).toMatchSnapshot();
 });
 test("waitFor literal timestamp", () => {
   const { stack } = initStepFunctionApp();
@@ -2016,24 +945,7 @@ test("waitFor literal timestamp", () => {
     $SFN.waitUntil("2022-08-01T00:00:00Z");
   }).definition;
 
-  expect(definition).toEqual({
-    StartAt: '$SFN.waitUntil("2022-08-01T00:00:00Z")',
-    States: {
-      '$SFN.waitUntil("2022-08-01T00:00:00Z")': {
-        Next: "return null",
-        Timestamp: "2022-08-01T00:00:00Z",
-        Type: "Wait",
-      },
-      "return null": {
-        End: true,
-        OutputPath: "$.null",
-        Parameters: {
-          null: null,
-        },
-        Type: "Pass",
-      },
-    },
-  });
+  expect(normalizeDefinition(definition)).toMatchSnapshot();
 });
 
 test("waitUntil reference timestamp", () => {
@@ -2047,24 +959,7 @@ test("waitUntil reference timestamp", () => {
     }
   ).definition;
 
-  expect(definition).toEqual({
-    StartAt: "$SFN.waitUntil(input.until)",
-    States: {
-      "$SFN.waitUntil(input.until)": {
-        Next: "return null",
-        TimestampPath: "$.until",
-        Type: "Wait",
-      },
-      "return null": {
-        End: true,
-        OutputPath: "$.null",
-        Parameters: {
-          null: null,
-        },
-        Type: "Pass",
-      },
-    },
-  });
+  expect(normalizeDefinition(definition)).toMatchSnapshot();
 });
 
 test("throw new Error", () => {
@@ -2074,16 +969,7 @@ test("throw new Error", () => {
     throw new Error("cause");
   }).definition;
 
-  expect(definition).toEqual({
-    StartAt: 'throw new Error("cause")',
-    States: {
-      'throw new Error("cause")': {
-        Type: "Fail",
-        Error: "Error",
-        Cause: '{"message":"cause"}',
-      },
-    },
-  });
+  expect(normalizeDefinition(definition)).toMatchSnapshot();
 });
 
 test("throw Error", () => {
@@ -2093,16 +979,7 @@ test("throw Error", () => {
     throw Error("cause");
   }).definition;
 
-  expect(definition).toEqual({
-    StartAt: 'throw Error("cause")',
-    States: {
-      'throw Error("cause")': {
-        Type: "Fail",
-        Error: "Error",
-        Cause: '{"message":"cause"}',
-      },
-    },
-  });
+  expect(normalizeDefinition(definition)).toMatchSnapshot();
 });
 
 class CustomError {
@@ -2116,16 +993,7 @@ test("throw new CustomError", () => {
     throw new CustomError("cause");
   }).definition;
 
-  expect(definition).toEqual({
-    StartAt: 'throw new CustomError("cause")',
-    States: {
-      'throw new CustomError("cause")': {
-        Type: "Fail",
-        Error: "CustomError",
-        Cause: '{"property":"cause"}',
-      },
-    },
-  });
+  expect(normalizeDefinition(definition)).toMatchSnapshot();
 });
 
 test("try, throw Error('error'), empty catch", () => {
@@ -2137,27 +1005,7 @@ test("try, throw Error('error'), empty catch", () => {
     } catch {}
   }).definition;
 
-  expect(definition).toEqual({
-    StartAt: 'throw Error("cause")',
-    States: {
-      'throw Error("cause")': {
-        Next: "return null",
-        Result: {
-          message: "cause",
-        },
-        ResultPath: null,
-        Type: "Pass",
-      },
-      "return null": {
-        End: true,
-        OutputPath: "$.null",
-        Parameters: {
-          null: null,
-        },
-        Type: "Pass",
-      },
-    },
-  });
+  expect(normalizeDefinition(definition)).toMatchSnapshot();
 });
 
 test("try, throw, empty catch", () => {
@@ -2169,27 +1017,7 @@ test("try, throw, empty catch", () => {
     } catch {}
   }).definition;
 
-  expect(definition).toEqual({
-    StartAt: 'throw new CustomError("cause")',
-    States: {
-      'throw new CustomError("cause")': {
-        Next: "return null",
-        Result: {
-          property: "cause",
-        },
-        ResultPath: null,
-        Type: "Pass",
-      },
-      "return null": {
-        End: true,
-        OutputPath: "$.null",
-        Parameters: {
-          null: null,
-        },
-        Type: "Pass",
-      },
-    },
-  });
+  expect(normalizeDefinition(definition)).toMatchSnapshot();
 });
 
 test("try, task, empty catch", () => {
@@ -2204,40 +1032,7 @@ test("try, task, empty catch", () => {
     } catch {}
   }).definition;
 
-  expect(definition).toEqual({
-    StartAt: 'computeScore({id: "id", name: "name"})',
-    States: {
-      'computeScore({id: "id", name: "name"})': {
-        Catch: [
-          {
-            ErrorEquals: ["States.ALL"],
-            Next: "return null",
-            ResultPath: null,
-          },
-        ],
-        Next: "return null",
-        ResultSelector: "$.Payload",
-        Parameters: {
-          FunctionName: computeScore.resource.functionName,
-          Payload: {
-            id: "id",
-            name: "name",
-          },
-        },
-        Resource: "arn:aws:states:::lambda:invoke",
-        ResultPath: null,
-        Type: "Task",
-      },
-      "return null": {
-        End: true,
-        OutputPath: "$.null",
-        Parameters: {
-          null: null,
-        },
-        Type: "Pass",
-      },
-    },
-  });
+  expect(normalizeDefinition(definition)).toMatchSnapshot();
 });
 
 test("catch and throw new Error", () => {
@@ -2251,24 +1046,7 @@ test("catch and throw new Error", () => {
     }
   }).definition;
 
-  expect(definition).toEqual({
-    StartAt: 'throw new Error("cause")',
-    States: {
-      'throw new Error("cause")': {
-        Type: "Pass",
-        Result: {
-          message: "cause",
-        },
-        ResultPath: "$.err",
-        Next: 'throw new CustomError("custom cause")',
-      },
-      'throw new CustomError("custom cause")': {
-        Type: "Fail",
-        Error: "CustomError",
-        Cause: '{"property":"custom cause"}',
-      },
-    },
-  });
+  expect(normalizeDefinition(definition)).toMatchSnapshot();
 });
 
 test("catch and throw Error", () => {
@@ -2282,24 +1060,7 @@ test("catch and throw Error", () => {
     }
   }).definition;
 
-  expect(definition).toEqual({
-    StartAt: 'throw Error("cause")',
-    States: {
-      'throw Error("cause")': {
-        Type: "Pass",
-        Result: {
-          message: "cause",
-        },
-        ResultPath: "$.err",
-        Next: 'throw new CustomError("custom cause")',
-      },
-      'throw new CustomError("custom cause")': {
-        Type: "Fail",
-        Error: "CustomError",
-        Cause: '{"property":"custom cause"}',
-      },
-    },
-  });
+  expect(normalizeDefinition(definition)).toMatchSnapshot();
 });
 
 test("try-catch with inner return and no catch variable", () => {
@@ -2317,45 +1078,7 @@ test("try-catch with inner return and no catch variable", () => {
     }
   }).definition;
 
-  expect(definition).toEqual({
-    StartAt: 'computeScore({id: "id", name: "name"})',
-    States: {
-      'computeScore({id: "id", name: "name"})': {
-        Type: "Task",
-
-        ResultSelector: "$.Payload",
-        Parameters: {
-          FunctionName: computeScore.resource.functionName,
-          Payload: {
-            id: "id",
-            name: "name",
-          },
-        },
-        Resource: "arn:aws:states:::lambda:invoke",
-        ResultPath: null,
-        Catch: [
-          {
-            ErrorEquals: ["States.ALL"],
-            Next: 'return "world"',
-            ResultPath: null,
-          },
-        ],
-        Next: 'return "hello"',
-      },
-      'return "hello"': {
-        End: true,
-        Result: "hello",
-        ResultPath: "$",
-        Type: "Pass",
-      },
-      'return "world"': {
-        End: true,
-        Result: "world",
-        ResultPath: "$",
-        Type: "Pass",
-      },
-    },
-  });
+  expect(normalizeDefinition(definition)).toMatchSnapshot();
 });
 
 test("try-catch with inner return and a catch variable", () => {
@@ -2373,57 +1096,7 @@ test("try-catch with inner return and a catch variable", () => {
     }
   }).definition;
 
-  expect(definition).toEqual({
-    StartAt: 'computeScore({id: "id", name: "name"})',
-    States: {
-      'computeScore({id: "id", name: "name"})': {
-        Catch: [
-          {
-            ErrorEquals: ["States.ALL"],
-            Next: "catch(err)",
-            ResultPath: "$.err",
-          },
-        ],
-        Next: 'return "hello"',
-        ResultSelector: "$.Payload",
-        Parameters: {
-          FunctionName: computeScore.resource.functionName,
-          Payload: {
-            id: "id",
-            name: "name",
-          },
-        },
-        Resource: "arn:aws:states:::lambda:invoke",
-        ResultPath: null,
-        Type: "Task",
-      },
-      "catch(err)": {
-        Next: "0_catch(err)",
-        Parameters: {
-          "0_ParsedError.$": "States.StringToJson($.err.Cause)",
-        },
-        ResultPath: "$.err",
-        Type: "Pass",
-      },
-      "0_catch(err)": {
-        InputPath: "$.err.0_ParsedError",
-        Next: "return err.message",
-        ResultPath: "$.err",
-        Type: "Pass",
-      },
-      'return "hello"': {
-        End: true,
-        Result: "hello",
-        ResultPath: "$",
-        Type: "Pass",
-      },
-      "return err.message": {
-        End: true,
-        OutputPath: "$.err.message",
-        Type: "Pass",
-      },
-    },
-  });
+  expect(normalizeDefinition(definition)).toMatchSnapshot();
 });
 
 test("try-catch with guaranteed throw new Error", () => {
@@ -2441,42 +1114,7 @@ test("try-catch with guaranteed throw new Error", () => {
     }
   }).definition;
 
-  expect(definition).toEqual({
-    StartAt: 'throw new Error("cause")',
-    States: {
-      'throw new Error("cause")': {
-        Type: "Pass",
-        Next: 'if(err.message == "cause")',
-        Result: {
-          message: "cause",
-        },
-        ResultPath: "$.err",
-      },
-      'if(err.message == "cause")': {
-        Choices: [
-          {
-            Next: 'return "hello"',
-            StringEquals: "cause",
-            Variable: "$.err.message",
-          },
-        ],
-        Default: 'return "world"',
-        Type: "Choice",
-      },
-      'return "hello"': {
-        End: true,
-        Result: "hello",
-        ResultPath: "$",
-        Type: "Pass",
-      },
-      'return "world"': {
-        End: true,
-        Result: "world",
-        ResultPath: "$",
-        Type: "Pass",
-      },
-    },
-  });
+  expect(normalizeDefinition(definition)).toMatchSnapshot();
 });
 
 test("try-catch with optional throw of an Error", () => {
@@ -2501,59 +1139,7 @@ test("try-catch with optional throw of an Error", () => {
     }
   ).definition;
 
-  expect(definition).toEqual({
-    StartAt: 'if(input.id == "hello")',
-    States: {
-      'if(input.id == "hello")': {
-        Choices: [
-          {
-            Next: 'throw new Error("cause")',
-            StringEquals: "hello",
-            Variable: "$.id",
-          },
-        ],
-        Default: 'return "hello world"',
-        Type: "Choice",
-      },
-      'throw new Error("cause")': {
-        Next: 'if(err.message == "cause")',
-        Result: {
-          message: "cause",
-        },
-        ResultPath: "$.err",
-        Type: "Pass",
-      },
-      'if(err.message == "cause")': {
-        Choices: [
-          {
-            Next: 'return "hello"',
-            StringEquals: "cause",
-            Variable: "$.err.message",
-          },
-        ],
-        Default: 'return "world"',
-        Type: "Choice",
-      },
-      'return "hello world"': {
-        End: true,
-        Result: "hello world",
-        ResultPath: "$",
-        Type: "Pass",
-      },
-      'return "hello"': {
-        End: true,
-        Result: "hello",
-        ResultPath: "$",
-        Type: "Pass",
-      },
-      'return "world"': {
-        End: true,
-        Result: "world",
-        ResultPath: "$",
-        Type: "Pass",
-      },
-    },
-  });
+  expect(normalizeDefinition(definition)).toMatchSnapshot();
 });
 
 test("try-catch with optional task", () => {
@@ -2581,86 +1167,7 @@ test("try-catch with optional task", () => {
     }
   ).definition;
 
-  expect(definition).toEqual({
-    StartAt: 'if(input.id == "hello")',
-    States: {
-      'if(input.id == "hello")': {
-        Choices: [
-          {
-            Next: 'computeScore({id: input.id, name: "sam"})',
-            StringEquals: "hello",
-            Variable: "$.id",
-          },
-        ],
-        Default: 'return "hello world"',
-        Type: "Choice",
-      },
-      'computeScore({id: input.id, name: "sam"})': {
-        Catch: [
-          {
-            ErrorEquals: ["States.ALL"],
-            Next: "catch(err)",
-            ResultPath: "$.err",
-          },
-        ],
-        Next: 'return "hello world"',
-        ResultSelector: "$.Payload",
-        Parameters: {
-          FunctionName: computeScore.resource.functionName,
-          Payload: {
-            "id.$": "$.id",
-            name: "sam",
-          },
-        },
-        Resource: "arn:aws:states:::lambda:invoke",
-        ResultPath: null,
-        Type: "Task",
-      },
-      'return "hello world"': {
-        End: true,
-        Result: "hello world",
-        ResultPath: "$",
-        Type: "Pass",
-      },
-      "catch(err)": {
-        Next: "0_catch(err)",
-        Parameters: {
-          "0_ParsedError.$": "States.StringToJson($.err.Cause)",
-        },
-        ResultPath: "$.err",
-        Type: "Pass",
-      },
-      "0_catch(err)": {
-        InputPath: "$.err.0_ParsedError",
-        Next: 'if(err.message == "cause")',
-        ResultPath: "$.err",
-        Type: "Pass",
-      },
-      'if(err.message == "cause")': {
-        Choices: [
-          {
-            Next: 'return "hello"',
-            StringEquals: "cause",
-            Variable: "$.err.message",
-          },
-        ],
-        Default: 'return "world"',
-        Type: "Choice",
-      },
-      'return "hello"': {
-        End: true,
-        Result: "hello",
-        ResultPath: "$",
-        Type: "Pass",
-      },
-      'return "world"': {
-        End: true,
-        Result: "world",
-        ResultPath: "$",
-        Type: "Pass",
-      },
-    },
-  });
+  expect(normalizeDefinition(definition)).toMatchSnapshot();
 });
 
 test("try-catch with optional return of task", () => {
@@ -2688,86 +1195,7 @@ test("try-catch with optional return of task", () => {
     }
   ).definition;
 
-  expect(definition).toEqual({
-    StartAt: 'if(input.id == "hello")',
-    States: {
-      'if(input.id == "hello")': {
-        Choices: [
-          {
-            Next: 'return computeScore({id: input.id, name: "sam"})',
-            StringEquals: "hello",
-            Variable: "$.id",
-          },
-        ],
-        Default: 'return "hello world"',
-        Type: "Choice",
-      },
-      'return computeScore({id: input.id, name: "sam"})': {
-        Catch: [
-          {
-            ErrorEquals: ["States.ALL"],
-            Next: "catch(err)",
-            ResultPath: "$.err",
-          },
-        ],
-        End: true,
-        ResultSelector: "$.Payload",
-        Parameters: {
-          FunctionName: computeScore.resource.functionName,
-          Payload: {
-            "id.$": "$.id",
-            name: "sam",
-          },
-        },
-        Resource: "arn:aws:states:::lambda:invoke",
-        ResultPath: "$",
-        Type: "Task",
-      },
-      'return "hello world"': {
-        End: true,
-        Result: "hello world",
-        ResultPath: "$",
-        Type: "Pass",
-      },
-      "catch(err)": {
-        Next: "0_catch(err)",
-        Parameters: {
-          "0_ParsedError.$": "States.StringToJson($.err.Cause)",
-        },
-        ResultPath: "$.err",
-        Type: "Pass",
-      },
-      "0_catch(err)": {
-        InputPath: "$.err.0_ParsedError",
-        Next: 'if(err.message == "cause")',
-        ResultPath: "$.err",
-        Type: "Pass",
-      },
-      'if(err.message == "cause")': {
-        Choices: [
-          {
-            Next: 'return "hello"',
-            StringEquals: "cause",
-            Variable: "$.err.message",
-          },
-        ],
-        Default: 'return "world"',
-        Type: "Choice",
-      },
-      'return "hello"': {
-        End: true,
-        Result: "hello",
-        ResultPath: "$",
-        Type: "Pass",
-      },
-      'return "world"': {
-        End: true,
-        Result: "world",
-        ResultPath: "$",
-        Type: "Pass",
-      },
-    },
-  });
+  expect(normalizeDefinition(definition)).toMatchSnapshot();
 });
 
 test("nested try-catch", () => {
@@ -2785,32 +1213,7 @@ test("nested try-catch", () => {
     }
   }).definition;
 
-  expect(definition).toEqual({
-    StartAt: 'throw new Error("error1")',
-    States: {
-      'throw new Error("error1")': {
-        Next: 'throw new Error("error2")',
-        Result: {
-          message: "error1",
-        },
-        ResultPath: null,
-        Type: "Pass",
-      },
-      'throw new Error("error2")': {
-        Next: 'throw new Error("error3")',
-        Result: {
-          message: "error2",
-        },
-        ResultPath: null,
-        Type: "Pass",
-      },
-      'throw new Error("error3")': {
-        Cause: '{"message":"error3"}',
-        Error: "Error",
-        Type: "Fail",
-      },
-    },
-  });
+  expect(normalizeDefinition(definition)).toMatchSnapshot();
 });
 
 test("throw in for-of", () => {
@@ -2827,39 +1230,7 @@ test("throw in for-of", () => {
     }
   ).definition;
 
-  expect(definition).toEqual({
-    StartAt: "for(item of input.items)",
-    States: {
-      "for(item of input.items)": {
-        ItemsPath: "$.items",
-        Iterator: {
-          StartAt: 'throw new Error("err")',
-          States: {
-            'throw new Error("err")': {
-              Cause: '{"message":"err"}',
-              Error: "Error",
-              Type: "Fail",
-            },
-          },
-        },
-        MaxConcurrency: 1,
-        Next: "return null",
-        Parameters: {
-          "item.$": "$$.Map.Item.Value",
-        },
-        ResultPath: null,
-        Type: "Map",
-      },
-      "return null": {
-        End: true,
-        OutputPath: "$.null",
-        Parameters: {
-          null: null,
-        },
-        Type: "Pass",
-      },
-    },
-  });
+  expect(normalizeDefinition(definition)).toMatchSnapshot();
 });
 
 test("try-catch, no variable, contains for-of, throw", () => {
@@ -2879,52 +1250,7 @@ test("try-catch, no variable, contains for-of, throw", () => {
     }
   }).definition;
 
-  expect(definition).toEqual({
-    StartAt: "for(item of input.items)",
-    States: {
-      "for(item of input.items)": {
-        Catch: [
-          {
-            ErrorEquals: ["States.ALL"],
-            ResultPath: null,
-            Next: 'return "hello"',
-          },
-        ],
-        ItemsPath: "$.items",
-        Iterator: {
-          StartAt: 'throw new Error("err")',
-          States: {
-            'throw new Error("err")': {
-              Type: "Fail",
-              Error: "Error",
-              Cause: '{"message":"err"}',
-            },
-          },
-        },
-        MaxConcurrency: 1,
-        Next: "return null",
-        Parameters: {
-          "item.$": "$$.Map.Item.Value",
-        },
-        ResultPath: null,
-        Type: "Map",
-      },
-      'return "hello"': {
-        End: true,
-        Result: "hello",
-        ResultPath: "$",
-        Type: "Pass",
-      },
-      "return null": {
-        End: true,
-        OutputPath: "$.null",
-        Parameters: {
-          null: null,
-        },
-        Type: "Pass",
-      },
-    },
-  });
+  expect(normalizeDefinition(definition)).toMatchSnapshot();
 });
 
 test("try-catch, err variable, contains for-of, throw new Error", () => {
@@ -2944,65 +1270,7 @@ test("try-catch, err variable, contains for-of, throw new Error", () => {
     }
   }).definition;
 
-  expect(definition).toEqual({
-    StartAt: "for(item of input.items)",
-    States: {
-      "for(item of input.items)": {
-        Catch: [
-          {
-            ErrorEquals: ["States.ALL"],
-            ResultPath: "$.err",
-            Next: "catch(err)",
-          },
-        ],
-        ItemsPath: "$.items",
-        Iterator: {
-          StartAt: 'throw new Error("err")',
-          States: {
-            'throw new Error("err")': {
-              Type: "Fail",
-              Error: "Error",
-              Cause: '{"message":"err"}',
-            },
-          },
-        },
-        MaxConcurrency: 1,
-        Next: "return null",
-        Parameters: {
-          "item.$": "$$.Map.Item.Value",
-        },
-        ResultPath: null,
-        Type: "Map",
-      },
-      "catch(err)": {
-        Next: "0_catch(err)",
-        Parameters: {
-          "0_ParsedError.$": "States.StringToJson($.err.Cause)",
-        },
-        ResultPath: "$.err",
-        Type: "Pass",
-      },
-      "0_catch(err)": {
-        InputPath: "$.err.0_ParsedError",
-        Next: "return err.message",
-        ResultPath: "$.err",
-        Type: "Pass",
-      },
-      "return err.message": {
-        End: true,
-        OutputPath: "$.err.message",
-        Type: "Pass",
-      },
-      "return null": {
-        End: true,
-        OutputPath: "$.null",
-        Parameters: {
-          null: null,
-        },
-        Type: "Pass",
-      },
-    },
-  });
+  expect(normalizeDefinition(definition)).toMatchSnapshot();
 });
 
 test("try-catch, err variable, contains for-of, throw Error", () => {
@@ -3022,65 +1290,7 @@ test("try-catch, err variable, contains for-of, throw Error", () => {
     }
   }).definition;
 
-  expect(definition).toEqual({
-    StartAt: "for(item of input.items)",
-    States: {
-      "for(item of input.items)": {
-        Catch: [
-          {
-            ErrorEquals: ["States.ALL"],
-            ResultPath: "$.err",
-            Next: "catch(err)",
-          },
-        ],
-        ItemsPath: "$.items",
-        Iterator: {
-          StartAt: 'throw Error("err")',
-          States: {
-            'throw Error("err")': {
-              Type: "Fail",
-              Error: "Error",
-              Cause: '{"message":"err"}',
-            },
-          },
-        },
-        MaxConcurrency: 1,
-        Next: "return null",
-        Parameters: {
-          "item.$": "$$.Map.Item.Value",
-        },
-        ResultPath: null,
-        Type: "Map",
-      },
-      "catch(err)": {
-        Next: "0_catch(err)",
-        Parameters: {
-          "0_ParsedError.$": "States.StringToJson($.err.Cause)",
-        },
-        ResultPath: "$.err",
-        Type: "Pass",
-      },
-      "0_catch(err)": {
-        InputPath: "$.err.0_ParsedError",
-        Next: "return err.message",
-        ResultPath: "$.err",
-        Type: "Pass",
-      },
-      "return err.message": {
-        End: true,
-        OutputPath: "$.err.message",
-        Type: "Pass",
-      },
-      "return null": {
-        End: true,
-        OutputPath: "$.null",
-        Parameters: {
-          null: null,
-        },
-        Type: "Pass",
-      },
-    },
-  });
+  expect(normalizeDefinition(definition)).toMatchSnapshot();
 });
 
 test("try-catch-finally", () => {
@@ -3098,38 +1308,7 @@ test("try-catch-finally", () => {
     }
   }).definition;
 
-  expect(definition).toEqual({
-    StartAt: 'computeScore({id: "id", name: "name"})',
-    States: {
-      'computeScore({id: "id", name: "name"})': {
-        Catch: [
-          {
-            ErrorEquals: ["States.ALL"],
-            Next: 'return "hello"',
-            ResultPath: null,
-          },
-        ],
-        Next: 'return "hello"',
-        ResultSelector: "$.Payload",
-        Parameters: {
-          FunctionName: computeScore.resource.functionName,
-          Payload: {
-            id: "id",
-            name: "name",
-          },
-        },
-        Resource: "arn:aws:states:::lambda:invoke",
-        ResultPath: null,
-        Type: "Task",
-      },
-      'return "hello"': {
-        End: true,
-        Result: "hello",
-        ResultPath: "$",
-        Type: "Pass",
-      },
-    },
-  });
+  expect(normalizeDefinition(definition)).toMatchSnapshot();
 });
 
 test("try { task } catch { throw } finally { task() }", () => {
@@ -3145,73 +1324,7 @@ test("try { task } catch { throw } finally { task() }", () => {
     }
   }).definition;
 
-  expect(definition).toEqual({
-    StartAt: "task()",
-    States: {
-      "task()": {
-        Catch: [
-          {
-            ErrorEquals: ["States.ALL"],
-            Next: 'throw new Error("cause")',
-            ResultPath: null,
-          },
-        ],
-        Next: 'task("recover")',
-        ResultSelector: "$.Payload",
-        Parameters: {
-          FunctionName: task.resource.functionName,
-          Payload: undefined,
-        },
-        Resource: "arn:aws:states:::lambda:invoke",
-        ResultPath: null,
-        Type: "Task",
-      },
-      'throw new Error("cause")': {
-        Next: 'task("recover")',
-        Result: {
-          message: "cause",
-        },
-        ResultPath: "$.0_tmp",
-        Type: "Pass",
-      },
-      'task("recover")': {
-        Next: "exit finally",
-        ResultSelector: "$.Payload",
-        Parameters: {
-          FunctionName: task.resource.functionName,
-          Payload: "recover",
-        },
-        Resource: "arn:aws:states:::lambda:invoke",
-        ResultPath: null,
-        Type: "Task",
-      },
-      "exit finally": {
-        Choices: [
-          {
-            IsPresent: true,
-            Next: "throw finally",
-            Variable: "$.0_tmp",
-          },
-        ],
-        Default: "return null",
-        Type: "Choice",
-      },
-      "throw finally": {
-        Cause:
-          "an error was re-thrown from a finally block which is unsupported by Step Functions",
-        Error: "ReThrowFromFinally",
-        Type: "Fail",
-      },
-      "return null": {
-        End: true,
-        OutputPath: "$.null",
-        Parameters: {
-          null: null,
-        },
-        Type: "Pass",
-      },
-    },
-  });
+  expect(normalizeDefinition(definition)).toMatchSnapshot();
 });
 
 test("try { task() } catch { task() } finally { task() }", () => {
@@ -3227,83 +1340,7 @@ test("try { task() } catch { task() } finally { task() }", () => {
     }
   }).definition;
 
-  expect(definition).toEqual({
-    StartAt: 'task("1")',
-    States: {
-      'task("1")': {
-        Catch: [
-          {
-            ErrorEquals: ["States.ALL"],
-            Next: 'task("2")',
-            ResultPath: null,
-          },
-        ],
-        Next: 'task("3")',
-        ResultSelector: "$.Payload",
-        Parameters: {
-          FunctionName: task.resource.functionName,
-          Payload: "1",
-        },
-        Resource: "arn:aws:states:::lambda:invoke",
-        ResultPath: null,
-        Type: "Task",
-      },
-      'task("2")': {
-        Catch: [
-          {
-            ErrorEquals: ["States.ALL"],
-            Next: 'task("3")',
-            ResultPath: "$.0_tmp",
-          },
-        ],
-        Next: 'task("3")',
-        ResultSelector: "$.Payload",
-        Parameters: {
-          FunctionName: task.resource.functionName,
-          Payload: "2",
-        },
-        Resource: "arn:aws:states:::lambda:invoke",
-        ResultPath: null,
-        Type: "Task",
-      },
-      'task("3")': {
-        Next: "exit finally",
-        ResultSelector: "$.Payload",
-        Parameters: {
-          FunctionName: task.resource.functionName,
-          Payload: "3",
-        },
-        Resource: "arn:aws:states:::lambda:invoke",
-        ResultPath: null,
-        Type: "Task",
-      },
-      "exit finally": {
-        Choices: [
-          {
-            IsPresent: true,
-            Next: "throw finally",
-            Variable: "$.0_tmp",
-          },
-        ],
-        Default: "return null",
-        Type: "Choice",
-      },
-      "throw finally": {
-        Cause:
-          "an error was re-thrown from a finally block which is unsupported by Step Functions",
-        Error: "ReThrowFromFinally",
-        Type: "Fail",
-      },
-      "return null": {
-        End: true,
-        OutputPath: "$.null",
-        Parameters: {
-          null: null,
-        },
-        Type: "Pass",
-      },
-    },
-  });
+  expect(normalizeDefinition(definition)).toMatchSnapshot();
 });
 
 test("try, throw, finally", () => {
@@ -3318,25 +1355,7 @@ test("try, throw, finally", () => {
     }
   }).definition;
 
-  expect(definition).toEqual({
-    StartAt: 'throw new Error("cause")',
-    States: {
-      'throw new Error("cause")': {
-        Next: 'return "hello"',
-        Result: {
-          message: "cause",
-        },
-        ResultPath: null,
-        Type: "Pass",
-      },
-      'return "hello"': {
-        End: true,
-        Result: "hello",
-        ResultPath: "$",
-        Type: "Pass",
-      },
-    },
-  });
+  expect(normalizeDefinition(definition)).toMatchSnapshot();
 });
 
 test("try, throw, catch, throw, finally, return", () => {
@@ -3352,33 +1371,7 @@ test("try, throw, catch, throw, finally, return", () => {
     }
   }).definition;
 
-  expect(definition).toEqual({
-    StartAt: 'throw new Error("go")',
-    States: {
-      'throw new Error("go")': {
-        Next: 'throw new Error("little")',
-        Result: {
-          message: "go",
-        },
-        ResultPath: null,
-        Type: "Pass",
-      },
-      'throw new Error("little")': {
-        Next: 'return "rock-star"',
-        Result: {
-          message: "little",
-        },
-        ResultPath: null,
-        Type: "Pass",
-      },
-      'return "rock-star"': {
-        End: true,
-        Result: "rock-star",
-        ResultPath: "$",
-        Type: "Pass",
-      },
-    },
-  });
+  expect(normalizeDefinition(definition)).toMatchSnapshot();
 });
 
 test("try { throw } catch { (maybe) throw } finally { task }", () => {
@@ -3402,74 +1395,7 @@ test("try { throw } catch { (maybe) throw } finally { task }", () => {
     }
   ).definition;
 
-  expect(definition).toEqual({
-    StartAt: 'throw new Error("go")',
-    States: {
-      'throw new Error("go")': {
-        Next: 'if(input.id == "sam")',
-        Result: {
-          message: "go",
-        },
-        ResultPath: null,
-        Type: "Pass",
-      },
-      'if(input.id == "sam")': {
-        Choices: [
-          {
-            Next: 'throw new Error("little")',
-            StringEquals: "sam",
-            Variable: "$.id",
-          },
-        ],
-        Default: "task()",
-        Type: "Choice",
-      },
-      'throw new Error("little")': {
-        Next: "task()",
-        Result: {
-          message: "little",
-        },
-        ResultPath: "$.0_tmp",
-        Type: "Pass",
-      },
-      "task()": {
-        Next: "exit finally",
-        ResultSelector: "$.Payload",
-        Parameters: {
-          FunctionName: task.resource.functionName,
-          Payload: undefined,
-        },
-        Resource: "arn:aws:states:::lambda:invoke",
-        ResultPath: null,
-        Type: "Task",
-      },
-      "exit finally": {
-        Choices: [
-          {
-            IsPresent: true,
-            Next: "throw finally",
-            Variable: "$.0_tmp",
-          },
-        ],
-        Default: "return null",
-        Type: "Choice",
-      },
-      "throw finally": {
-        Cause:
-          "an error was re-thrown from a finally block which is unsupported by Step Functions",
-        Error: "ReThrowFromFinally",
-        Type: "Fail",
-      },
-      "return null": {
-        End: true,
-        OutputPath: "$.null",
-        Parameters: {
-          null: null,
-        },
-        Type: "Pass",
-      },
-    },
-  });
+  expect(normalizeDefinition(definition)).toMatchSnapshot();
 });
 
 test("try { task() } catch { (maybe) throw } finally { task }", () => {
@@ -3493,84 +1419,7 @@ test("try { task() } catch { (maybe) throw } finally { task }", () => {
     }
   ).definition;
 
-  expect(definition).toEqual({
-    StartAt: 'task("1")',
-    States: {
-      'task("1")': {
-        Catch: [
-          {
-            ErrorEquals: ["States.ALL"],
-            Next: 'if(input.id == "sam")',
-            ResultPath: null,
-          },
-        ],
-        Next: 'task("2")',
-        ResultSelector: "$.Payload",
-        Parameters: {
-          FunctionName: task.resource.functionName,
-          Payload: "1",
-        },
-        Resource: "arn:aws:states:::lambda:invoke",
-        ResultPath: null,
-        Type: "Task",
-      },
-      'if(input.id == "sam")': {
-        Choices: [
-          {
-            Next: 'throw new Error("little")',
-            StringEquals: "sam",
-            Variable: "$.id",
-          },
-        ],
-        Default: 'task("2")',
-        Type: "Choice",
-      },
-      'throw new Error("little")': {
-        Next: 'task("2")',
-        Result: {
-          message: "little",
-        },
-        ResultPath: "$.0_tmp",
-        Type: "Pass",
-      },
-      'task("2")': {
-        Next: "exit finally",
-        ResultSelector: "$.Payload",
-        Parameters: {
-          FunctionName: task.resource.functionName,
-          Payload: "2",
-        },
-        Resource: "arn:aws:states:::lambda:invoke",
-        ResultPath: null,
-        Type: "Task",
-      },
-      "exit finally": {
-        Choices: [
-          {
-            IsPresent: true,
-            Next: "throw finally",
-            Variable: "$.0_tmp",
-          },
-        ],
-        Default: "return null",
-        Type: "Choice",
-      },
-      "throw finally": {
-        Cause:
-          "an error was re-thrown from a finally block which is unsupported by Step Functions",
-        Error: "ReThrowFromFinally",
-        Type: "Fail",
-      },
-      "return null": {
-        End: true,
-        OutputPath: "$.null",
-        Parameters: {
-          null: null,
-        },
-        Type: "Pass",
-      },
-    },
-  });
+  expect(normalizeDefinition(definition)).toMatchSnapshot();
 });
 
 test("try { task() } catch(err) { (maybe) throw } finally { task }", () => {
@@ -3590,98 +1439,7 @@ test("try { task() } catch(err) { (maybe) throw } finally { task }", () => {
     }
   }).definition;
 
-  expect(definition).toEqual({
-    StartAt: 'task("1")',
-    States: {
-      'task("1")': {
-        Catch: [
-          {
-            ErrorEquals: ["States.ALL"],
-            Next: "catch(err)",
-            ResultPath: "$.err",
-          },
-        ],
-        Next: 'task("2")',
-        ResultSelector: "$.Payload",
-        Parameters: {
-          FunctionName: task.resource.functionName,
-          Payload: "1",
-        },
-        Resource: "arn:aws:states:::lambda:invoke",
-        ResultPath: null,
-        Type: "Task",
-      },
-      "catch(err)": {
-        Next: "0_catch(err)",
-        Parameters: {
-          "0_ParsedError.$": "States.StringToJson($.err.Cause)",
-        },
-        ResultPath: "$.err",
-        Type: "Pass",
-      },
-      "0_catch(err)": {
-        InputPath: "$.err.0_ParsedError",
-        Next: 'if(err.message == "sam")',
-        ResultPath: "$.err",
-        Type: "Pass",
-      },
-      'if(err.message == "sam")': {
-        Choices: [
-          {
-            Next: 'throw new Error("little")',
-            StringEquals: "sam",
-            Variable: "$.err.message",
-          },
-        ],
-        Default: 'task("2")',
-        Type: "Choice",
-      },
-      'throw new Error("little")': {
-        Next: 'task("2")',
-        Result: {
-          message: "little",
-        },
-        ResultPath: "$.0_tmp",
-        Type: "Pass",
-      },
-      'task("2")': {
-        Next: "exit finally",
-        ResultSelector: "$.Payload",
-        Parameters: {
-          FunctionName: task.resource.functionName,
-          Payload: "2",
-        },
-        Resource: "arn:aws:states:::lambda:invoke",
-        ResultPath: null,
-        Type: "Task",
-      },
-      "exit finally": {
-        Choices: [
-          {
-            IsPresent: true,
-            Next: "throw finally",
-            Variable: "$.0_tmp",
-          },
-        ],
-        Default: "return null",
-        Type: "Choice",
-      },
-      "throw finally": {
-        Cause:
-          "an error was re-thrown from a finally block which is unsupported by Step Functions",
-        Error: "ReThrowFromFinally",
-        Type: "Fail",
-      },
-      "return null": {
-        End: true,
-        OutputPath: "$.null",
-        Parameters: {
-          null: null,
-        },
-        Type: "Pass",
-      },
-    },
-  });
+  expect(normalizeDefinition(definition)).toMatchSnapshot();
 });
 
 test("try { for-of } catch { (maybe) throw } finally { task }", () => {
@@ -3706,113 +1464,7 @@ test("try { for-of } catch { (maybe) throw } finally { task }", () => {
     }
   }).definition;
 
-  expect(definition).toEqual({
-    StartAt: "for(item of input.items)",
-    States: {
-      "for(item of input.items)": {
-        Catch: [
-          {
-            ErrorEquals: ["States.ALL"],
-            Next: "catch(err)",
-            ResultPath: "$.err",
-          },
-        ],
-        ItemsPath: "$.items",
-        Iterator: {
-          StartAt: "task(item)",
-          States: {
-            "task(item)": {
-              End: true,
-              ResultSelector: "$.Payload",
-              Parameters: {
-                FunctionName: task.resource.functionName,
-                "Payload.$": "$.item",
-              },
-              Resource: "arn:aws:states:::lambda:invoke",
-              ResultPath: null,
-              Type: "Task",
-            },
-          },
-        },
-        MaxConcurrency: 1,
-        Next: 'task("2")',
-        Parameters: {
-          "item.$": "$$.Map.Item.Value",
-        },
-        ResultPath: null,
-        Type: "Map",
-      },
-      "0_catch(err)": {
-        InputPath: "$.err.0_ParsedError",
-        Next: 'if(err.message == "you dun\' goofed")',
-        ResultPath: "$.err",
-        Type: "Pass",
-      },
-      "catch(err)": {
-        Next: "0_catch(err)",
-        Parameters: {
-          "0_ParsedError.$": "States.StringToJson($.err.Cause)",
-        },
-        ResultPath: "$.err",
-        Type: "Pass",
-      },
-      'if(err.message == "you dun\' goofed")': {
-        Choices: [
-          {
-            Next: 'throw new Error("little")',
-            StringEquals: "you dun' goofed",
-            Variable: "$.err.message",
-          },
-        ],
-        Default: 'task("2")',
-        Type: "Choice",
-      },
-      'throw new Error("little")': {
-        Next: 'task("2")',
-        Result: {
-          message: "little",
-        },
-        ResultPath: "$.0_tmp",
-        Type: "Pass",
-      },
-      "return null": {
-        End: true,
-        OutputPath: "$.null",
-        Parameters: {
-          null: null,
-        },
-        Type: "Pass",
-      },
-      'task("2")': {
-        Next: "exit finally",
-        ResultSelector: "$.Payload",
-        Parameters: {
-          FunctionName: task.resource.functionName,
-          Payload: "2",
-        },
-        Resource: "arn:aws:states:::lambda:invoke",
-        ResultPath: null,
-        Type: "Task",
-      },
-      "exit finally": {
-        Choices: [
-          {
-            IsPresent: true,
-            Next: "throw finally",
-            Variable: "$.0_tmp",
-          },
-        ],
-        Default: "return null",
-        Type: "Choice",
-      },
-      "throw finally": {
-        Cause:
-          "an error was re-thrown from a finally block which is unsupported by Step Functions",
-        Error: "ReThrowFromFinally",
-        Type: "Fail",
-      },
-    },
-  });
+  expect(normalizeDefinition(definition)).toMatchSnapshot();
 });
 
 test("for-of { try { task() } catch (err) { if(err) throw } finally { task() } }", () => {
@@ -3837,113 +1489,7 @@ test("for-of { try { task() } catch (err) { if(err) throw } finally { task() } }
     }
   }).definition;
 
-  expect(definition).toEqual({
-    StartAt: "for(item of input.items)",
-    States: {
-      "for(item of input.items)": {
-        ItemsPath: "$.items",
-        Iterator: {
-          StartAt: "task(item)",
-          States: {
-            "task(item)": {
-              Catch: [
-                {
-                  ErrorEquals: ["States.ALL"],
-                  Next: "catch(err)",
-                  ResultPath: "$.err",
-                },
-              ],
-              Next: 'task("2")',
-              ResultSelector: "$.Payload",
-              Parameters: {
-                FunctionName: task.resource.functionName,
-                "Payload.$": "$.item",
-              },
-              Resource: "arn:aws:states:::lambda:invoke",
-              ResultPath: null,
-              Type: "Task",
-            },
-            "0_catch(err)": {
-              InputPath: "$.err.0_ParsedError",
-              Next: 'if(err.message == "you dun\' goofed")',
-              ResultPath: "$.err",
-              Type: "Pass",
-            },
-            "catch(err)": {
-              Next: "0_catch(err)",
-              Parameters: {
-                "0_ParsedError.$": "States.StringToJson($.err.Cause)",
-              },
-              ResultPath: "$.err",
-              Type: "Pass",
-            },
-            'if(err.message == "you dun\' goofed")': {
-              Choices: [
-                {
-                  Next: 'throw new Error("little")',
-                  StringEquals: "you dun' goofed",
-                  Variable: "$.err.message",
-                },
-              ],
-              Default: 'task("2")',
-              Type: "Choice",
-            },
-            'throw new Error("little")': {
-              Next: 'task("2")',
-              Result: {
-                message: "little",
-              },
-              ResultPath: "$.0_tmp",
-              Type: "Pass",
-            },
-            'task("2")': {
-              Next: "exit finally",
-              ResultSelector: "$.Payload",
-              Parameters: {
-                FunctionName: task.resource.functionName,
-                Payload: "2",
-              },
-              Resource: "arn:aws:states:::lambda:invoke",
-              ResultPath: null,
-              Type: "Task",
-            },
-            "exit finally": {
-              Choices: [
-                {
-                  IsPresent: true,
-                  Next: "throw finally",
-                  Variable: "$.0_tmp",
-                },
-              ],
-              Default: "return null",
-              Type: "Choice",
-            },
-            "throw finally": {
-              Cause:
-                "an error was re-thrown from a finally block which is unsupported by Step Functions",
-              Error: "ReThrowFromFinally",
-              Type: "Fail",
-            },
-          },
-        },
-        MaxConcurrency: 1,
-        Next: "return null",
-        Parameters: {
-          "item.$": "$$.Map.Item.Value",
-        },
-        ResultPath: null,
-        Type: "Map",
-      },
-      "return null": {
-        End: true,
-        OutputPath: "$.null",
-        Parameters: {
-          null: null,
-        },
-        Type: "Pass",
-      },
-    },
-  });
+  expect(normalizeDefinition(definition)).toMatchSnapshot();
 });
 
 test("while (cond) { cond = task() }", () => {
@@ -3955,49 +1501,7 @@ test("while (cond) { cond = task() }", () => {
     }
   }).definition;
 
-  expect(definition).toEqual({
-    StartAt: "while (cond == undefined)",
-    States: {
-      "while (cond == undefined)": {
-        Choices: [
-          {
-            Next: "cond = task()",
-            Or: [
-              {
-                IsPresent: false,
-                Variable: "$.cond",
-              },
-              {
-                IsNull: true,
-                Variable: "$.cond",
-              },
-            ],
-          },
-        ],
-        Default: "return null",
-        Type: "Choice",
-      },
-      "cond = task()": {
-        Next: "while (cond == undefined)",
-        ResultSelector: "$.Payload",
-        Parameters: {
-          FunctionName: task.resource.functionName,
-          Payload: undefined,
-        },
-        Resource: "arn:aws:states:::lambda:invoke",
-        ResultPath: "$.cond",
-        Type: "Task",
-      },
-      "return null": {
-        End: true,
-        OutputPath: "$.null",
-        Parameters: {
-          null: null,
-        },
-        Type: "Pass",
-      },
-    },
-  });
+  expect(normalizeDefinition(definition)).toMatchSnapshot();
 });
 
 test("while (cond); cond = task()", () => {
@@ -4007,49 +1511,7 @@ test("while (cond); cond = task()", () => {
     while (cond === undefined) cond = task();
   }).definition;
 
-  expect(definition).toEqual({
-    StartAt: "while (cond == undefined)",
-    States: {
-      "while (cond == undefined)": {
-        Choices: [
-          {
-            Next: "cond = task()",
-            Or: [
-              {
-                IsPresent: false,
-                Variable: "$.cond",
-              },
-              {
-                IsNull: true,
-                Variable: "$.cond",
-              },
-            ],
-          },
-        ],
-        Default: "return null",
-        Type: "Choice",
-      },
-      "cond = task()": {
-        Next: "while (cond == undefined)",
-        ResultSelector: "$.Payload",
-        Parameters: {
-          FunctionName: task.resource.functionName,
-          Payload: undefined,
-        },
-        Resource: "arn:aws:states:::lambda:invoke",
-        ResultPath: "$.cond",
-        Type: "Task",
-      },
-      "return null": {
-        End: true,
-        OutputPath: "$.null",
-        Parameters: {
-          null: null,
-        },
-        Type: "Pass",
-      },
-    },
-  });
+  expect(normalizeDefinition(definition)).toMatchSnapshot();
 });
 
 test("let cond; do { cond = task() } while (cond)", () => {
@@ -4061,49 +1523,7 @@ test("let cond; do { cond = task() } while (cond)", () => {
     } while (cond === undefined);
   }).definition;
 
-  expect(definition).toEqual({
-    StartAt: "cond = task()",
-    States: {
-      "while (cond == undefined)": {
-        Choices: [
-          {
-            Next: "cond = task()",
-            Or: [
-              {
-                IsPresent: false,
-                Variable: "$.cond",
-              },
-              {
-                IsNull: true,
-                Variable: "$.cond",
-              },
-            ],
-          },
-        ],
-        Default: "return null",
-        Type: "Choice",
-      },
-      "cond = task()": {
-        Next: "while (cond == undefined)",
-        ResultSelector: "$.Payload",
-        Parameters: {
-          FunctionName: task.resource.functionName,
-          Payload: undefined,
-        },
-        Resource: "arn:aws:states:::lambda:invoke",
-        ResultPath: "$.cond",
-        Type: "Task",
-      },
-      "return null": {
-        End: true,
-        OutputPath: "$.null",
-        Parameters: {
-          null: null,
-        },
-        Type: "Pass",
-      },
-    },
-  });
+  expect(normalizeDefinition(definition)).toMatchSnapshot();
 });
 
 test("list.map(item => task(item))", () => {
@@ -4115,37 +1535,7 @@ test("list.map(item => task(item))", () => {
     return input.list.map((item) => task(item));
   }).definition;
 
-  expect(definition).toEqual({
-    StartAt: "return input.list.map(function(item))",
-    States: {
-      "return input.list.map(function(item))": {
-        End: true,
-        ItemsPath: "$.list",
-        Iterator: {
-          StartAt: "return task(item)",
-          States: {
-            "return task(item)": {
-              End: true,
-              ResultSelector: "$.Payload",
-              Parameters: {
-                FunctionName: task.resource.functionName,
-                "Payload.$": "$.item",
-              },
-              Resource: "arn:aws:states:::lambda:invoke",
-              ResultPath: "$",
-              Type: "Task",
-            },
-          },
-        },
-        MaxConcurrency: 1,
-        Parameters: {
-          "item.$": "$$.Map.Item.Value",
-        },
-        ResultPath: "$",
-        Type: "Map",
-      },
-    },
-  });
+  expect(normalizeDefinition(definition)).toMatchSnapshot();
 });
 
 test("list.map((item, i) => if (i == 0) task(item))", () => {
@@ -4163,57 +1553,7 @@ test("list.map((item, i) => if (i == 0) task(item))", () => {
     });
   }).definition;
 
-  expect(definition).toEqual({
-    StartAt: "return input.list.map(function(item, i))",
-    States: {
-      "return input.list.map(function(item, i))": {
-        Type: "Map",
-        End: true,
-        ItemsPath: "$.list",
-        MaxConcurrency: 1,
-        Parameters: {
-          "i.$": "$$.Map.Item.Index",
-          "item.$": "$$.Map.Item.Value",
-        },
-        ResultPath: "$",
-        Iterator: {
-          StartAt: "if(i == 0)",
-          States: {
-            "if(i == 0)": {
-              Choices: [
-                {
-                  Next: "return task(item)",
-                  NumericEquals: 0,
-                  Variable: "$.i",
-                },
-              ],
-              Default: "return null",
-              Type: "Choice",
-            },
-            "return task(item)": {
-              End: true,
-              ResultSelector: "$.Payload",
-              Parameters: {
-                FunctionName: task.resource.functionName,
-                "Payload.$": "$.item",
-              },
-              Resource: "arn:aws:states:::lambda:invoke",
-              ResultPath: "$",
-              Type: "Task",
-            },
-            "return null": {
-              End: true,
-              OutputPath: "$.null",
-              Parameters: {
-                null: null,
-              },
-              Type: "Pass",
-            },
-          },
-        },
-      },
-    },
-  });
+  expect(normalizeDefinition(definition)).toMatchSnapshot();
 });
 
 test("list.map((item, i, list) => if (i == 0) task(item) else task(list[0]))", () => {
@@ -4231,60 +1571,7 @@ test("list.map((item, i, list) => if (i == 0) task(item) else task(list[0]))", (
     });
   }).definition;
 
-  expect(definition).toEqual({
-    StartAt: "return input.list.map(function(item, i))",
-    States: {
-      "return input.list.map(function(item, i))": {
-        End: true,
-        ItemsPath: "$.list",
-        Iterator: {
-          StartAt: "if(i == 0)",
-          States: {
-            "if(i == 0)": {
-              Choices: [
-                {
-                  Next: "return task(item)",
-                  NumericEquals: 0,
-                  Variable: "$.i",
-                },
-              ],
-              Default: "return task(input.list[0])",
-              Type: "Choice",
-            },
-            "return task(item)": {
-              End: true,
-              ResultSelector: "$.Payload",
-              Parameters: {
-                FunctionName: task.resource.functionName,
-                "Payload.$": "$.item",
-              },
-              Resource: "arn:aws:states:::lambda:invoke",
-              ResultPath: "$",
-              Type: "Task",
-            },
-            "return task(input.list[0])": {
-              End: true,
-              ResultSelector: "$.Payload",
-              Parameters: {
-                FunctionName: task.resource.functionName,
-                "Payload.$": "$.list[0]",
-              },
-              Resource: "arn:aws:states:::lambda:invoke",
-              ResultPath: "$",
-              Type: "Task",
-            },
-          },
-        },
-        MaxConcurrency: 1,
-        Parameters: {
-          "i.$": "$$.Map.Item.Index",
-          "item.$": "$$.Map.Item.Value",
-        },
-        ResultPath: "$",
-        Type: "Map",
-      },
-    },
-  });
+  expect(normalizeDefinition(definition)).toMatchSnapshot();
 });
 
 test("try { list.map(item => task(item)) }", () => {
@@ -4300,52 +1587,7 @@ test("try { list.map(item => task(item)) }", () => {
     }
   }).definition;
 
-  expect(definition).toEqual({
-    StartAt: "return input.list.map(function(item))",
-    States: {
-      "return input.list.map(function(item))": {
-        Catch: [
-          {
-            ErrorEquals: ["States.ALL"],
-            Next: "return null",
-            ResultPath: null,
-          },
-        ],
-        End: true,
-        ItemsPath: "$.list",
-        Iterator: {
-          StartAt: "return task(item)",
-          States: {
-            "return task(item)": {
-              End: true,
-              ResultSelector: "$.Payload",
-              Parameters: {
-                FunctionName: task.resource.functionName,
-                "Payload.$": "$.item",
-              },
-              Resource: "arn:aws:states:::lambda:invoke",
-              ResultPath: "$",
-              Type: "Task",
-            },
-          },
-        },
-        MaxConcurrency: 1,
-        Parameters: {
-          "item.$": "$$.Map.Item.Value",
-        },
-        ResultPath: "$",
-        Type: "Map",
-      },
-      "return null": {
-        End: true,
-        OutputPath: "$.null",
-        Parameters: {
-          null: null,
-        },
-        Type: "Pass",
-      },
-    },
-  });
+  expect(normalizeDefinition(definition)).toMatchSnapshot();
 });
 
 test("try { list.map(item => task(item)) }", () => {
@@ -4363,52 +1605,7 @@ test("try { list.map(item => task(item)) }", () => {
     });
   }).definition;
 
-  expect(definition).toEqual({
-    StartAt: "return input.list.map(function(item))",
-    States: {
-      "return input.list.map(function(item))": {
-        End: true,
-        ItemsPath: "$.list",
-        Iterator: {
-          StartAt: "return task(item)",
-          States: {
-            "return task(item)": {
-              Catch: [
-                {
-                  ErrorEquals: ["States.ALL"],
-                  Next: "return null",
-                  ResultPath: null,
-                },
-              ],
-              End: true,
-              ResultSelector: "$.Payload",
-              Parameters: {
-                FunctionName: task.resource.functionName,
-                "Payload.$": "$.item",
-              },
-              Resource: "arn:aws:states:::lambda:invoke",
-              ResultPath: "$",
-              Type: "Task",
-            },
-            "return null": {
-              End: true,
-              OutputPath: "$.null",
-              Parameters: {
-                null: null,
-              },
-              Type: "Pass",
-            },
-          },
-        },
-        MaxConcurrency: 1,
-        Parameters: {
-          "item.$": "$$.Map.Item.Value",
-        },
-        ResultPath: "$",
-        Type: "Map",
-      },
-    },
-  });
+  expect(normalizeDefinition(definition)).toMatchSnapshot();
 });
 
 test("try { list.map(item => throw) }", () => {
@@ -4426,44 +1623,7 @@ test("try { list.map(item => throw) }", () => {
     }
   }).definition;
 
-  expect(definition).toEqual({
-    StartAt: "return input.list.map(function())",
-    States: {
-      "return input.list.map(function())": {
-        Catch: [
-          {
-            ErrorEquals: ["States.ALL"],
-            Next: "return null",
-            ResultPath: null,
-          },
-        ],
-        End: true,
-        ItemsPath: "$.list",
-        Iterator: {
-          StartAt: 'throw new Error("cause")',
-          States: {
-            'throw new Error("cause")': {
-              Type: "Fail",
-              Error: "Error",
-              Cause: '{"message":"cause"}',
-            },
-          },
-        },
-        MaxConcurrency: 1,
-        Parameters: {},
-        ResultPath: "$",
-        Type: "Map",
-      },
-      "return null": {
-        End: true,
-        OutputPath: "$.null",
-        Parameters: {
-          null: null,
-        },
-        Type: "Pass",
-      },
-    },
-  });
+  expect(normalizeDefinition(definition)).toMatchSnapshot();
 });
 
 test("try { list.map(item => throw) } catch (err)", () => {
@@ -4485,73 +1645,7 @@ test("try { list.map(item => throw) } catch (err)", () => {
     }
   }).definition;
 
-  expect(definition).toEqual({
-    StartAt: "return input.list.map(function())",
-    States: {
-      "return input.list.map(function())": {
-        Catch: [
-          {
-            ErrorEquals: ["States.ALL"],
-            Next: "catch(err)",
-            ResultPath: "$.err",
-          },
-        ],
-        End: true,
-        ItemsPath: "$.list",
-        Iterator: {
-          StartAt: 'throw new Error("cause")',
-          States: {
-            'throw new Error("cause")': {
-              Cause: '{"message":"cause"}',
-              Error: "Error",
-              Type: "Fail",
-            },
-          },
-        },
-        MaxConcurrency: 1,
-        Parameters: {},
-        ResultPath: "$",
-        Type: "Map",
-      },
-      "catch(err)": {
-        Next: "0_catch(err)",
-        Parameters: {
-          "0_ParsedError.$": "States.StringToJson($.err.Cause)",
-        },
-        ResultPath: "$.err",
-        Type: "Pass",
-      },
-      "0_catch(err)": {
-        InputPath: "$.err.0_ParsedError",
-        Next: 'if(err.message == "cause")',
-        ResultPath: "$.err",
-        Type: "Pass",
-      },
-      'if(err.message == "cause")': {
-        Choices: [
-          {
-            Next: "return 0",
-            StringEquals: "cause",
-            Variable: "$.err.message",
-          },
-        ],
-        Default: "return 1",
-        Type: "Choice",
-      },
-      "return 0": {
-        End: true,
-        Result: 0,
-        ResultPath: "$",
-        Type: "Pass",
-      },
-      "return 1": {
-        End: true,
-        Result: 1,
-        ResultPath: "$",
-        Type: "Pass",
-      },
-    },
-  });
+  expect(normalizeDefinition(definition)).toMatchSnapshot();
 });
 
 test("list.forEach(item => task(item))", () => {
@@ -4564,37 +1658,7 @@ test("list.forEach(item => task(item))", () => {
     }
   ).definition;
 
-  expect(definition).toEqual({
-    StartAt: "return input.list.forEach(function(item))",
-    States: {
-      "return input.list.forEach(function(item))": {
-        End: true,
-        ItemsPath: "$.list",
-        Iterator: {
-          StartAt: "return task(item)",
-          States: {
-            "return task(item)": {
-              End: true,
-              ResultSelector: "$.Payload",
-              Parameters: {
-                FunctionName: task.resource.functionName,
-                "Payload.$": "$.item",
-              },
-              Resource: "arn:aws:states:::lambda:invoke",
-              ResultPath: "$",
-              Type: "Task",
-            },
-          },
-        },
-        MaxConcurrency: 1,
-        Parameters: {
-          "item.$": "$$.Map.Item.Value",
-        },
-        ResultPath: "$",
-        Type: "Map",
-      },
-    },
-  });
+  expect(normalizeDefinition(definition)).toMatchSnapshot();
 });
 
 test("list.forEach((item, i) => if (i == 0) task(item))", () => {
@@ -4613,57 +1677,7 @@ test("list.forEach((item, i) => if (i == 0) task(item))", () => {
     }
   ).definition;
 
-  expect(definition).toEqual({
-    StartAt: "return input.list.forEach(function(item, i))",
-    States: {
-      "return input.list.forEach(function(item, i))": {
-        Type: "Map",
-        End: true,
-        ItemsPath: "$.list",
-        MaxConcurrency: 1,
-        Parameters: {
-          "i.$": "$$.Map.Item.Index",
-          "item.$": "$$.Map.Item.Value",
-        },
-        ResultPath: "$",
-        Iterator: {
-          StartAt: "if(i == 0)",
-          States: {
-            "if(i == 0)": {
-              Choices: [
-                {
-                  Next: "return task(item)",
-                  NumericEquals: 0,
-                  Variable: "$.i",
-                },
-              ],
-              Default: "return null",
-              Type: "Choice",
-            },
-            "return task(item)": {
-              End: true,
-              ResultSelector: "$.Payload",
-              Parameters: {
-                FunctionName: task.resource.functionName,
-                "Payload.$": "$.item",
-              },
-              Resource: "arn:aws:states:::lambda:invoke",
-              ResultPath: "$",
-              Type: "Task",
-            },
-            "return null": {
-              End: true,
-              OutputPath: "$.null",
-              Parameters: {
-                null: null,
-              },
-              Type: "Pass",
-            },
-          },
-        },
-      },
-    },
-  });
+  expect(normalizeDefinition(definition)).toMatchSnapshot();
 });
 
 test("list.forEach((item, i, list) => if (i == 0) task(item) else task(list[0]))", () => {
@@ -4682,60 +1696,7 @@ test("list.forEach((item, i, list) => if (i == 0) task(item) else task(list[0]))
     }
   ).definition;
 
-  expect(definition).toEqual({
-    StartAt: "return input.list.forEach(function(item, i))",
-    States: {
-      "return input.list.forEach(function(item, i))": {
-        End: true,
-        ItemsPath: "$.list",
-        Iterator: {
-          StartAt: "if(i == 0)",
-          States: {
-            "if(i == 0)": {
-              Choices: [
-                {
-                  Next: "return task(item)",
-                  NumericEquals: 0,
-                  Variable: "$.i",
-                },
-              ],
-              Default: "return task(input.list[0])",
-              Type: "Choice",
-            },
-            "return task(item)": {
-              End: true,
-              ResultSelector: "$.Payload",
-              Parameters: {
-                FunctionName: task.resource.functionName,
-                "Payload.$": "$.item",
-              },
-              Resource: "arn:aws:states:::lambda:invoke",
-              ResultPath: "$",
-              Type: "Task",
-            },
-            "return task(input.list[0])": {
-              End: true,
-              ResultSelector: "$.Payload",
-              Parameters: {
-                FunctionName: task.resource.functionName,
-                "Payload.$": "$.list[0]",
-              },
-              Resource: "arn:aws:states:::lambda:invoke",
-              ResultPath: "$",
-              Type: "Task",
-            },
-          },
-        },
-        MaxConcurrency: 1,
-        Parameters: {
-          "i.$": "$$.Map.Item.Index",
-          "item.$": "$$.Map.Item.Value",
-        },
-        ResultPath: "$",
-        Type: "Map",
-      },
-    },
-  });
+  expect(normalizeDefinition(definition)).toMatchSnapshot();
 });
 
 test("try { list.forEach(item => task(item)) }", () => {
@@ -4752,52 +1713,7 @@ test("try { list.forEach(item => task(item)) }", () => {
     }
   ).definition;
 
-  expect(definition).toEqual({
-    StartAt: "return input.list.forEach(function(item))",
-    States: {
-      "return input.list.forEach(function(item))": {
-        Catch: [
-          {
-            ErrorEquals: ["States.ALL"],
-            Next: "return null",
-            ResultPath: null,
-          },
-        ],
-        End: true,
-        ItemsPath: "$.list",
-        Iterator: {
-          StartAt: "return task(item)",
-          States: {
-            "return task(item)": {
-              End: true,
-              ResultSelector: "$.Payload",
-              Parameters: {
-                FunctionName: task.resource.functionName,
-                "Payload.$": "$.item",
-              },
-              Resource: "arn:aws:states:::lambda:invoke",
-              ResultPath: "$",
-              Type: "Task",
-            },
-          },
-        },
-        MaxConcurrency: 1,
-        Parameters: {
-          "item.$": "$$.Map.Item.Value",
-        },
-        ResultPath: "$",
-        Type: "Map",
-      },
-      "return null": {
-        End: true,
-        OutputPath: "$.null",
-        Parameters: {
-          null: null,
-        },
-        Type: "Pass",
-      },
-    },
-  });
+  expect(normalizeDefinition(definition)).toMatchSnapshot();
 });
 
 test("try { list.forEach(item => task(item)) }", () => {
@@ -4816,52 +1732,7 @@ test("try { list.forEach(item => task(item)) }", () => {
     }
   ).definition;
 
-  expect(definition).toEqual({
-    StartAt: "return input.list.forEach(function(item))",
-    States: {
-      "return input.list.forEach(function(item))": {
-        End: true,
-        ItemsPath: "$.list",
-        Iterator: {
-          StartAt: "return task(item)",
-          States: {
-            "return task(item)": {
-              Catch: [
-                {
-                  ErrorEquals: ["States.ALL"],
-                  Next: "return null",
-                  ResultPath: null,
-                },
-              ],
-              End: true,
-              ResultSelector: "$.Payload",
-              Parameters: {
-                FunctionName: task.resource.functionName,
-                "Payload.$": "$.item",
-              },
-              Resource: "arn:aws:states:::lambda:invoke",
-              ResultPath: "$",
-              Type: "Task",
-            },
-            "return null": {
-              End: true,
-              OutputPath: "$.null",
-              Parameters: {
-                null: null,
-              },
-              Type: "Pass",
-            },
-          },
-        },
-        MaxConcurrency: 1,
-        Parameters: {
-          "item.$": "$$.Map.Item.Value",
-        },
-        ResultPath: "$",
-        Type: "Map",
-      },
-    },
-  });
+  expect(normalizeDefinition(definition)).toMatchSnapshot();
 });
 
 test("try { list.forEach(item => throw) }", () => {
@@ -4880,44 +1751,7 @@ test("try { list.forEach(item => throw) }", () => {
     }
   ).definition;
 
-  expect(definition).toEqual({
-    StartAt: "return input.list.forEach(function())",
-    States: {
-      "return input.list.forEach(function())": {
-        Catch: [
-          {
-            ErrorEquals: ["States.ALL"],
-            Next: "return null",
-            ResultPath: null,
-          },
-        ],
-        End: true,
-        ItemsPath: "$.list",
-        Iterator: {
-          StartAt: 'throw new Error("cause")',
-          States: {
-            'throw new Error("cause")': {
-              Type: "Fail",
-              Error: "Error",
-              Cause: '{"message":"cause"}',
-            },
-          },
-        },
-        MaxConcurrency: 1,
-        Parameters: {},
-        ResultPath: "$",
-        Type: "Map",
-      },
-      "return null": {
-        End: true,
-        OutputPath: "$.null",
-        Parameters: {
-          null: null,
-        },
-        Type: "Pass",
-      },
-    },
-  });
+  expect(normalizeDefinition(definition)).toMatchSnapshot();
 });
 
 test("try { list.forEach(item => throw) } catch (err)", () => {
@@ -4940,73 +1774,7 @@ test("try { list.forEach(item => throw) } catch (err)", () => {
     }
   ).definition;
 
-  expect(definition).toEqual({
-    StartAt: "return input.list.forEach(function())",
-    States: {
-      "return input.list.forEach(function())": {
-        Catch: [
-          {
-            ErrorEquals: ["States.ALL"],
-            Next: "catch(err)",
-            ResultPath: "$.err",
-          },
-        ],
-        End: true,
-        ItemsPath: "$.list",
-        Iterator: {
-          StartAt: 'throw new Error("cause")',
-          States: {
-            'throw new Error("cause")': {
-              Cause: '{"message":"cause"}',
-              Error: "Error",
-              Type: "Fail",
-            },
-          },
-        },
-        MaxConcurrency: 1,
-        Parameters: {},
-        ResultPath: "$",
-        Type: "Map",
-      },
-      "catch(err)": {
-        Next: "0_catch(err)",
-        Parameters: {
-          "0_ParsedError.$": "States.StringToJson($.err.Cause)",
-        },
-        ResultPath: "$.err",
-        Type: "Pass",
-      },
-      "0_catch(err)": {
-        InputPath: "$.err.0_ParsedError",
-        Next: 'if(err.message == "cause")',
-        ResultPath: "$.err",
-        Type: "Pass",
-      },
-      'if(err.message == "cause")': {
-        Choices: [
-          {
-            Next: "return 0",
-            StringEquals: "cause",
-            Variable: "$.err.message",
-          },
-        ],
-        Default: "return 1",
-        Type: "Choice",
-      },
-      "return 0": {
-        End: true,
-        Result: 0,
-        ResultPath: "$",
-        Type: "Pass",
-      },
-      "return 1": {
-        End: true,
-        Result: 1,
-        ResultPath: "$",
-        Type: "Pass",
-      },
-    },
-  });
+  expect(normalizeDefinition(definition)).toMatchSnapshot();
 });
 
 test("return $SFN.map(list, (item) => task(item))", () => {
@@ -5018,36 +1786,7 @@ test("return $SFN.map(list, (item) => task(item))", () => {
     return $SFN.map(input.list, (item) => task(item));
   }).definition;
 
-  expect(definition).toEqual({
-    StartAt: "return $SFN.map(input.list, function(item))",
-    States: {
-      "return $SFN.map(input.list, function(item))": {
-        End: true,
-        ItemsPath: "$.list",
-        Iterator: {
-          StartAt: "return task(item)",
-          States: {
-            "return task(item)": {
-              End: true,
-              ResultSelector: "$.Payload",
-              Parameters: {
-                FunctionName: task.resource.functionName,
-                "Payload.$": "$.item",
-              },
-              Resource: "arn:aws:states:::lambda:invoke",
-              ResultPath: "$",
-              Type: "Task",
-            },
-          },
-        },
-        Parameters: {
-          "item.$": "$$.Map.Item.Value",
-        },
-        ResultPath: "$",
-        Type: "Map",
-      },
-    },
-  });
+  expect(normalizeDefinition(definition)).toMatchSnapshot();
 });
 
 test("return $SFN.map(list, {maxConcurrency: 2} (item) => task(item))", () => {
@@ -5059,37 +1798,7 @@ test("return $SFN.map(list, {maxConcurrency: 2} (item) => task(item))", () => {
     return $SFN.map(input.list, { maxConcurrency: 2 }, (item) => task(item));
   }).definition;
 
-  expect(definition).toEqual({
-    StartAt: "return $SFN.map(input.list, {maxConcurrency: 2}, function(item))",
-    States: {
-      "return $SFN.map(input.list, {maxConcurrency: 2}, function(item))": {
-        End: true,
-        ItemsPath: "$.list",
-        MaxConcurrency: 2,
-        Iterator: {
-          StartAt: "return task(item)",
-          States: {
-            "return task(item)": {
-              End: true,
-              ResultSelector: "$.Payload",
-              Parameters: {
-                FunctionName: task.resource.functionName,
-                "Payload.$": "$.item",
-              },
-              Resource: "arn:aws:states:::lambda:invoke",
-              ResultPath: "$",
-              Type: "Task",
-            },
-          },
-        },
-        Parameters: {
-          "item.$": "$$.Map.Item.Value",
-        },
-        ResultPath: "$",
-        Type: "Map",
-      },
-    },
-  });
+  expect(normalizeDefinition(definition)).toMatchSnapshot();
 });
 
 test("$SFN.map(list, (item) => task(item))", () => {
@@ -5102,44 +1811,7 @@ test("$SFN.map(list, (item) => task(item))", () => {
     }
   ).definition;
 
-  expect(definition).toEqual({
-    StartAt: "$SFN.map(input.list, function(item))",
-    States: {
-      "$SFN.map(input.list, function(item))": {
-        ItemsPath: "$.list",
-        Next: "return null",
-        Iterator: {
-          StartAt: "return task(item)",
-          States: {
-            "return task(item)": {
-              End: true,
-              ResultSelector: "$.Payload",
-              Parameters: {
-                FunctionName: task.resource.functionName,
-                "Payload.$": "$.item",
-              },
-              Resource: "arn:aws:states:::lambda:invoke",
-              ResultPath: "$",
-              Type: "Task",
-            },
-          },
-        },
-        Parameters: {
-          "item.$": "$$.Map.Item.Value",
-        },
-        ResultPath: null,
-        Type: "Map",
-      },
-      "return null": {
-        End: true,
-        OutputPath: "$.null",
-        Parameters: {
-          null: null,
-        },
-        Type: "Pass",
-      },
-    },
-  });
+  expect(normalizeDefinition(definition)).toMatchSnapshot();
 });
 
 test("result = $SFN.map(list, (item) => task(item))", () => {
@@ -5152,41 +1824,7 @@ test("result = $SFN.map(list, (item) => task(item))", () => {
     return result;
   }).definition;
 
-  expect(definition).toEqual({
-    StartAt: "result = $SFN.map(input.list, function(item))",
-    States: {
-      "result = $SFN.map(input.list, function(item))": {
-        ItemsPath: "$.list",
-        Iterator: {
-          StartAt: "return task(item)",
-          States: {
-            "return task(item)": {
-              End: true,
-              ResultSelector: "$.Payload",
-              Parameters: {
-                FunctionName: task.resource.functionName,
-                "Payload.$": "$.item",
-              },
-              Resource: "arn:aws:states:::lambda:invoke",
-              ResultPath: "$",
-              Type: "Task",
-            },
-          },
-        },
-        Next: "return result",
-        Parameters: {
-          "item.$": "$$.Map.Item.Value",
-        },
-        ResultPath: "$.result",
-        Type: "Map",
-      },
-      "return result": {
-        End: true,
-        OutputPath: "$.result",
-        Type: "Pass",
-      },
-    },
-  });
+  expect(normalizeDefinition(definition)).toMatchSnapshot();
 });
 
 test("return $SFN.map(list, (item) => try { task(item)) } catch { return null }", () => {
@@ -5204,51 +1842,7 @@ test("return $SFN.map(list, (item) => try { task(item)) } catch { return null }"
     });
   }).definition;
 
-  expect(definition).toEqual({
-    StartAt: "return $SFN.map(input.list, function(item))",
-    States: {
-      "return $SFN.map(input.list, function(item))": {
-        End: true,
-        ItemsPath: "$.list",
-        Iterator: {
-          StartAt: "return task(item)",
-          States: {
-            "return task(item)": {
-              Catch: [
-                {
-                  ErrorEquals: ["States.ALL"],
-                  Next: "return null",
-                  ResultPath: null,
-                },
-              ],
-              End: true,
-              ResultSelector: "$.Payload",
-              Parameters: {
-                FunctionName: task.resource.functionName,
-                "Payload.$": "$.item",
-              },
-              Resource: "arn:aws:states:::lambda:invoke",
-              ResultPath: "$",
-              Type: "Task",
-            },
-            "return null": {
-              End: true,
-              OutputPath: "$.null",
-              Parameters: {
-                null: null,
-              },
-              Type: "Pass",
-            },
-          },
-        },
-        Parameters: {
-          "item.$": "$$.Map.Item.Value",
-        },
-        ResultPath: "$",
-        Type: "Map",
-      },
-    },
-  });
+  expect(normalizeDefinition(definition)).toMatchSnapshot();
 });
 
 test("try { $SFN.map(list, (item) => task(item)) } catch { return null }", () => {
@@ -5264,51 +1858,7 @@ test("try { $SFN.map(list, (item) => task(item)) } catch { return null }", () =>
     }
   }).definition;
 
-  expect(definition).toEqual({
-    StartAt: "return $SFN.map(input.list, function(item))",
-    States: {
-      "return $SFN.map(input.list, function(item))": {
-        Catch: [
-          {
-            ErrorEquals: ["States.ALL"],
-            Next: "return null",
-            ResultPath: null,
-          },
-        ],
-        End: true,
-        ItemsPath: "$.list",
-        Iterator: {
-          StartAt: "return task(item)",
-          States: {
-            "return task(item)": {
-              End: true,
-              ResultSelector: "$.Payload",
-              Parameters: {
-                FunctionName: task.resource.functionName,
-                "Payload.$": "$.item",
-              },
-              Resource: "arn:aws:states:::lambda:invoke",
-              ResultPath: "$",
-              Type: "Task",
-            },
-          },
-        },
-        Parameters: {
-          "item.$": "$$.Map.Item.Value",
-        },
-        ResultPath: "$",
-        Type: "Map",
-      },
-      "return null": {
-        End: true,
-        OutputPath: "$.null",
-        Parameters: {
-          null: null,
-        },
-        Type: "Pass",
-      },
-    },
-  });
+  expect(normalizeDefinition(definition)).toMatchSnapshot();
 });
 
 test("return $SFN.forEach(list, (item) => task(item))", () => {
@@ -5321,36 +1871,7 @@ test("return $SFN.forEach(list, (item) => task(item))", () => {
     }
   ).definition;
 
-  expect(definition).toEqual({
-    StartAt: "return $SFN.forEach(input.list, function(item))",
-    States: {
-      "return $SFN.forEach(input.list, function(item))": {
-        End: true,
-        ItemsPath: "$.list",
-        Iterator: {
-          StartAt: "return task(item)",
-          States: {
-            "return task(item)": {
-              End: true,
-              ResultSelector: "$.Payload",
-              Parameters: {
-                FunctionName: task.resource.functionName,
-                "Payload.$": "$.item",
-              },
-              Resource: "arn:aws:states:::lambda:invoke",
-              ResultPath: "$",
-              Type: "Task",
-            },
-          },
-        },
-        Parameters: {
-          "item.$": "$$.Map.Item.Value",
-        },
-        ResultPath: "$",
-        Type: "Map",
-      },
-    },
-  });
+  expect(normalizeDefinition(definition)).toMatchSnapshot();
 });
 
 test("return $SFN.forEach(list, {maxConcurrency: 2} (item) => task(item))", () => {
@@ -5365,38 +1886,7 @@ test("return $SFN.forEach(list, {maxConcurrency: 2} (item) => task(item))", () =
     }
   ).definition;
 
-  expect(definition).toEqual({
-    StartAt:
-      "return $SFN.forEach(input.list, {maxConcurrency: 2}, function(item))",
-    States: {
-      "return $SFN.forEach(input.list, {maxConcurrency: 2}, function(item))": {
-        End: true,
-        ItemsPath: "$.list",
-        MaxConcurrency: 2,
-        Iterator: {
-          StartAt: "return task(item)",
-          States: {
-            "return task(item)": {
-              End: true,
-              ResultSelector: "$.Payload",
-              Parameters: {
-                FunctionName: task.resource.functionName,
-                "Payload.$": "$.item",
-              },
-              Resource: "arn:aws:states:::lambda:invoke",
-              ResultPath: "$",
-              Type: "Task",
-            },
-          },
-        },
-        Parameters: {
-          "item.$": "$$.Map.Item.Value",
-        },
-        ResultPath: "$",
-        Type: "Map",
-      },
-    },
-  });
+  expect(normalizeDefinition(definition)).toMatchSnapshot();
 });
 
 test("$SFN.forEach(list, (item) => task(item))", () => {
@@ -5409,44 +1899,7 @@ test("$SFN.forEach(list, (item) => task(item))", () => {
     }
   ).definition;
 
-  expect(definition).toEqual({
-    StartAt: "$SFN.forEach(input.list, function(item))",
-    States: {
-      "$SFN.forEach(input.list, function(item))": {
-        ItemsPath: "$.list",
-        Next: "return null",
-        Iterator: {
-          StartAt: "return task(item)",
-          States: {
-            "return task(item)": {
-              End: true,
-              ResultSelector: "$.Payload",
-              Parameters: {
-                FunctionName: task.resource.functionName,
-                "Payload.$": "$.item",
-              },
-              Resource: "arn:aws:states:::lambda:invoke",
-              ResultPath: "$",
-              Type: "Task",
-            },
-          },
-        },
-        Parameters: {
-          "item.$": "$$.Map.Item.Value",
-        },
-        ResultPath: null,
-        Type: "Map",
-      },
-      "return null": {
-        End: true,
-        OutputPath: "$.null",
-        Parameters: {
-          null: null,
-        },
-        Type: "Pass",
-      },
-    },
-  });
+  expect(normalizeDefinition(definition)).toMatchSnapshot();
 });
 
 test("result = $SFN.forEach(list, (item) => task(item))", () => {
@@ -5460,41 +1913,7 @@ test("result = $SFN.forEach(list, (item) => task(item))", () => {
     }
   ).definition;
 
-  expect(definition).toEqual({
-    StartAt: "result = $SFN.forEach(input.list, function(item))",
-    States: {
-      "result = $SFN.forEach(input.list, function(item))": {
-        ItemsPath: "$.list",
-        Iterator: {
-          StartAt: "return task(item)",
-          States: {
-            "return task(item)": {
-              End: true,
-              ResultSelector: "$.Payload",
-              Parameters: {
-                FunctionName: task.resource.functionName,
-                "Payload.$": "$.item",
-              },
-              Resource: "arn:aws:states:::lambda:invoke",
-              ResultPath: "$",
-              Type: "Task",
-            },
-          },
-        },
-        Next: "return result",
-        Parameters: {
-          "item.$": "$$.Map.Item.Value",
-        },
-        ResultPath: "$.result",
-        Type: "Map",
-      },
-      "return result": {
-        End: true,
-        OutputPath: "$.result",
-        Type: "Pass",
-      },
-    },
-  });
+  expect(normalizeDefinition(definition)).toMatchSnapshot();
 });
 
 test("return $SFN.forEach(list, (item) => try { task(item)) } catch { return null }", () => {
@@ -5513,51 +1932,7 @@ test("return $SFN.forEach(list, (item) => try { task(item)) } catch { return nul
     }
   ).definition;
 
-  expect(definition).toEqual({
-    StartAt: "return $SFN.forEach(input.list, function(item))",
-    States: {
-      "return $SFN.forEach(input.list, function(item))": {
-        End: true,
-        ItemsPath: "$.list",
-        Iterator: {
-          StartAt: "return task(item)",
-          States: {
-            "return task(item)": {
-              Catch: [
-                {
-                  ErrorEquals: ["States.ALL"],
-                  Next: "return null",
-                  ResultPath: null,
-                },
-              ],
-              End: true,
-              ResultSelector: "$.Payload",
-              Parameters: {
-                FunctionName: task.resource.functionName,
-                "Payload.$": "$.item",
-              },
-              Resource: "arn:aws:states:::lambda:invoke",
-              ResultPath: "$",
-              Type: "Task",
-            },
-            "return null": {
-              End: true,
-              OutputPath: "$.null",
-              Parameters: {
-                null: null,
-              },
-              Type: "Pass",
-            },
-          },
-        },
-        Parameters: {
-          "item.$": "$$.Map.Item.Value",
-        },
-        ResultPath: "$",
-        Type: "Map",
-      },
-    },
-  });
+  expect(normalizeDefinition(definition)).toMatchSnapshot();
 });
 
 test("try { $SFN.forEach(list, (item) => task(item)) } catch { return null }", () => {
@@ -5574,51 +1949,7 @@ test("try { $SFN.forEach(list, (item) => task(item)) } catch { return null }", (
     }
   ).definition;
 
-  expect(definition).toEqual({
-    StartAt: "return $SFN.forEach(input.list, function(item))",
-    States: {
-      "return $SFN.forEach(input.list, function(item))": {
-        Catch: [
-          {
-            ErrorEquals: ["States.ALL"],
-            Next: "return null",
-            ResultPath: null,
-          },
-        ],
-        End: true,
-        ItemsPath: "$.list",
-        Iterator: {
-          StartAt: "return task(item)",
-          States: {
-            "return task(item)": {
-              End: true,
-              ResultSelector: "$.Payload",
-              Parameters: {
-                FunctionName: task.resource.functionName,
-                "Payload.$": "$.item",
-              },
-              Resource: "arn:aws:states:::lambda:invoke",
-              ResultPath: "$",
-              Type: "Task",
-            },
-          },
-        },
-        Parameters: {
-          "item.$": "$$.Map.Item.Value",
-        },
-        ResultPath: "$",
-        Type: "Map",
-      },
-      "return null": {
-        End: true,
-        OutputPath: "$.null",
-        Parameters: {
-          null: null,
-        },
-        Type: "Pass",
-      },
-    },
-  });
+  expect(normalizeDefinition(definition)).toMatchSnapshot();
 });
 
 test('return $SFN.parallel(() => "hello", () => "world"))', () => {
@@ -5630,40 +1961,7 @@ test('return $SFN.parallel(() => "hello", () => "world"))', () => {
     );
   }).definition;
 
-  expect(definition).toEqual({
-    StartAt: "return $SFN.parallel([function(), function()])",
-    States: {
-      "return $SFN.parallel([function(), function()])": {
-        Branches: [
-          {
-            StartAt: 'return "hello"',
-            States: {
-              'return "hello"': {
-                End: true,
-                Result: "hello",
-                ResultPath: "$",
-                Type: "Pass",
-              },
-            },
-          },
-          {
-            StartAt: 'return "world"',
-            States: {
-              'return "world"': {
-                End: true,
-                Result: "world",
-                ResultPath: "$",
-                Type: "Pass",
-              },
-            },
-          },
-        ],
-        End: true,
-        ResultPath: "$",
-        Type: "Parallel",
-      },
-    },
-  });
+  expect(normalizeDefinition(definition)).toMatchSnapshot();
 });
 
 test('try { return $SFN.parallel(() => "hello", () => "world")) } catch { return null }', () => {
@@ -5679,55 +1977,7 @@ test('try { return $SFN.parallel(() => "hello", () => "world")) } catch { return
     }
   }).definition;
 
-  expect(definition).toEqual({
-    StartAt: "return $SFN.parallel([function(), function()])",
-    States: {
-      "return $SFN.parallel([function(), function()])": {
-        Branches: [
-          {
-            StartAt: 'return "hello"',
-            States: {
-              'return "hello"': {
-                End: true,
-                Result: "hello",
-                ResultPath: "$",
-                Type: "Pass",
-              },
-            },
-          },
-          {
-            StartAt: 'return "world"',
-            States: {
-              'return "world"': {
-                End: true,
-                Result: "world",
-                ResultPath: "$",
-                Type: "Pass",
-              },
-            },
-          },
-        ],
-        Catch: [
-          {
-            ErrorEquals: ["States.ALL"],
-            Next: "return null",
-            ResultPath: null,
-          },
-        ],
-        End: true,
-        ResultPath: "$",
-        Type: "Parallel",
-      },
-      "return null": {
-        Type: "Pass",
-        Parameters: {
-          null: null,
-        },
-        OutputPath: "$.null",
-        End: true,
-      },
-    },
-  });
+  expect(normalizeDefinition(definition)).toMatchSnapshot();
 });
 
 test("return $SFN.parallel(() => try { task() } catch { return null })) }", () => {
@@ -5746,64 +1996,7 @@ test("return $SFN.parallel(() => try { task() } catch { return null })) }", () =
     }
   }).definition;
 
-  expect(definition).toEqual({
-    StartAt: "return $SFN.parallel([function()])",
-    States: {
-      "return $SFN.parallel([function()])": {
-        Branches: [
-          {
-            StartAt: "return task()",
-            States: {
-              "return task()": {
-                Catch: [
-                  {
-                    ErrorEquals: ["States.ALL"],
-                    Next: "return null",
-                    ResultPath: null,
-                  },
-                ],
-                End: true,
-                ResultSelector: "$.Payload",
-                Parameters: {
-                  FunctionName: task.resource.functionName,
-                  Payload: undefined,
-                },
-                Resource: "arn:aws:states:::lambda:invoke",
-                ResultPath: "$",
-                Type: "Task",
-              },
-              "return null": {
-                End: true,
-                OutputPath: "$.null",
-                Parameters: {
-                  null: null,
-                },
-                Type: "Pass",
-              },
-            },
-          },
-        ],
-        Catch: [
-          {
-            ErrorEquals: ["States.ALL"],
-            Next: "return null 1",
-            ResultPath: null,
-          },
-        ],
-        End: true,
-        ResultPath: "$",
-        Type: "Parallel",
-      },
-      "return null 1": {
-        End: true,
-        OutputPath: "$.null",
-        Parameters: {
-          null: null,
-        },
-        Type: "Pass",
-      },
-    },
-  });
+  expect(normalizeDefinition(definition)).toMatchSnapshot();
 });
 
 test("return task({ key: items.filter(*) })", () => {
@@ -5823,28 +2016,7 @@ test("return task({ key: items.filter(*) })", () => {
     });
   }).definition;
 
-  expect(definition).toEqual({
-    StartAt:
-      "return task({equals: input.items.filter(function(item)), and: input.items.f",
-    States: {
-      "return task({equals: input.items.filter(function(item)), and: input.items.f":
-        {
-          Type: "Task",
-          End: true,
-          Resource: "arn:aws:states:::lambda:invoke",
-          ResultSelector: "$.Payload",
-          Parameters: {
-            FunctionName: task.resource.functionName,
-            Payload: {
-              "equals.$": "$.items[?(@.str=='hello')]",
-              "and.$": "$.items[?(@.str=='hello'&&@.items[0]=='hello')]",
-              "or.$": "$.items[?(@.str=='hello'||@.items[0]=='hello')]",
-            },
-          },
-          ResultPath: "$",
-        },
-    },
-  });
+  expect(normalizeDefinition(definition)).toMatchSnapshot();
 });
 
 test("single quotes in StringLiteralExpr should be escaped in a JSON Path filter expression", () => {
@@ -5858,24 +2030,7 @@ test("single quotes in StringLiteralExpr should be escaped in a JSON Path filter
     });
   }).definition;
 
-  expect(definition).toEqual({
-    StartAt: "return task({escape: input.items.filter(function(item))})",
-    States: {
-      "return task({escape: input.items.filter(function(item))})": {
-        Type: "Task",
-        End: true,
-        Resource: "arn:aws:states:::lambda:invoke",
-        ResultSelector: "$.Payload",
-        Parameters: {
-          FunctionName: task.resource.functionName,
-          Payload: {
-            "escape.$": "$.items[?(@.str=='hello\\'world')]",
-          },
-        },
-        ResultPath: "$",
-      },
-    },
-  });
+  expect(normalizeDefinition(definition)).toMatchSnapshot();
 });
 
 test("template literal strings", () => {
@@ -5889,24 +2044,7 @@ test("template literal strings", () => {
     });
   }).definition;
 
-  expect(definition).toEqual({
-    StartAt: "return task({key: `input.obj.str hello input.obj.items[0]`})",
-    States: {
-      "return task({key: `input.obj.str hello input.obj.items[0]`})": {
-        End: true,
-        ResultSelector: "$.Payload",
-        Parameters: {
-          FunctionName: task.resource.functionName,
-          Payload: {
-            "key.$": "States.Format('{} hello {}',$.obj.str,$.obj.items[0])",
-          },
-        },
-        Resource: "arn:aws:states:::lambda:invoke",
-        ResultPath: "$",
-        Type: "Task",
-      },
-    },
-  });
+  expect(normalizeDefinition(definition)).toMatchSnapshot();
 });
 
 test("break from for-loop", () => {
@@ -5923,60 +2061,7 @@ test("break from for-loop", () => {
     }
   ).definition;
 
-  expect(definition).toEqual({
-    StartAt: "for(item of input.items)",
-    States: {
-      "for(item of input.items)": {
-        Catch: [
-          {
-            ErrorEquals: ["Break"],
-            Next: "return null",
-            ResultPath: null,
-          },
-        ],
-        ItemsPath: "$.items",
-        Iterator: {
-          StartAt: 'if(item == "hello")',
-          States: {
-            'if(item == "hello")': {
-              Choices: [
-                {
-                  Next: "break",
-                  StringEquals: "hello",
-                  Variable: "$.item",
-                },
-              ],
-              Default: '0_empty_else_if(item == "hello")',
-              Type: "Choice",
-            },
-            '0_empty_else_if(item == "hello")': {
-              End: true,
-              Type: "Pass",
-            },
-            break: {
-              Type: "Fail",
-              Error: "Break",
-            },
-          },
-        },
-        MaxConcurrency: 1,
-        Next: "return null",
-        Parameters: {
-          "item.$": "$$.Map.Item.Value",
-        },
-        ResultPath: null,
-        Type: "Map",
-      },
-      "return null": {
-        End: true,
-        OutputPath: "$.null",
-        Parameters: {
-          null: null,
-        },
-        Type: "Pass",
-      },
-    },
-  });
+  expect(normalizeDefinition(definition)).toMatchSnapshot();
 });
 
 test("break from while-loop", () => {
@@ -5987,34 +2072,7 @@ test("break from while-loop", () => {
     }
   }).definition;
 
-  expect(definition).toEqual({
-    StartAt: "while (true)",
-    States: {
-      "while (true)": {
-        Choices: [
-          {
-            IsPresent: false,
-            Next: "break",
-            Variable: "$.0_true",
-          },
-        ],
-        Default: "return null",
-        Type: "Choice",
-      },
-      break: {
-        Next: "return null",
-        Type: "Pass",
-      },
-      "return null": {
-        End: true,
-        OutputPath: "$.null",
-        Parameters: {
-          null: null,
-        },
-        Type: "Pass",
-      },
-    },
-  });
+  expect(normalizeDefinition(definition)).toMatchSnapshot();
 });
 
 test("break from do-while-loop", () => {
@@ -6025,34 +2083,7 @@ test("break from do-while-loop", () => {
     } while (true);
   }).definition;
 
-  expect(definition).toEqual({
-    StartAt: "break",
-    States: {
-      "while (true)": {
-        Choices: [
-          {
-            IsPresent: false,
-            Next: "break",
-            Variable: "$.0_true",
-          },
-        ],
-        Default: "return null",
-        Type: "Choice",
-      },
-      break: {
-        Next: "return null",
-        Type: "Pass",
-      },
-      "return null": {
-        End: true,
-        OutputPath: "$.null",
-        Parameters: {
-          null: null,
-        },
-        Type: "Pass",
-      },
-    },
-  });
+  expect(normalizeDefinition(definition)).toMatchSnapshot();
 });
 
 test("continue in for loop", () => {
@@ -6069,54 +2100,7 @@ test("continue in for loop", () => {
     }
   ).definition;
 
-  expect(definition).toEqual({
-    StartAt: "for(item of input.items)",
-    States: {
-      "for(item of input.items)": {
-        ItemsPath: "$.items",
-        Iterator: {
-          StartAt: 'if(item == "hello")',
-          States: {
-            'if(item == "hello")': {
-              Choices: [
-                {
-                  Next: "continue",
-                  StringEquals: "hello",
-                  Variable: "$.item",
-                },
-              ],
-              Default: '0_empty_else_if(item == "hello")',
-              Type: "Choice",
-            },
-            continue: {
-              End: true,
-              ResultPath: null,
-              Type: "Pass",
-            },
-            '0_empty_else_if(item == "hello")': {
-              End: true,
-              Type: "Pass",
-            },
-          },
-        },
-        MaxConcurrency: 1,
-        Next: "return null",
-        Parameters: {
-          "item.$": "$$.Map.Item.Value",
-        },
-        ResultPath: null,
-        Type: "Map",
-      },
-      "return null": {
-        End: true,
-        OutputPath: "$.null",
-        Parameters: {
-          null: null,
-        },
-        Type: "Pass",
-      },
-    },
-  });
+  expect(normalizeDefinition(definition)).toMatchSnapshot();
 });
 
 test("continue in while loop", () => {
@@ -6134,57 +2118,7 @@ test("continue in while loop", () => {
     }
   ).definition;
 
-  expect(definition).toEqual({
-    StartAt: "while (true)",
-    States: {
-      "while (true)": {
-        Choices: [
-          {
-            IsPresent: false,
-            Next: 'if(input.key == "sam")',
-            Variable: "$.0_true",
-          },
-        ],
-        Default: "return null",
-        Type: "Choice",
-      },
-      'if(input.key == "sam")': {
-        Choices: [
-          {
-            Next: "continue",
-            StringEquals: "sam",
-            Variable: "$.key",
-          },
-        ],
-        Default: "task(input.key)",
-        Type: "Choice",
-      },
-      continue: {
-        Next: "while (true)",
-        ResultPath: null,
-        Type: "Pass",
-      },
-      "task(input.key)": {
-        Next: "while (true)",
-        ResultSelector: "$.Payload",
-        Parameters: {
-          FunctionName: task.resource.functionName,
-          "Payload.$": "$.key",
-        },
-        Resource: "arn:aws:states:::lambda:invoke",
-        ResultPath: null,
-        Type: "Task",
-      },
-      "return null": {
-        End: true,
-        OutputPath: "$.null",
-        Parameters: {
-          null: null,
-        },
-        Type: "Pass",
-      },
-    },
-  });
+  expect(normalizeDefinition(definition)).toMatchSnapshot();
 });
 
 test("continue in do..while loop", () => {
@@ -6202,57 +2136,7 @@ test("continue in do..while loop", () => {
     }
   ).definition;
 
-  expect(definition).toEqual({
-    StartAt: 'if(input.key == "sam")',
-    States: {
-      'if(input.key == "sam")': {
-        Choices: [
-          {
-            Next: "continue",
-            StringEquals: "sam",
-            Variable: "$.key",
-          },
-        ],
-        Default: "task(input.key)",
-        Type: "Choice",
-      },
-      continue: {
-        Next: 'if(input.key == "sam")',
-        ResultPath: null,
-        Type: "Pass",
-      },
-      "task(input.key)": {
-        Next: "while (true)",
-        ResultSelector: "$.Payload",
-        Parameters: {
-          FunctionName: task.resource.functionName,
-          "Payload.$": "$.key",
-        },
-        Resource: "arn:aws:states:::lambda:invoke",
-        ResultPath: null,
-        Type: "Task",
-      },
-      "while (true)": {
-        Choices: [
-          {
-            IsPresent: false,
-            Next: 'if(input.key == "sam")',
-            Variable: "$.0_true",
-          },
-        ],
-        Default: "return null",
-        Type: "Choice",
-      },
-      "return null": {
-        End: true,
-        OutputPath: "$.null",
-        Parameters: {
-          null: null,
-        },
-        Type: "Pass",
-      },
-    },
-  });
+  expect(normalizeDefinition(definition)).toMatchSnapshot();
 });
 
 test("return task(task())", () => {
@@ -6261,33 +2145,7 @@ test("return task(task())", () => {
     return task(task());
   }).definition;
 
-  expect(definition).toEqual({
-    StartAt: "0_tmp = task()",
-    States: {
-      "0_tmp = task()": {
-        Next: "return task(0_tmp)",
-        ResultSelector: "$.Payload",
-        Parameters: {
-          FunctionName: task.resource.functionName,
-          Payload: undefined,
-        },
-        Resource: "arn:aws:states:::lambda:invoke",
-        ResultPath: "$.0_tmp",
-        Type: "Task",
-      },
-      "return task(0_tmp)": {
-        End: true,
-        ResultSelector: "$.Payload",
-        Parameters: {
-          FunctionName: task.resource.functionName,
-          "Payload.$": "$.0_tmp",
-        },
-        Resource: "arn:aws:states:::lambda:invoke",
-        ResultPath: "$",
-        Type: "Task",
-      },
-    },
-  });
+  expect(normalizeDefinition(definition)).toMatchSnapshot();
 });
 
 // test("return cond ? task(1) : task(2))", () => {
@@ -6296,7 +2154,7 @@ test("return task(task())", () => {
 //     return cond ? task(1) : task(2);
 //   }).definition;
 
-//   expect(definition).toEqual({});
+//   expect(definition).toMatchSnapshot()
 // });
 
 // test("return task(1) ?? task(2))", () => {
@@ -6305,7 +2163,7 @@ test("return task(task())", () => {
 //     return task(1) ?? task(2);
 //   }).definition;
 
-//   expect(definition).toEqual({});
+//   expect(definition).toMatchSnapshot()
 // });
 
 test("while(true) { try { } catch { wait }", () => {
@@ -6320,53 +2178,7 @@ test("while(true) { try { } catch { wait }", () => {
     }
   }).definition;
 
-  expect(definition).toEqual({
-    StartAt: "while (true)",
-    States: {
-      "while (true)": {
-        Choices: [
-          {
-            IsPresent: false,
-            Next: "task()",
-            Variable: "$.0_true",
-          },
-        ],
-        Default: "return null",
-        Type: "Choice",
-      },
-      "task()": {
-        Catch: [
-          {
-            ErrorEquals: ["States.ALL"],
-            Next: "$SFN.waitFor(1)",
-            ResultPath: null,
-          },
-        ],
-        Next: "while (true)",
-        ResultSelector: "$.Payload",
-        Parameters: {
-          FunctionName: task.resource.functionName,
-          Payload: undefined,
-        },
-        Resource: "arn:aws:states:::lambda:invoke",
-        ResultPath: null,
-        Type: "Task",
-      },
-      "$SFN.waitFor(1)": {
-        Next: "while (true)",
-        Seconds: 1,
-        Type: "Wait",
-      },
-      "return null": {
-        End: true,
-        OutputPath: "$.null",
-        Parameters: {
-          null: null,
-        },
-        Type: "Pass",
-      },
-    },
-  });
+  expect(normalizeDefinition(definition)).toMatchSnapshot();
 });
 
 test("call Step Function from another Step Function", () => {
@@ -6380,25 +2192,7 @@ test("call Step Function from another Step Function", () => {
     return result;
   }).definition;
 
-  expect(definition).toEqual({
-    StartAt: "result = machine1({})",
-    States: {
-      "result = machine1({})": {
-        Next: "return result",
-        Parameters: {
-          StateMachineArn: machine1.stateMachineArn,
-        },
-        Resource: "arn:aws:states:::aws-sdk:sfn:startSyncExecution",
-        ResultPath: "$.result",
-        Type: "Task",
-      },
-      "return result": {
-        End: true,
-        OutputPath: "$.result",
-        Type: "Pass",
-      },
-    },
-  });
+  expect(normalizeDefinition(definition)).toMatchSnapshot();
 });
 
 test("call Step Function from another Step Function with name and trace", () => {
@@ -6415,27 +2209,7 @@ test("call Step Function from another Step Function with name and trace", () => 
     return result;
   }).definition;
 
-  expect(definition).toEqual({
-    StartAt: 'result = machine1({name: "exec1", traceHeader: "1"})',
-    States: {
-      'result = machine1({name: "exec1", traceHeader: "1"})': {
-        Next: "return result",
-        Parameters: {
-          StateMachineArn: machine1.stateMachineArn,
-          Name: "exec1",
-          TraceHeader: "1",
-        },
-        Resource: "arn:aws:states:::aws-sdk:sfn:startSyncExecution",
-        ResultPath: "$.result",
-        Type: "Task",
-      },
-      "return result": {
-        End: true,
-        OutputPath: "$.result",
-        Type: "Pass",
-      },
-    },
-  });
+  expect(normalizeDefinition(definition)).toMatchSnapshot();
 });
 
 test("call Step Function from another Step Function with name and trace from variables", () => {
@@ -6456,27 +2230,7 @@ test("call Step Function from another Step Function with name and trace from var
     }
   ).definition;
 
-  expect(definition).toEqual({
-    StartAt: "result = machine1({name: input.name, traceHeader: input.header})",
-    States: {
-      "result = machine1({name: input.name, traceHeader: input.header})": {
-        Next: "return result",
-        Parameters: {
-          StateMachineArn: machine1.stateMachineArn,
-          "Name.$": "$.name",
-          "TraceHeader.$": "$.header",
-        },
-        Resource: "arn:aws:states:::aws-sdk:sfn:startSyncExecution",
-        ResultPath: "$.result",
-        Type: "Task",
-      },
-      "return result": {
-        End: true,
-        OutputPath: "$.result",
-        Type: "Pass",
-      },
-    },
-  });
+  expect(normalizeDefinition(definition)).toMatchSnapshot();
 });
 
 test("call Step Function from another Step Function with input", () => {
@@ -6498,28 +2252,7 @@ test("call Step Function from another Step Function with input", () => {
     return result;
   }).definition;
 
-  expect(definition).toEqual({
-    StartAt: 'result = machine1({input: {value: "hello"}})',
-    States: {
-      'result = machine1({input: {value: "hello"}})': {
-        Next: "return result",
-        Parameters: {
-          Input: {
-            value: "hello",
-          },
-          StateMachineArn: machine1.stateMachineArn,
-        },
-        Resource: "arn:aws:states:::aws-sdk:sfn:startSyncExecution",
-        ResultPath: "$.result",
-        Type: "Task",
-      },
-      "return result": {
-        End: true,
-        OutputPath: "$.result",
-        Type: "Pass",
-      },
-    },
-  });
+  expect(normalizeDefinition(definition)).toMatchSnapshot();
 });
 
 test("call Step Function from another Step Function with dynamic input", () => {
@@ -6544,28 +2277,7 @@ test("call Step Function from another Step Function with dynamic input", () => {
     return result;
   }).definition;
 
-  expect(definition).toEqual({
-    StartAt: "result = machine1({input: {value: input.value1}})",
-    States: {
-      "result = machine1({input: {value: input.value1}})": {
-        Next: "return result",
-        Parameters: {
-          Input: {
-            "value.$": "$.value1",
-          },
-          StateMachineArn: machine1.stateMachineArn,
-        },
-        Resource: "arn:aws:states:::aws-sdk:sfn:startSyncExecution",
-        ResultPath: "$.result",
-        Type: "Task",
-      },
-      "return result": {
-        End: true,
-        OutputPath: "$.result",
-        Type: "Pass",
-      },
-    },
-  });
+  expect(normalizeDefinition(definition)).toMatchSnapshot();
 });
 
 test("call Step Function from another Step Function with dynamic input field input", () => {
@@ -6588,26 +2300,7 @@ test("call Step Function from another Step Function with dynamic input field inp
     return result;
   }).definition;
 
-  expect(definition).toEqual({
-    StartAt: "result = machine1({input: input})",
-    States: {
-      "result = machine1({input: input})": {
-        Next: "return result",
-        Parameters: {
-          "Input.$": "$",
-          StateMachineArn: machine1.stateMachineArn,
-        },
-        Resource: "arn:aws:states:::aws-sdk:sfn:startSyncExecution",
-        ResultPath: "$.result",
-        Type: "Task",
-      },
-      "return result": {
-        End: true,
-        OutputPath: "$.result",
-        Type: "Pass",
-      },
-    },
-  });
+  expect(normalizeDefinition(definition)).toMatchSnapshot();
 });
 
 test("call Step Function from another Step Function not supported with reference argument", () => {
@@ -6715,25 +2408,7 @@ test("call Step Function describe from another Step Function", () => {
     return result;
   }).definition;
 
-  expect(definition).toEqual({
-    StartAt: 'result = machine1.describeExecution("hello")',
-    States: {
-      'result = machine1.describeExecution("hello")': {
-        Next: "return result",
-        Parameters: {
-          ExecutionArn: "hello",
-        },
-        Resource: "arn:aws:states:::aws-sdk:sfn:describeExecution",
-        ResultPath: "$.result",
-        Type: "Task",
-      },
-      "return result": {
-        End: true,
-        OutputPath: "$.result",
-        Type: "Pass",
-      },
-    },
-  });
+  expect(normalizeDefinition(definition)).toMatchSnapshot();
 });
 
 test("call Step Function describe from another Step Function from context", () => {
@@ -6755,25 +2430,7 @@ test("call Step Function describe from another Step Function from context", () =
     }
   ).definition;
 
-  expect(definition).toEqual({
-    StartAt: "result = machine1.describeExecution(input.id)",
-    States: {
-      "result = machine1.describeExecution(input.id)": {
-        Next: "return result",
-        Parameters: {
-          "ExecutionArn.$": "$.id",
-        },
-        Resource: "arn:aws:states:::aws-sdk:sfn:describeExecution",
-        ResultPath: "$.result",
-        Type: "Task",
-      },
-      "return result": {
-        End: true,
-        OutputPath: "$.result",
-        Type: "Pass",
-      },
-    },
-  });
+  expect(normalizeDefinition(definition)).toMatchSnapshot();
 });
 
 test("on success event", () => {

--- a/test/util.ts
+++ b/test/util.ts
@@ -121,6 +121,7 @@ export function initStepFunctionApp() {
     ),
     handler: "index.handler",
     runtime: aws_lambda.Runtime.NODEJS_14_X,
+    functionName: "testFunction",
   });
 
   // These functions do not actually execute.
@@ -138,6 +139,7 @@ export function initStepFunctionApp() {
         name: "id",
         type: aws_dynamodb.AttributeType.STRING,
       },
+      tableName: "testTable",
     })
   );
 


### PR DESCRIPTION
Updating sfn tests to snapshot tests to reduce fragile tests on compiler changes.

Motivation - Large changes like #202 will cause major, mostly cosmetic changes to step function tests. Using snapshots will reduce time for author and PR reviewer. 

* [x] Update most sfn tests to use snapshots
   * [x] solved the randomized `IResolvable` token issue
* [x] Write fine grained tests to test token wiring
* [x] Any other tests to update?