### PR TITLE
chore: move app sync tests to snapshots

### DIFF
--- a/test/__snapshots__/appsync.test.ts.snap
+++ b/test/__snapshots__/appsync.test.ts.snap
@@ -1,0 +1,276 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`step function describe execution machine describe exec string 1`] = `
+Array [
+  "{}",
+  "#if($context.stash.return__flag)
+  #return($context.stash.return__val)
+#end
+{
+  \\"version\\": \\"2018-05-29\\",
+  \\"method\\": \\"POST\\",
+  \\"resourcePath\\": \\"/\\",
+  \\"params\\": {
+    \\"headers\\": {
+      \\"content-type\\": \\"application/x-amz-json-1.0\\",
+      \\"x-amz-target\\": \\"AWSStepFunctions.DescribeExecution\\"
+    },
+    \\"body\\": {
+      \\"executionArn\\": $util.toJson('exec1')
+    }
+  }
+}",
+  "{}",
+  "#if($context.stash.return__flag)
+  #return($context.stash.return__val)
+#end",
+]
+`;
+
+exports[`step function describe execution machine describe exec string 2`] = `
+Object {
+  "method": "POST",
+  "params": Object {
+    "body": Object {
+      "executionArn": "exec1",
+    },
+    "headers": Object {
+      "content-type": "application/x-amz-json-1.0",
+      "x-amz-target": "AWSStepFunctions.DescribeExecution",
+    },
+  },
+  "resourcePath": "/",
+  "version": "2018-05-29",
+}
+`;
+
+exports[`step function integration machine describe exec 1`] = `
+Array [
+  "{}",
+  "#if($context.stash.return__flag)
+  #return($context.stash.return__val)
+#end
+#set($context.stash.exec = 'exec1')
+{
+  \\"version\\": \\"2018-05-29\\",
+  \\"method\\": \\"POST\\",
+  \\"resourcePath\\": \\"/\\",
+  \\"params\\": {
+    \\"headers\\": {
+      \\"content-type\\": \\"application/x-amz-json-1.0\\",
+      \\"x-amz-target\\": \\"AWSStepFunctions.DescribeExecution\\"
+    },
+    \\"body\\": {
+      \\"executionArn\\": $util.toJson($context.stash.exec)
+    }
+  }
+}",
+  "{}",
+  "#if($context.stash.return__flag)
+  #return($context.stash.return__val)
+#end",
+]
+`;
+
+exports[`step function integration machine describe exec 2`] = `
+Object {
+  "method": "POST",
+  "params": Object {
+    "body": Object {
+      "executionArn": "exec1",
+    },
+    "headers": Object {
+      "content-type": "application/x-amz-json-1.0",
+      "x-amz-target": "AWSStepFunctions.DescribeExecution",
+    },
+  },
+  "resourcePath": "/",
+  "version": "2018-05-29",
+}
+`;
+
+exports[`step function integration machine with dynamic parameters 1`] = `
+Array [
+  "{}",
+  "#if($context.stash.return__flag)
+  #return($context.stash.return__val)
+#end
+#set($v1 = {})
+#set($v2 = {})
+$util.qr($v2.put('id', $context.arguments.id))
+$util.qr($v1.put('input', $util.toJson($v2)))
+$util.qr($v1.put('stateMachineArn', '__REPLACED_TOKEN'))
+{
+  \\"version\\": \\"2018-05-29\\",
+  \\"method\\": \\"POST\\",
+  \\"resourcePath\\": \\"/\\",
+  \\"params\\": {
+    \\"headers\\": {
+      \\"content-type\\": \\"application/x-amz-json-1.0\\",
+      \\"x-amz-target\\": \\"AWSStepFunctions.StartExecution\\"
+    },
+    \\"body\\": $util.toJson($v1)
+  }
+}",
+  "{}",
+  "#if($context.stash.return__flag)
+  #return($context.stash.return__val)
+#end",
+]
+`;
+
+exports[`step function integration machine with dynamic parameters 2`] = `
+Object {
+  "method": "POST",
+  "params": Object {
+    "body": Object {
+      "input": "{\\"id\\":\\"1\\"}",
+      "stateMachineArn": "__REPLACED_TOKEN",
+    },
+    "headers": Object {
+      "content-type": "application/x-amz-json-1.0",
+      "x-amz-target": "AWSStepFunctions.StartExecution",
+    },
+  },
+  "resourcePath": "/",
+  "version": "2018-05-29",
+}
+`;
+
+exports[`step function integration machine with name 1`] = `
+Array [
+  "{}",
+  "#if($context.stash.return__flag)
+  #return($context.stash.return__val)
+#end
+#set($v1 = {})
+$util.qr($v1.put('name', $context.arguments.id))
+$util.qr($v1.put('stateMachineArn', '__REPLACED_TOKEN'))
+{
+  \\"version\\": \\"2018-05-29\\",
+  \\"method\\": \\"POST\\",
+  \\"resourcePath\\": \\"/\\",
+  \\"params\\": {
+    \\"headers\\": {
+      \\"content-type\\": \\"application/x-amz-json-1.0\\",
+      \\"x-amz-target\\": \\"AWSStepFunctions.StartExecution\\"
+    },
+    \\"body\\": $util.toJson($v1)
+  }
+}",
+  "{}",
+  "#if($context.stash.return__flag)
+  #return($context.stash.return__val)
+#end",
+]
+`;
+
+exports[`step function integration machine with name 2`] = `
+Object {
+  "method": "POST",
+  "params": Object {
+    "body": Object {
+      "name": "1",
+      "stateMachineArn": "__REPLACED_TOKEN",
+    },
+    "headers": Object {
+      "content-type": "application/x-amz-json-1.0",
+      "x-amz-target": "AWSStepFunctions.StartExecution",
+    },
+  },
+  "resourcePath": "/",
+  "version": "2018-05-29",
+}
+`;
+
+exports[`step function integration machine with no parameters 1`] = `
+Array [
+  "{}",
+  "#if($context.stash.return__flag)
+  #return($context.stash.return__val)
+#end
+#set($v1 = {})
+$util.qr($v1.put('stateMachineArn', '__REPLACED_TOKEN'))
+{
+  \\"version\\": \\"2018-05-29\\",
+  \\"method\\": \\"POST\\",
+  \\"resourcePath\\": \\"/\\",
+  \\"params\\": {
+    \\"headers\\": {
+      \\"content-type\\": \\"application/x-amz-json-1.0\\",
+      \\"x-amz-target\\": \\"AWSStepFunctions.StartExecution\\"
+    },
+    \\"body\\": $util.toJson($v1)
+  }
+}",
+  "{}",
+  "#if($context.stash.return__flag)
+  #return($context.stash.return__val)
+#end",
+]
+`;
+
+exports[`step function integration machine with no parameters 2`] = `
+Object {
+  "method": "POST",
+  "params": Object {
+    "body": Object {
+      "stateMachineArn": "__REPLACED_TOKEN",
+    },
+    "headers": Object {
+      "content-type": "application/x-amz-json-1.0",
+      "x-amz-target": "AWSStepFunctions.StartExecution",
+    },
+  },
+  "resourcePath": "/",
+  "version": "2018-05-29",
+}
+`;
+
+exports[`step function integration machine with static parameters 1`] = `
+Array [
+  "{}",
+  "#if($context.stash.return__flag)
+  #return($context.stash.return__val)
+#end
+#set($v1 = {})
+#set($v2 = {})
+$util.qr($v2.put('id', '1'))
+$util.qr($v1.put('input', $util.toJson($v2)))
+$util.qr($v1.put('stateMachineArn', '__REPLACED_TOKEN'))
+{
+  \\"version\\": \\"2018-05-29\\",
+  \\"method\\": \\"POST\\",
+  \\"resourcePath\\": \\"/\\",
+  \\"params\\": {
+    \\"headers\\": {
+      \\"content-type\\": \\"application/x-amz-json-1.0\\",
+      \\"x-amz-target\\": \\"AWSStepFunctions.StartExecution\\"
+    },
+    \\"body\\": $util.toJson($v1)
+  }
+}",
+  "{}",
+  "#if($context.stash.return__flag)
+  #return($context.stash.return__val)
+#end",
+]
+`;
+
+exports[`step function integration machine with static parameters 2`] = `
+Object {
+  "method": "POST",
+  "params": Object {
+    "body": Object {
+      "input": "{\\"id\\":\\"1\\"}",
+      "stateMachineArn": "__REPLACED_TOKEN",
+    },
+    "headers": Object {
+      "content-type": "application/x-amz-json-1.0",
+      "x-amz-target": "AWSStepFunctions.StartExecution",
+    },
+  },
+  "resourcePath": "/",
+  "version": "2018-05-29",
+}
+`;

--- a/test/__snapshots__/appsync.test.ts.snap
+++ b/test/__snapshots__/appsync.test.ts.snap
@@ -1,5 +1,695 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`multiple isolated integrations 1`] = `
+Array [
+  "{}",
+  "#if($context.stash.return__flag)
+  #return($context.stash.return__val)
+#end
+{
+  \\"version\\": \\"2018-05-29\\",
+  \\"method\\": \\"POST\\",
+  \\"resourcePath\\": \\"/\\",
+  \\"params\\": {
+    \\"headers\\": {
+      \\"content-type\\": \\"application/x-amz-json-1.0\\",
+      \\"x-amz-target\\": \\"AWSStepFunctions.DescribeExecution\\"
+    },
+    \\"body\\": {
+      \\"executionArn\\": $util.toJson('exec1')
+    }
+  }
+}",
+  "{}",
+  "#if($context.stash.return__flag)
+  #return($context.stash.return__val)
+#end
+{
+  \\"version\\": \\"2018-05-29\\",
+  \\"method\\": \\"POST\\",
+  \\"resourcePath\\": \\"/\\",
+  \\"params\\": {
+    \\"headers\\": {
+      \\"content-type\\": \\"application/x-amz-json-1.0\\",
+      \\"x-amz-target\\": \\"AWSStepFunctions.DescribeExecution\\"
+    },
+    \\"body\\": {
+      \\"executionArn\\": $util.toJson('exec2')
+    }
+  }
+}",
+  "{}",
+  "#if($context.stash.return__flag)
+  #return($context.stash.return__val)
+#end
+{
+  \\"version\\": \\"2018-05-29\\",
+  \\"method\\": \\"POST\\",
+  \\"resourcePath\\": \\"/\\",
+  \\"params\\": {
+    \\"headers\\": {
+      \\"content-type\\": \\"application/x-amz-json-1.0\\",
+      \\"x-amz-target\\": \\"AWSStepFunctions.DescribeExecution\\"
+    },
+    \\"body\\": {
+      \\"executionArn\\": $util.toJson('exec3')
+    }
+  }
+}",
+  "{}",
+  "#if($context.stash.return__flag)
+  #return($context.stash.return__val)
+#end
+{
+  \\"version\\": \\"2018-05-29\\",
+  \\"method\\": \\"POST\\",
+  \\"resourcePath\\": \\"/\\",
+  \\"params\\": {
+    \\"headers\\": {
+      \\"content-type\\": \\"application/x-amz-json-1.0\\",
+      \\"x-amz-target\\": \\"AWSStepFunctions.DescribeExecution\\"
+    },
+    \\"body\\": {
+      \\"executionArn\\": $util.toJson('exec4')
+    }
+  }
+}",
+  "{}",
+  "#if($context.stash.return__flag)
+  #return($context.stash.return__val)
+#end",
+]
+`;
+
+exports[`multiple isolated integrations 2`] = `
+Object {
+  "method": "POST",
+  "params": Object {
+    "body": Object {
+      "executionArn": "exec1",
+    },
+    "headers": Object {
+      "content-type": "application/x-amz-json-1.0",
+      "x-amz-target": "AWSStepFunctions.DescribeExecution",
+    },
+  },
+  "resourcePath": "/",
+  "version": "2018-05-29",
+}
+`;
+
+exports[`multiple linked integrations 1`] = `
+Array [
+  "{}",
+  "#if($context.stash.return__flag)
+  #return($context.stash.return__val)
+#end
+#set($v1 = {})
+#set($v2 = {})
+$util.qr($v1.put('input', $util.toJson($v2)))
+$util.qr($v1.put('stateMachineArn', '__REPLACED_TOKEN'))
+{
+  \\"version\\": \\"2018-05-29\\",
+  \\"method\\": \\"POST\\",
+  \\"resourcePath\\": \\"/\\",
+  \\"params\\": {
+    \\"headers\\": {
+      \\"content-type\\": \\"application/x-amz-json-1.0\\",
+      \\"x-amz-target\\": \\"AWSStepFunctions.StartExecution\\"
+    },
+    \\"body\\": $util.toJson($v1)
+  }
+}",
+  "#if($context.result.statusCode == 200)
+    #set($sfn__result = $util.parseJson($context.result.body))
+    #else 
+    $util.error($context.result.body, \\"$context.result.statusCode\\")
+    #end
+#set( $context.stash.res1 = $sfn__result )
+{}",
+  "#if($context.stash.return__flag)
+  #return($context.stash.return__val)
+#end
+#set($v1 = {})
+$util.qr($v1.put('input', $util.toJson($context.stash.res1)))
+$util.qr($v1.put('stateMachineArn', '__REPLACED_TOKEN'))
+{
+  \\"version\\": \\"2018-05-29\\",
+  \\"method\\": \\"POST\\",
+  \\"resourcePath\\": \\"/\\",
+  \\"params\\": {
+    \\"headers\\": {
+      \\"content-type\\": \\"application/x-amz-json-1.0\\",
+      \\"x-amz-target\\": \\"AWSStepFunctions.StartExecution\\"
+    },
+    \\"body\\": $util.toJson($v1)
+  }
+}",
+  "#if($context.result.statusCode == 200)
+    #set($sfn__result = $util.parseJson($context.result.body))
+    #else 
+    $util.error($context.result.body, \\"$context.result.statusCode\\")
+    #end
+#set( $context.stash.res2 = $sfn__result )
+{}",
+  "#if($context.stash.return__flag)
+  #return($context.stash.return__val)
+#end
+#set($v1 = {})
+$util.qr($v1.put('input', $util.toJson($context.stash.res2)))
+$util.qr($v1.put('stateMachineArn', '__REPLACED_TOKEN'))
+{
+  \\"version\\": \\"2018-05-29\\",
+  \\"method\\": \\"POST\\",
+  \\"resourcePath\\": \\"/\\",
+  \\"params\\": {
+    \\"headers\\": {
+      \\"content-type\\": \\"application/x-amz-json-1.0\\",
+      \\"x-amz-target\\": \\"AWSStepFunctions.StartExecution\\"
+    },
+    \\"body\\": $util.toJson($v1)
+  }
+}",
+  "{}",
+  "#if($context.stash.return__flag)
+  #return($context.stash.return__val)
+#end",
+]
+`;
+
+exports[`multiple linked integrations 2`] = `
+Object {
+  "method": "POST",
+  "params": Object {
+    "body": Object {
+      "input": "{}",
+      "stateMachineArn": "__REPLACED_TOKEN",
+    },
+    "headers": Object {
+      "content-type": "application/x-amz-json-1.0",
+      "x-amz-target": "AWSStepFunctions.StartExecution",
+    },
+  },
+  "resourcePath": "/",
+  "version": "2018-05-29",
+}
+`;
+
+exports[`multiple linked integrations post-compute 1`] = `
+Array [
+  "{}",
+  "#if($context.stash.return__flag)
+  #return($context.stash.return__val)
+#end
+#set($v1 = {})
+#set($v2 = {})
+$util.qr($v1.put('input', $util.toJson($v2)))
+$util.qr($v1.put('stateMachineArn', '__REPLACED_TOKEN'))
+{
+  \\"version\\": \\"2018-05-29\\",
+  \\"method\\": \\"POST\\",
+  \\"resourcePath\\": \\"/\\",
+  \\"params\\": {
+    \\"headers\\": {
+      \\"content-type\\": \\"application/x-amz-json-1.0\\",
+      \\"x-amz-target\\": \\"AWSStepFunctions.StartExecution\\"
+    },
+    \\"body\\": $util.toJson($v1)
+  }
+}",
+  "#if($context.result.statusCode == 200)
+    #set($sfn__result = $util.parseJson($context.result.body))
+    #else 
+    $util.error($context.result.body, \\"$context.result.statusCode\\")
+    #end
+#set( $context.stash.res1 = $sfn__result )
+{}",
+  "#if($context.stash.return__flag)
+  #return($context.stash.return__val)
+#end
+#set($v1 = {})
+$util.qr($v1.put('input', $util.toJson($context.stash.res1)))
+$util.qr($v1.put('stateMachineArn', '__REPLACED_TOKEN'))
+{
+  \\"version\\": \\"2018-05-29\\",
+  \\"method\\": \\"POST\\",
+  \\"resourcePath\\": \\"/\\",
+  \\"params\\": {
+    \\"headers\\": {
+      \\"content-type\\": \\"application/x-amz-json-1.0\\",
+      \\"x-amz-target\\": \\"AWSStepFunctions.StartExecution\\"
+    },
+    \\"body\\": $util.toJson($v1)
+  }
+}",
+  "#if($context.result.statusCode == 200)
+    #set($sfn__result = $util.parseJson($context.result.body))
+    #else 
+    $util.error($context.result.body, \\"$context.result.statusCode\\")
+    #end
+#set( $context.stash.res2 = $sfn__result )
+{}",
+  "#if($context.stash.return__flag)
+  #return($context.stash.return__val)
+#end
+#set($v1 = {})
+$util.qr($v1.put('input', $util.toJson($context.stash.res2)))
+$util.qr($v1.put('stateMachineArn', '__REPLACED_TOKEN'))
+{
+  \\"version\\": \\"2018-05-29\\",
+  \\"method\\": \\"POST\\",
+  \\"resourcePath\\": \\"/\\",
+  \\"params\\": {
+    \\"headers\\": {
+      \\"content-type\\": \\"application/x-amz-json-1.0\\",
+      \\"x-amz-target\\": \\"AWSStepFunctions.StartExecution\\"
+    },
+    \\"body\\": $util.toJson($v1)
+  }
+}",
+  "#if($context.result.statusCode == 200)
+    #set($sfn__result = $util.parseJson($context.result.body))
+    #else 
+    $util.error($context.result.body, \\"$context.result.statusCode\\")
+    #end
+#set( $context.stash.result = $sfn__result )
+{}",
+  "#if($context.stash.return__flag)
+  #return($context.stash.return__val)
+#end
+#return($context.stash.result.startDate)",
+]
+`;
+
+exports[`multiple linked integrations post-compute 2`] = `
+Object {
+  "method": "POST",
+  "params": Object {
+    "body": Object {
+      "input": "{}",
+      "stateMachineArn": "__REPLACED_TOKEN",
+    },
+    "headers": Object {
+      "content-type": "application/x-amz-json-1.0",
+      "x-amz-target": "AWSStepFunctions.StartExecution",
+    },
+  },
+  "resourcePath": "/",
+  "version": "2018-05-29",
+}
+`;
+
+exports[`multiple linked integrations pre-compute 1`] = `
+Array [
+  "{}",
+  "#if($context.stash.return__flag)
+  #return($context.stash.return__val)
+#end
+#set($context.stash.x = 'y')
+#set($v1 = {})
+#set($v2 = {})
+$util.qr($v2.put('x', $context.stash.x))
+$util.qr($v1.put('input', $util.toJson($v2)))
+$util.qr($v1.put('stateMachineArn', '__REPLACED_TOKEN'))
+{
+  \\"version\\": \\"2018-05-29\\",
+  \\"method\\": \\"POST\\",
+  \\"resourcePath\\": \\"/\\",
+  \\"params\\": {
+    \\"headers\\": {
+      \\"content-type\\": \\"application/x-amz-json-1.0\\",
+      \\"x-amz-target\\": \\"AWSStepFunctions.StartExecution\\"
+    },
+    \\"body\\": $util.toJson($v1)
+  }
+}",
+  "#if($context.result.statusCode == 200)
+    #set($sfn__result = $util.parseJson($context.result.body))
+    #else 
+    $util.error($context.result.body, \\"$context.result.statusCode\\")
+    #end
+#set( $context.stash.res1 = $sfn__result )
+{}",
+  "#if($context.stash.return__flag)
+  #return($context.stash.return__val)
+#end
+#set($v1 = {})
+$util.qr($v1.put('input', $util.toJson($context.stash.res1)))
+$util.qr($v1.put('stateMachineArn', '__REPLACED_TOKEN'))
+{
+  \\"version\\": \\"2018-05-29\\",
+  \\"method\\": \\"POST\\",
+  \\"resourcePath\\": \\"/\\",
+  \\"params\\": {
+    \\"headers\\": {
+      \\"content-type\\": \\"application/x-amz-json-1.0\\",
+      \\"x-amz-target\\": \\"AWSStepFunctions.StartExecution\\"
+    },
+    \\"body\\": $util.toJson($v1)
+  }
+}",
+  "#if($context.result.statusCode == 200)
+    #set($sfn__result = $util.parseJson($context.result.body))
+    #else 
+    $util.error($context.result.body, \\"$context.result.statusCode\\")
+    #end
+#set( $context.stash.res2 = $sfn__result )
+{}",
+  "#if($context.stash.return__flag)
+  #return($context.stash.return__val)
+#end
+#set($v1 = {})
+$util.qr($v1.put('input', $util.toJson($context.stash.res2)))
+$util.qr($v1.put('stateMachineArn', '__REPLACED_TOKEN'))
+{
+  \\"version\\": \\"2018-05-29\\",
+  \\"method\\": \\"POST\\",
+  \\"resourcePath\\": \\"/\\",
+  \\"params\\": {
+    \\"headers\\": {
+      \\"content-type\\": \\"application/x-amz-json-1.0\\",
+      \\"x-amz-target\\": \\"AWSStepFunctions.StartExecution\\"
+    },
+    \\"body\\": $util.toJson($v1)
+  }
+}",
+  "{}",
+  "#if($context.stash.return__flag)
+  #return($context.stash.return__val)
+#end",
+]
+`;
+
+exports[`multiple linked integrations pre-compute 2`] = `
+Object {
+  "method": "POST",
+  "params": Object {
+    "body": Object {
+      "input": "{\\"x\\":\\"y\\"}",
+      "stateMachineArn": "__REPLACED_TOKEN",
+    },
+    "headers": Object {
+      "content-type": "application/x-amz-json-1.0",
+      "x-amz-target": "AWSStepFunctions.StartExecution",
+    },
+  },
+  "resourcePath": "/",
+  "version": "2018-05-29",
+}
+`;
+
+exports[`multiple linked integrations with mutation 1`] = `
+Array [
+  "{}",
+  "#if($context.stash.return__flag)
+  #return($context.stash.return__val)
+#end
+{
+  \\"version\\": \\"2018-05-29\\",
+  \\"method\\": \\"POST\\",
+  \\"resourcePath\\": \\"/\\",
+  \\"params\\": {
+    \\"headers\\": {
+      \\"content-type\\": \\"application/x-amz-json-1.0\\",
+      \\"x-amz-target\\": \\"AWSStepFunctions.DescribeExecution\\"
+    },
+    \\"body\\": {
+      \\"executionArn\\": $util.toJson('exec1')
+    }
+  }
+}",
+  "#if($context.result.statusCode == 200)
+    #set($sfn__result = $util.parseJson($context.result.body))
+    #else 
+    $util.error($context.result.body, \\"$context.result.statusCode\\")
+    #end
+#set( $context.stash.res1 = $sfn__result )
+{}",
+  "#if($context.stash.return__flag)
+  #return($context.stash.return__val)
+#end
+#set($context.stash.formatted = \\"status: \${context.stash.res1.status}\\")
+#set($v1 = {})
+#set($v2 = {})
+$util.qr($v2.put('x', $context.stash.formatted))
+$util.qr($v1.put('input', $util.toJson($v2)))
+$util.qr($v1.put('stateMachineArn', '__REPLACED_TOKEN'))
+{
+  \\"version\\": \\"2018-05-29\\",
+  \\"method\\": \\"POST\\",
+  \\"resourcePath\\": \\"/\\",
+  \\"params\\": {
+    \\"headers\\": {
+      \\"content-type\\": \\"application/x-amz-json-1.0\\",
+      \\"x-amz-target\\": \\"AWSStepFunctions.StartExecution\\"
+    },
+    \\"body\\": $util.toJson($v1)
+  }
+}",
+  "{}",
+  "#if($context.stash.return__flag)
+  #return($context.stash.return__val)
+#end",
+]
+`;
+
+exports[`multiple linked integrations with mutation 2`] = `
+Object {
+  "method": "POST",
+  "params": Object {
+    "body": Object {
+      "executionArn": "exec1",
+    },
+    "headers": Object {
+      "content-type": "application/x-amz-json-1.0",
+      "x-amz-target": "AWSStepFunctions.DescribeExecution",
+    },
+  },
+  "resourcePath": "/",
+  "version": "2018-05-29",
+}
+`;
+
+exports[`multiple linked integrations with props 1`] = `
+Array [
+  "{}",
+  "#if($context.stash.return__flag)
+  #return($context.stash.return__val)
+#end
+{
+  \\"version\\": \\"2018-05-29\\",
+  \\"method\\": \\"POST\\",
+  \\"resourcePath\\": \\"/\\",
+  \\"params\\": {
+    \\"headers\\": {
+      \\"content-type\\": \\"application/x-amz-json-1.0\\",
+      \\"x-amz-target\\": \\"AWSStepFunctions.DescribeExecution\\"
+    },
+    \\"body\\": {
+      \\"executionArn\\": $util.toJson('exec1')
+    }
+  }
+}",
+  "#if($context.result.statusCode == 200)
+    #set($sfn__result = $util.parseJson($context.result.body))
+    #else 
+    $util.error($context.result.body, \\"$context.result.statusCode\\")
+    #end
+#set( $context.stash.res1 = $sfn__result )
+{}",
+  "#if($context.stash.return__flag)
+  #return($context.stash.return__val)
+#end
+{
+  \\"version\\": \\"2018-05-29\\",
+  \\"method\\": \\"POST\\",
+  \\"resourcePath\\": \\"/\\",
+  \\"params\\": {
+    \\"headers\\": {
+      \\"content-type\\": \\"application/x-amz-json-1.0\\",
+      \\"x-amz-target\\": \\"AWSStepFunctions.DescribeExecution\\"
+    },
+    \\"body\\": {
+      \\"executionArn\\": $util.toJson($context.stash.res1.executionArn)
+    }
+  }
+}",
+  "#if($context.result.statusCode == 200)
+    #set($sfn__result = $util.parseJson($context.result.body))
+    #else 
+    $util.error($context.result.body, \\"$context.result.statusCode\\")
+    #end
+#set( $context.stash.res2 = $sfn__result )
+{}",
+  "#if($context.stash.return__flag)
+  #return($context.stash.return__val)
+#end
+{
+  \\"version\\": \\"2018-05-29\\",
+  \\"method\\": \\"POST\\",
+  \\"resourcePath\\": \\"/\\",
+  \\"params\\": {
+    \\"headers\\": {
+      \\"content-type\\": \\"application/x-amz-json-1.0\\",
+      \\"x-amz-target\\": \\"AWSStepFunctions.DescribeExecution\\"
+    },
+    \\"body\\": {
+      \\"executionArn\\": $util.toJson($context.stash.res2.executionArn)
+    }
+  }
+}",
+  "{}",
+  "#if($context.stash.return__flag)
+  #return($context.stash.return__val)
+#end",
+]
+`;
+
+exports[`multiple linked integrations with props 2`] = `
+Object {
+  "method": "POST",
+  "params": Object {
+    "body": Object {
+      "executionArn": "exec1",
+    },
+    "headers": Object {
+      "content-type": "application/x-amz-json-1.0",
+      "x-amz-target": "AWSStepFunctions.DescribeExecution",
+    },
+  },
+  "resourcePath": "/",
+  "version": "2018-05-29",
+}
+`;
+
+exports[`multiple nested integrations 1`] = `
+Array [
+  "{}",
+  "#if($context.stash.return__flag)
+  #return($context.stash.return__val)
+#end
+#set($v1 = {})
+#set($v2 = {})
+#set($v3 = {})
+#set($v4 = {})
+$util.qr($v3.put('input', $util.toJson($v4)))
+$util.qr($v3.put('stateMachineArn', '__REPLACED_TOKEN'))
+$util.qr($v2.put('input', $util.toJson({
+  \\"version\\": \\"2018-05-29\\",
+  \\"method\\": \\"POST\\",
+  \\"resourcePath\\": \\"/\\",
+  \\"params\\": {
+    \\"headers\\": {
+      \\"content-type\\": \\"application/x-amz-json-1.0\\",
+      \\"x-amz-target\\": \\"AWSStepFunctions.StartExecution\\"
+    },
+    \\"body\\": $util.toJson($v3)
+  }
+})))
+$util.qr($v2.put('stateMachineArn', '__REPLACED_TOKEN'))
+$util.qr($v1.put('input', $util.toJson({
+  \\"version\\": \\"2018-05-29\\",
+  \\"method\\": \\"POST\\",
+  \\"resourcePath\\": \\"/\\",
+  \\"params\\": {
+    \\"headers\\": {
+      \\"content-type\\": \\"application/x-amz-json-1.0\\",
+      \\"x-amz-target\\": \\"AWSStepFunctions.StartExecution\\"
+    },
+    \\"body\\": $util.toJson($v2)
+  }
+})))
+$util.qr($v1.put('stateMachineArn', '__REPLACED_TOKEN'))
+{
+  \\"version\\": \\"2018-05-29\\",
+  \\"method\\": \\"POST\\",
+  \\"resourcePath\\": \\"/\\",
+  \\"params\\": {
+    \\"headers\\": {
+      \\"content-type\\": \\"application/x-amz-json-1.0\\",
+      \\"x-amz-target\\": \\"AWSStepFunctions.StartExecution\\"
+    },
+    \\"body\\": $util.toJson($v1)
+  }
+}",
+  "{}",
+  "#if($context.stash.return__flag)
+  #return($context.stash.return__val)
+#end",
+]
+`;
+
+exports[`multiple nested integrations 2`] = `
+Object {
+  "method": "POST",
+  "params": Object {
+    "body": Object {
+      "input": "{\\"version\\":\\"2018-05-29\\",\\"method\\":\\"POST\\",\\"resourcePath\\":\\"/\\",\\"params\\":{\\"headers\\":{\\"content-type\\":\\"application/x-amz-json-1.0\\",\\"x-amz-target\\":\\"AWSStepFunctions.StartExecution\\"},\\"body\\":\\"{\\\\\\"input\\\\\\":\\\\\\"{\\\\\\\\\\\\\\"version\\\\\\\\\\\\\\":\\\\\\\\\\\\\\"2018-05-29\\\\\\\\\\\\\\",\\\\\\\\\\\\\\"method\\\\\\\\\\\\\\":\\\\\\\\\\\\\\"POST\\\\\\\\\\\\\\",\\\\\\\\\\\\\\"resourcePath\\\\\\\\\\\\\\":\\\\\\\\\\\\\\"/\\\\\\\\\\\\\\",\\\\\\\\\\\\\\"params\\\\\\\\\\\\\\":{\\\\\\\\\\\\\\"headers\\\\\\\\\\\\\\":{\\\\\\\\\\\\\\"content-type\\\\\\\\\\\\\\":\\\\\\\\\\\\\\"application/x-amz-json-1.0\\\\\\\\\\\\\\",\\\\\\\\\\\\\\"x-amz-target\\\\\\\\\\\\\\":\\\\\\\\\\\\\\"AWSStepFunctions.StartExecution\\\\\\\\\\\\\\"},\\\\\\\\\\\\\\"body\\\\\\\\\\\\\\":\\\\\\\\\\\\\\"{\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\"input\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\":\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\"{}\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\",\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\"stateMachineArn\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\":\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\"__REPLACED_TOKEN\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\"}\\\\\\\\\\\\\\"}}\\\\\\",\\\\\\"stateMachineArn\\\\\\":\\\\\\"__REPLACED_TOKEN\\\\\\"}\\"}}",
+      "stateMachineArn": "__REPLACED_TOKEN",
+    },
+    "headers": Object {
+      "content-type": "application/x-amz-json-1.0",
+      "x-amz-target": "AWSStepFunctions.StartExecution",
+    },
+  },
+  "resourcePath": "/",
+  "version": "2018-05-29",
+}
+`;
+
+exports[`multiple nested integrations prop access 1`] = `
+Array [
+  "{}",
+  "#if($context.stash.return__flag)
+  #return($context.stash.return__val)
+#end
+{
+  \\"version\\": \\"2018-05-29\\",
+  \\"method\\": \\"POST\\",
+  \\"resourcePath\\": \\"/\\",
+  \\"params\\": {
+    \\"headers\\": {
+      \\"content-type\\": \\"application/x-amz-json-1.0\\",
+      \\"x-amz-target\\": \\"AWSStepFunctions.DescribeExecution\\"
+    },
+    \\"body\\": {
+      \\"executionArn\\": $util.toJson({
+  \\"version\\": \\"2018-05-29\\",
+  \\"method\\": \\"POST\\",
+  \\"resourcePath\\": \\"/\\",
+  \\"params\\": {
+    \\"headers\\": {
+      \\"content-type\\": \\"application/x-amz-json-1.0\\",
+      \\"x-amz-target\\": \\"AWSStepFunctions.DescribeExecution\\"
+    },
+    \\"body\\": {
+      \\"executionArn\\": $util.toJson({
+  \\"version\\": \\"2018-05-29\\",
+  \\"method\\": \\"POST\\",
+  \\"resourcePath\\": \\"/\\",
+  \\"params\\": {
+    \\"headers\\": {
+      \\"content-type\\": \\"application/x-amz-json-1.0\\",
+      \\"x-amz-target\\": \\"AWSStepFunctions.DescribeExecution\\"
+    },
+    \\"body\\": {
+      \\"executionArn\\": $util.toJson('exec1')
+    }
+  }
+}.executionArn)
+    }
+  }
+}.executionArn)
+    }
+  }
+}",
+  "{}",
+  "#if($context.stash.return__flag)
+  #return($context.stash.return__val)
+#end",
+]
+`;
+
 exports[`step function describe execution machine describe exec string 1`] = `
 Array [
   "{}",

--- a/test/__snapshots__/function.test.ts.snap
+++ b/test/__snapshots__/function.test.ts.snap
@@ -1,0 +1,115 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`call function 1`] = `
+Array [
+  "{}",
+  "#if($context.stash.return__flag)
+  #return($context.stash.return__val)
+#end
+#set($v1 = {\\"version\\": \\"2018-05-29\\", \\"operation\\": \\"Invoke\\", \\"payload\\": $context.arguments})
+$util.toJson($v1)",
+  "#set( $context.stash.return__flag = true )
+#set( $context.stash.return__val = $context.result )
+{}",
+  "#if($context.stash.return__flag)
+  #return($context.stash.return__val)
+#end",
+]
+`;
+
+exports[`call function and conditional return 1`] = `
+Array [
+  "{}",
+  "#if($context.stash.return__flag)
+  #return($context.stash.return__val)
+#end
+#set($v1 = {\\"version\\": \\"2018-05-29\\", \\"operation\\": \\"Invoke\\", \\"payload\\": $context.arguments})
+$util.toJson($v1)",
+  "#set( $context.stash.result = $context.result )
+{}",
+  "#if($context.stash.return__flag)
+  #return($context.stash.return__val)
+#end
+#set($v1 = $context.stash.result.id == 'sam')
+#if($v1)
+#set($context.stash.return__val = true)
+#set($context.stash.return__flag = true)
+#return($context.stash.return__val)
+#else
+#set($context.stash.return__val = false)
+#set($context.stash.return__flag = true)
+#return($context.stash.return__val)
+#end",
+]
+`;
+
+exports[`call function including optional arg 1`] = `
+Array [
+  "{}",
+  "#if($context.stash.return__flag)
+  #return($context.stash.return__val)
+#end
+#set($v1 = {})
+$util.qr($v1.put('arg', $context.arguments.arg))
+$util.qr($v1.put('optional', 'hello'))
+#set($v2 = {\\"version\\": \\"2018-05-29\\", \\"operation\\": \\"Invoke\\", \\"payload\\": $v1})
+$util.toJson($v2)",
+  "#set( $context.stash.return__flag = true )
+#set( $context.stash.return__val = $context.result )
+{}",
+  "#if($context.stash.return__flag)
+  #return($context.stash.return__val)
+#end",
+]
+`;
+
+exports[`call function including with no parameters 1`] = `
+Array [
+  "{}",
+  "#if($context.stash.return__flag)
+  #return($context.stash.return__val)
+#end
+#set($v1 = {\\"version\\": \\"2018-05-29\\", \\"operation\\": \\"Invoke\\", \\"payload\\": $null})
+$util.toJson($v1)",
+  "#set( $context.stash.return__flag = true )
+#set( $context.stash.return__val = $context.result )
+{}",
+  "#if($context.stash.return__flag)
+  #return($context.stash.return__val)
+#end",
+]
+`;
+
+exports[`call function including with void result 1`] = `
+Array [
+  "{}",
+  "#if($context.stash.return__flag)
+  #return($context.stash.return__val)
+#end
+#set($v1 = {\\"version\\": \\"2018-05-29\\", \\"operation\\": \\"Invoke\\", \\"payload\\": $context.arguments})
+$util.toJson($v1)",
+  "#set( $context.stash.return__flag = true )
+#set( $context.stash.return__val = $context.result )
+{}",
+  "#if($context.stash.return__flag)
+  #return($context.stash.return__val)
+#end",
+]
+`;
+
+exports[`call function omitting optional arg 1`] = `
+Array [
+  "{}",
+  "#if($context.stash.return__flag)
+  #return($context.stash.return__val)
+#end
+#set($v1 = {\\"version\\": \\"2018-05-29\\", \\"operation\\": \\"Invoke\\", \\"payload\\": $context.arguments})
+$util.toJson($v1)",
+  "#set( $context.stash.return__flag = true )
+#set( $context.stash.return__val = $context.result )
+{}",
+  "#if($context.stash.return__flag)
+  #return($context.stash.return__val)
+#end",
+]
+`;

--- a/test/__snapshots__/table.test.ts.snap
+++ b/test/__snapshots__/table.test.ts.snap
@@ -1,0 +1,223 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`delete item 1`] = `
+Array [
+  "{}",
+  "#if($context.stash.return__flag)
+  #return($context.stash.return__val)
+#end
+#set($v1 = {})
+#set($v2 = {})
+#set($v3 = {})
+$util.qr($v3.put('S', $context.arguments.id))
+$util.qr($v2.put('id', $v3))
+$util.qr($v1.put('key', $v2))
+#set($v4 = {})
+$util.qr($v4.put('expression', '#name = #name + 1'))
+#set($v5 = {})
+$util.qr($v5.put('#name', 'name'))
+$util.qr($v4.put('expressionNames', $v5))
+$util.qr($v1.put('condition', $v4))
+#set($v6 = {\\"operation\\": \\"DeleteItem\\", \\"version\\": \\"2018-05-29\\"})
+$util.qr($v6.put('key', $v1.get('key')))
+#if($v1.containsKey('condition'))
+$util.qr($v6.put('condition', $v1.get('condition')))
+#end
+#if($v1.containsKey('_version'))
+$util.qr($v6.put('_version', $v1.get('_version')))
+#end
+$util.toJson($v6)",
+  "#set( $context.stash.return__flag = true )
+#set( $context.stash.return__val = $context.result )
+{}",
+  "#if($context.stash.return__flag)
+  #return($context.stash.return__val)
+#end",
+]
+`;
+
+exports[`get item 1`] = `
+Array [
+  "{}",
+  "#if($context.stash.return__flag)
+  #return($context.stash.return__val)
+#end
+#set($v1 = {})
+#set($v2 = {})
+#set($v3 = {})
+$util.qr($v3.put('S', $context.arguments.id))
+$util.qr($v2.put('id', $v3))
+$util.qr($v1.put('key', $v2))
+#set($v4 = {\\"operation\\": \\"GetItem\\", \\"version\\": \\"2018-05-29\\"})
+$util.qr($v4.put('key', $v1.get('key')))
+#if($v1.containsKey('consistentRead'))
+$util.qr($v4.put('consistentRead', $v1.get('consistentRead')))
+#end
+$util.toJson($v4)",
+  "#set( $context.stash.return__flag = true )
+#set( $context.stash.return__val = $context.result )
+{}",
+  "#if($context.stash.return__flag)
+  #return($context.stash.return__val)
+#end",
+]
+`;
+
+exports[`get item and set consistentRead:true 1`] = `
+Array [
+  "{}",
+  "#if($context.stash.return__flag)
+  #return($context.stash.return__val)
+#end
+#set($v1 = {})
+#set($v2 = {})
+#set($v3 = {})
+$util.qr($v3.put('S', $context.arguments.id))
+$util.qr($v2.put('id', $v3))
+$util.qr($v1.put('key', $v2))
+$util.qr($v1.put('consistentRead', true))
+#set($v4 = {\\"operation\\": \\"GetItem\\", \\"version\\": \\"2018-05-29\\"})
+$util.qr($v4.put('key', $v1.get('key')))
+#if($v1.containsKey('consistentRead'))
+$util.qr($v4.put('consistentRead', $v1.get('consistentRead')))
+#end
+$util.toJson($v4)",
+  "#set( $context.stash.return__flag = true )
+#set( $context.stash.return__val = $context.result )
+{}",
+  "#if($context.stash.return__flag)
+  #return($context.stash.return__val)
+#end",
+]
+`;
+
+exports[`put item 1`] = `
+Array [
+  "{}",
+  "#if($context.stash.return__flag)
+  #return($context.stash.return__val)
+#end
+#set($v1 = {})
+#set($v2 = {})
+#set($v3 = {})
+$util.qr($v3.put('S', $context.arguments.id))
+$util.qr($v2.put('id', $v3))
+$util.qr($v1.put('key', $v2))
+#set($v4 = {})
+#set($v5 = {})
+$util.qr($v5.put('N', \\"\${context.arguments.name}\\"))
+$util.qr($v4.put('name', $v5))
+$util.qr($v1.put('attributeValues', $v4))
+#set($v6 = {})
+$util.qr($v6.put('expression', '#name = :val'))
+#set($v7 = {})
+$util.qr($v7.put('#name', 'name'))
+$util.qr($v6.put('expressionNames', $v7))
+#set($v8 = {})
+#set($v9 = {})
+$util.qr($v9.put('S', $context.arguments.id))
+$util.qr($v8.put(':val', $v9))
+$util.qr($v6.put('expressionValues', $v8))
+$util.qr($v1.put('condition', $v6))
+#set($v10 = {\\"operation\\": \\"PutItem\\", \\"version\\": \\"2018-05-29\\"})
+$util.qr($v10.put('key', $v1.get('key')))
+$util.qr($v10.put('attributeValues', $v1.get('attributeValues')))
+#if($v1.containsKey('condition'))
+$util.qr($v10.put('condition', $v1.get('condition')))
+#end
+#if($v1.containsKey('_version'))
+$util.qr($v10.put('_version', $v1.get('_version')))
+#end
+$util.toJson($v10)",
+  "#set( $context.stash.return__flag = true )
+#set( $context.stash.return__val = $context.result )
+{}",
+  "#if($context.stash.return__flag)
+  #return($context.stash.return__val)
+#end",
+]
+`;
+
+exports[`query 1`] = `
+Array [
+  "{}",
+  "#if($context.stash.return__flag)
+  #return($context.stash.return__val)
+#end
+#set($v1 = {})
+#set($v2 = {})
+$util.qr($v2.put('expression', 'id = :id and #name = :val'))
+#set($v3 = {})
+$util.qr($v3.put('#name', 'name'))
+$util.qr($v2.put('expressionNames', $v3))
+#set($v4 = {})
+$util.qr($v4.put(':id', $util.dynamodb.toDynamoDB($context.arguments.id)))
+$util.qr($v4.put(':val', $util.dynamodb.toDynamoDB($context.arguments.sort)))
+$util.qr($v2.put('expressionValues', $v4))
+$util.qr($v1.put('query', $v2))
+#set($v5 = {\\"operation\\": \\"Query\\", \\"version\\": \\"2018-05-29\\"})
+$util.qr($v5.put('query', $v1.get('query')))
+#if($v1.containsKey('index'))
+$util.qr($v5.put('index', $v1.get('index')))
+#end
+#if($v1.containsKey('nextToken'))
+$util.qr($v5.put('nextToken', $v1.get('nextToken')))
+#end
+#if($v1.containsKey('limit'))
+$util.qr($v5.put('limit', $v1.get('limit')))
+#end
+#if($v1.containsKey('scanIndexForward'))
+$util.qr($v5.put('scanIndexForward', $v1.get('scanIndexForward')))
+#end
+#if($v1.containsKey('consistentRead'))
+$util.qr($v5.put('consistentRead', $v1.get('consistentRead')))
+#end
+#if($v1.containsKey('select'))
+$util.qr($v5.put('select', $v1.get('select')))
+#end
+$util.toJson($v5)",
+  "#set( $context.stash.return__flag = true )
+#set( $context.stash.return__val = $context.result.items )
+{}",
+  "#if($context.stash.return__flag)
+  #return($context.stash.return__val)
+#end",
+]
+`;
+
+exports[`update item 1`] = `
+Array [
+  "{}",
+  "#if($context.stash.return__flag)
+  #return($context.stash.return__val)
+#end
+#set($v1 = {})
+#set($v2 = {})
+#set($v3 = {})
+$util.qr($v3.put('S', $context.arguments.id))
+$util.qr($v2.put('id', $v3))
+$util.qr($v1.put('key', $v2))
+#set($v4 = {})
+$util.qr($v4.put('expression', '#name = #name + 1'))
+#set($v5 = {})
+$util.qr($v5.put('#name', 'name'))
+$util.qr($v4.put('expressionNames', $v5))
+$util.qr($v1.put('update', $v4))
+#set($v6 = {\\"operation\\": \\"UpdateItem\\", \\"version\\": \\"2018-05-29\\"})
+$util.qr($v6.put('key', $v1.get('key')))
+$util.qr($v6.put('update', $v1.get('update')))
+#if($v1.containsKey('condition'))
+$util.qr($v6.put('condition', $v1.get('condition')))
+#end
+#if($v1.containsKey('_version'))
+$util.qr($v6.put('_version', $v1.get('_version')))
+#end
+$util.toJson($v6)",
+  "#set( $context.stash.return__flag = true )
+#set( $context.stash.return__val = $context.result )
+{}",
+  "#if($context.stash.return__flag)
+  #return($context.stash.return__val)
+#end",
+]
+`;

--- a/test/__snapshots__/vtl.test.ts.snap
+++ b/test/__snapshots__/vtl.test.ts.snap
@@ -1,0 +1,531 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`$util.time.nowISO8601 1`] = `
+Array [
+  "{
+  \\"version\\": \\"2018-05-29\\",
+  \\"payload\\": null
+}",
+  "#return($util.time.nowISO8601())",
+]
+`;
+
+exports[`BinaryExpr and UnaryExpr are evaluated to temporary variables 1`] = `
+Array [
+  "{
+  \\"version\\": \\"2018-05-29\\",
+  \\"payload\\": null
+}",
+  "#set($v1 = {})
+#set($v2 = 0 - 1)
+$util.qr($v1.put('x', $v2))
+#set($v3 = 1 + 1)
+#set($v4 = 0 - $v3)
+$util.qr($v1.put('y', $v4))
+#set($v5 = true && false)
+#set($v6 = !$v5)
+$util.qr($v1.put('z', $v6))
+#return($v1)",
+]
+`;
+
+exports[`break from for-loop 1`] = `
+Array [
+  "{
+  \\"version\\": \\"2018-05-29\\",
+  \\"payload\\": null
+}",
+  "#set($context.stash.newList = [])
+#foreach($item in $context.arguments.list)
+#set($v1 = $item == 'hello')
+#if($v1)
+#break
+#end
+$util.qr($context.stash.newList.addAll([$item]))
+#end
+#return($context.stash.newList)",
+]
+`;
+
+exports[`call function and return its value 1`] = `
+Array [
+  "{
+  \\"version\\": \\"2018-05-29\\",
+  \\"payload\\": null
+}",
+  "#return($util.autoId())",
+]
+`;
+
+exports[`call function, assign to variable and return variable reference 1`] = `
+Array [
+  "{
+  \\"version\\": \\"2018-05-29\\",
+  \\"payload\\": null
+}",
+  "#set($context.stash.id = $util.autoId())
+#return($context.stash.id)",
+]
+`;
+
+exports[`chain map over list 1`] = `
+Array [
+  "{
+  \\"version\\": \\"2018-05-29\\",
+  \\"payload\\": null
+}",
+  "#set($v1 = [])
+#foreach($item in $context.arguments.list)
+#set($item = \\"hello \${item}\\")
+#set($v2 = \\"hello \${item}\\")
+$util.qr($v1.add($v2))
+#end
+#return($v1)",
+]
+`;
+
+exports[`chain map over list complex 1`] = `
+Array [
+  "{
+  \\"version\\": \\"2018-05-29\\",
+  \\"payload\\": null
+}",
+  "#set($v1 = [])
+#foreach($item in $context.arguments.list)
+#set($i = $foreach.index)
+#set($arr = $context.arguments.list)
+#set($v2 = $i + 1)
+#set($x = $v2)
+#set($item2 = \\"hello \${item} \${x} \${arr.length}\\")
+#set($ii = $foreach.index)
+#set($v3 = \\"hello \${item2} \${ii}\\")
+$util.qr($v1.add($v3))
+#end
+#return($v1)",
+]
+`;
+
+exports[`chain map over list multiple array 1`] = `
+Array [
+  "{
+  \\"version\\": \\"2018-05-29\\",
+  \\"payload\\": null
+}",
+  "#set($v1 = [])
+#set($v2 = [])
+#foreach($item in $context.arguments.list)
+#set($_i = $foreach.index)
+#set($_arr = $context.arguments.list)
+#set($v3 = \\"hello \${item}\\")
+$util.qr($v2.add($v3))
+#end
+#foreach($item in $v2)
+#set($_i = $foreach.index)
+#set($_arr = $v2)
+#set($v4 = \\"hello \${item}\\")
+$util.qr($v1.add($v4))
+#end
+#return($v1)",
+]
+`;
+
+exports[`computed property names 1`] = `
+Array [
+  "{
+  \\"version\\": \\"2018-05-29\\",
+  \\"payload\\": null
+}",
+  "#set($context.stash.name = $context.arguments.arg)
+#set($v1 = $context.stash.name + '_test')
+#set($context.stash.value = $v1)
+#set($v2 = {})
+$util.qr($v2.put($context.stash.name, $context.arguments.arg))
+$util.qr($v2.put($context.stash.value, $context.arguments.arg))
+#return($v2)",
+]
+`;
+
+exports[`conditional expression in template expression 1`] = `
+Array [
+  "{
+  \\"version\\": \\"2018-05-29\\",
+  \\"payload\\": null
+}",
+  "#set($v2 = $context.arguments.a == 'hello')
+#if($v2)
+#set($v1 = 'world')
+#else
+#set($v1 = $context.arguments.a)
+#end
+#return(\\"head \${v1}\\")",
+]
+`;
+
+exports[`empty function returning an argument 1`] = `
+Array [
+  "{
+  \\"version\\": \\"2018-05-29\\",
+  \\"payload\\": null
+}",
+  "#return($context.arguments.a)",
+]
+`;
+
+exports[`for-in loop and element access 1`] = `
+Array [
+  "{
+  \\"version\\": \\"2018-05-29\\",
+  \\"payload\\": null
+}",
+  "#set($context.stash.newList = [])
+#foreach($key in $context.arguments.record.keySet())
+$util.qr($context.stash.newList.addAll([$context.arguments.record[$key]]))
+#end
+#return($context.stash.newList)",
+]
+`;
+
+exports[`for-of loop 1`] = `
+Array [
+  "{
+  \\"version\\": \\"2018-05-29\\",
+  \\"payload\\": null
+}",
+  "#set($context.stash.newList = [])
+#foreach($item in $context.arguments.list)
+$util.qr($context.stash.newList.addAll([$item]))
+#end
+#return($context.stash.newList)",
+]
+`;
+
+exports[`forEach over list 1`] = `
+Array [
+  "{
+  \\"version\\": \\"2018-05-29\\",
+  \\"payload\\": null
+}",
+  "#foreach($item in $context.arguments.list)
+$util.qr($util.error($item))
+#end
+#return($null)",
+]
+`;
+
+exports[`if statement 1`] = `
+Array [
+  "{
+  \\"version\\": \\"2018-05-29\\",
+  \\"payload\\": null
+}",
+  "#set($v1 = $context.arguments.list.length > 0)
+#if($v1)
+#set($context.stash.return__val = true)
+#set($context.stash.return__flag = true)
+#return($context.stash.return__val)
+#else
+#set($context.stash.return__val = false)
+#set($context.stash.return__flag = true)
+#return($context.stash.return__val)
+#end",
+]
+`;
+
+exports[`local variable inside for-of loop is declared as a local variable 1`] = `
+Array [
+  "{
+  \\"version\\": \\"2018-05-29\\",
+  \\"payload\\": null
+}",
+  "#set($context.stash.newList = [])
+#foreach($item in $context.arguments.list)
+#set($i = $item)
+$util.qr($context.stash.newList.addAll([$i]))
+#end
+#return($context.stash.newList)",
+]
+`;
+
+exports[`map and reduce and map and reduce over list with initial value 1`] = `
+Array [
+  "{
+  \\"version\\": \\"2018-05-29\\",
+  \\"payload\\": null
+}",
+  "#set($v2 = [])
+#foreach($item in $context.arguments.list)
+#set($item = \\"hello \${item}\\")
+#set($newList = $v2)
+#set($v4 = [])
+$util.qr($v4.addAll($newList))
+$util.qr($v4.add($item))
+#set($v3 = $v4)
+#set($v2 = $v3)
+#end
+#set($v1 = [])
+#foreach($item in $v2)
+#set($item = \\"hello \${item}\\")
+#set($newList = $v1)
+#set($v6 = [])
+$util.qr($v6.addAll($newList))
+$util.qr($v6.add($item))
+#set($v5 = $v6)
+#set($v1 = $v5)
+#end
+#return($v1)",
+]
+`;
+
+exports[`map and reduce over list with initial value 1`] = `
+Array [
+  "{
+  \\"version\\": \\"2018-05-29\\",
+  \\"payload\\": null
+}",
+  "#set($v1 = [])
+#foreach($item in $context.arguments.list)
+#set($item = \\"hello \${item}\\")
+#set($newList = $v1)
+#set($v3 = [])
+$util.qr($v3.addAll($newList))
+$util.qr($v3.add($item))
+#set($v2 = $v3)
+#set($v1 = $v2)
+#end
+#return($v1)",
+]
+`;
+
+exports[`map and reduce with array over list with initial value 1`] = `
+Array [
+  "{
+  \\"version\\": \\"2018-05-29\\",
+  \\"payload\\": null
+}",
+  "#set($v2 = [])
+#foreach($item in $context.arguments.list)
+#set($v3 = \\"hello \${item}\\")
+$util.qr($v2.add($v3))
+#end
+#set($v1 = [])
+#foreach($item in $v2)
+#set($_i = $foreach.index)
+#set($_arr = $v2)
+#set($newList = $v1)
+#set($v5 = [])
+$util.qr($v5.addAll($newList))
+$util.qr($v5.add($item))
+#set($v4 = $v5)
+#set($v1 = $v4)
+#end
+#return($v1)",
+]
+`;
+
+exports[`map over list 1`] = `
+Array [
+  "{
+  \\"version\\": \\"2018-05-29\\",
+  \\"payload\\": null
+}",
+  "#set($v1 = [])
+#foreach($item in $context.arguments.list)
+#set($v2 = \\"hello \${item}\\")
+$util.qr($v1.add($v2))
+#end
+#return($v1)",
+]
+`;
+
+exports[`map over list with in-line return 1`] = `
+Array [
+  "{
+  \\"version\\": \\"2018-05-29\\",
+  \\"payload\\": null
+}",
+  "#set($v1 = [])
+#foreach($item in $context.arguments.list)
+#set($v2 = \\"hello \${item}\\")
+$util.qr($v1.add($v2))
+#end
+#return($v1)",
+]
+`;
+
+exports[`null and undefined 1`] = `
+Array [
+  "{
+  \\"version\\": \\"2018-05-29\\",
+  \\"payload\\": null
+}",
+  "#set($v1 = {})
+$util.qr($v1.put('name', $null))
+$util.qr($v1.put('value', $null))
+#return($v1)",
+]
+`;
+
+exports[`property assignment of conditional expression 1`] = `
+Array [
+  "{
+  \\"version\\": \\"2018-05-29\\",
+  \\"payload\\": null
+}",
+  "#set($v1 = {})
+#set($v3 = $context.arguments.list.length > 0)
+#if($v3)
+#set($v2 = true)
+#else
+#set($v2 = false)
+#end
+$util.qr($v1.put('prop', $v2))
+#return($v1)",
+]
+`;
+
+exports[`push element to array is renamed to add 1`] = `
+Array [
+  "{
+  \\"version\\": \\"2018-05-29\\",
+  \\"payload\\": null
+}",
+  "$util.qr($context.arguments.list.addAll(['hello']))
+#return($context.arguments.list)",
+]
+`;
+
+exports[`reduce over list with initial value 1`] = `
+Array [
+  "{
+  \\"version\\": \\"2018-05-29\\",
+  \\"payload\\": null
+}",
+  "#set($v1 = [])
+#foreach($item in $context.arguments.list)
+#set($newList = $v1)
+#set($v3 = [])
+$util.qr($v3.addAll($newList))
+$util.qr($v3.add($item))
+#set($v2 = $v3)
+#set($v1 = $v2)
+#end
+#return($v1)",
+]
+`;
+
+exports[`reduce over list without initial value 1`] = `
+Array [
+  "{
+  \\"version\\": \\"2018-05-29\\",
+  \\"payload\\": null
+}",
+  "#if($context.arguments.list.isEmpty())
+$util.error('Reduce of empty array with no initial value')
+#end
+#foreach($item in $context.arguments.list)
+#if($foreach.index == 0)
+#set($v1 = $item)
+#else
+#set($str = $v1)
+#set($v2 = \\"\${str}\${item}\\")
+#set($v1 = $v2)
+#end
+#end
+#return($v1)",
+]
+`;
+
+exports[`return conditional expression 1`] = `
+Array [
+  "{
+  \\"version\\": \\"2018-05-29\\",
+  \\"payload\\": null
+}",
+  "#set($v2 = $context.arguments.list.length > 0)
+#if($v2)
+#set($v1 = true)
+#else
+#set($v1 = false)
+#end
+#return($v1)",
+]
+`;
+
+exports[`return in-line list literal 1`] = `
+Array [
+  "{
+  \\"version\\": \\"2018-05-29\\",
+  \\"payload\\": null
+}",
+  "#return([$context.arguments.a, $context.arguments.b])",
+]
+`;
+
+exports[`return in-line spread object 1`] = `
+Array [
+  "{
+  \\"version\\": \\"2018-05-29\\",
+  \\"payload\\": null
+}",
+  "#set($v1 = {})
+$util.qr($v1.put('id', $util.autoId()))
+$util.qr($v1.putAll($context.arguments.obj))
+#return($v1)",
+]
+`;
+
+exports[`return list element 1`] = `
+Array [
+  "{
+  \\"version\\": \\"2018-05-29\\",
+  \\"payload\\": null
+}",
+  "#set($context.stash.list = [$context.arguments.a, $context.arguments.b])
+#return($context.stash.list[0])",
+]
+`;
+
+exports[`return list literal variable 1`] = `
+Array [
+  "{
+  \\"version\\": \\"2018-05-29\\",
+  \\"payload\\": null
+}",
+  "#set($context.stash.list = [$context.arguments.a, $context.arguments.b])
+#return($context.stash.list)",
+]
+`;
+
+exports[`return literal object with values 1`] = `
+Array [
+  "{
+  \\"version\\": \\"2018-05-29\\",
+  \\"payload\\": null
+}",
+  "#set($context.stash.arg = $context.arguments.arg)
+#set($context.stash.obj = $context.arguments.obj)
+#set($v1 = {})
+$util.qr($v1.put('null', $null))
+$util.qr($v1.put('undefined', $null))
+$util.qr($v1.put('string', 'hello'))
+$util.qr($v1.put('number', 1))
+$util.qr($v1.put('list', ['hello']))
+#set($v2 = {})
+$util.qr($v2.put('key', 'value'))
+$util.qr($v1.put('obj', $v2))
+$util.qr($v1.put('arg', $context.stash.arg))
+$util.qr($v1.putAll($context.stash.obj))
+#return($v1)",
+]
+`;
+
+exports[`template expression 1`] = `
+Array [
+  "{
+  \\"version\\": \\"2018-05-29\\",
+  \\"payload\\": null
+}",
+  "#set($context.stash.local = $context.arguments.a)
+#return(\\"head \${context.arguments.a} \${context.stash.local}\${context.arguments.a}\\")",
+]
+`;

--- a/test/appsync.test.ts
+++ b/test/appsync.test.ts
@@ -143,15 +143,16 @@ describe("step function describe execution", () => {
   test("machine describe exec string", () => {
     const machine = new StepFunction(stack, "machine", () => {});
 
-    const func = reflect(() => {
-      machine.describeExecution("exec1");
-    });
-
-    appsyncTestCase(func, [
-      {
-        index: 1,
-      },
-    ]);
+    appsyncTestCase(
+      reflect(() => {
+        machine.describeExecution("exec1");
+      }),
+      [
+        {
+          index: 1,
+        },
+      ]
+    );
   });
 
   test("machine with trace header", () => {

--- a/test/appsync.test.ts
+++ b/test/appsync.test.ts
@@ -1,11 +1,6 @@
 import { Stack } from "aws-cdk-lib";
 import { AppsyncResolver, reflect, StepFunction } from "../src";
-import { VTL } from "../src/vtl";
-import {
-  appsyncTestCase,
-  appsyncVelocityJsonTestCase,
-  getAppSyncTemplates,
-} from "./util";
+import { appsyncTestCase } from "./util";
 
 let stack: Stack;
 beforeEach(() => {
@@ -16,53 +11,24 @@ describe("step function integration", () => {
   test("machine with no parameters", () => {
     const machine = new StepFunction(stack, "machine", () => {});
 
-    const func = reflect(() => {
-      machine({});
-    });
-
     appsyncTestCase(
-      func,
-      "{}",
-      `${VTL.CircuitBreaker}
-#set($v1 = {})
-$util.qr($v1.put('stateMachineArn', '${machine.stateMachineArn}'))
-{
-  "version": "2018-05-29",
-  "method": "POST",
-  "resourcePath": "/",
-  "params": {
-    "headers": {
-      "content-type": "application/x-amz-json-1.0",
-      "x-amz-target": "AWSStepFunctions.StartExecution"
-    },
-    "body": $util.toJson($v1)
-  }
-}`,
-      "{}",
-      VTL.CircuitBreaker
-    );
-
-    const templates = getAppSyncTemplates(func);
-
-    appsyncVelocityJsonTestCase(
-      templates[1],
-      { arguments: {}, source: {} },
-      {
-        result: {
-          version: "2018-05-29",
-          method: "POST",
-          resourcePath: "/",
-          params: {
-            headers: {
-              "content-type": "application/x-amz-json-1.0",
-              "x-amz-target": "AWSStepFunctions.StartExecution",
-            },
-            body: {
-              stateMachineArn: machine.stateMachineArn,
+      reflect(() => {
+        machine({});
+      }),
+      [
+        {
+          index: 1,
+          expected: {
+            match: {
+              params: {
+                body: {
+                  stateMachineArn: machine.stateMachineArn,
+                },
+              },
             },
           },
         },
-      }
+      ]
     );
   });
 
@@ -73,32 +39,24 @@ $util.qr($v1.put('stateMachineArn', '${machine.stateMachineArn}'))
       () => {}
     );
 
-    const templates = getAppSyncTemplates(
+    appsyncTestCase(
       reflect(() => {
         machine({ input: { id: "1" } });
-      })
-    );
-
-    appsyncVelocityJsonTestCase(
-      templates[1],
-      { arguments: {}, source: {} },
-      {
-        result: {
-          version: "2018-05-29",
-          method: "POST",
-          resourcePath: "/",
-          params: {
-            headers: {
-              "content-type": "application/x-amz-json-1.0",
-              "x-amz-target": "AWSStepFunctions.StartExecution",
-            },
-            body: {
-              stateMachineArn: machine.stateMachineArn,
-              input: JSON.stringify({ id: "1" }),
+      }),
+      [
+        {
+          index: 1,
+          expected: {
+            match: {
+              params: {
+                body: {
+                  stateMachineArn: machine.stateMachineArn,
+                },
+              },
             },
           },
         },
-      }
+      ]
     );
   });
 
@@ -109,69 +67,56 @@ $util.qr($v1.put('stateMachineArn', '${machine.stateMachineArn}'))
       () => {}
     );
 
-    const templates = getAppSyncTemplates(
+    appsyncTestCase(
       reflect((context) => {
         machine({ input: { id: context.arguments.id } });
-      })
-    );
-
-    appsyncVelocityJsonTestCase(
-      templates[1],
-      { arguments: { id: "1" }, source: {} },
-      {
-        result: {
-          version: "2018-05-29",
-          method: "POST",
-          resourcePath: "/",
-          params: {
-            headers: {
-              "content-type": "application/x-amz-json-1.0",
-              "x-amz-target": "AWSStepFunctions.StartExecution",
-            },
-            body: {
-              stateMachineArn: machine.stateMachineArn,
-              input: JSON.stringify({ id: "1" }),
+      }),
+      [
+        {
+          index: 1,
+          context: { arguments: { id: "1" }, source: {} },
+          expected: {
+            match: {
+              params: {
+                body: {
+                  stateMachineArn: machine.stateMachineArn,
+                },
+              },
             },
           },
         },
-      }
+      ]
     );
   });
 
   test("machine with name", () => {
     const machine = new StepFunction(stack, "machine", () => {});
 
-    const templates = getAppSyncTemplates(
+    appsyncTestCase(
       reflect((context) => {
         machine({ name: context.arguments.id });
-      })
-    );
-
-    appsyncVelocityJsonTestCase(
-      templates[1],
-      { arguments: { id: "1" }, source: {} },
-      {
-        result: {
-          version: "2018-05-29",
-          method: "POST",
-          resourcePath: "/",
-          params: {
-            headers: {
-              "content-type": "application/x-amz-json-1.0",
-              "x-amz-target": "AWSStepFunctions.StartExecution",
-            },
-            body: {
-              stateMachineArn: machine.stateMachineArn,
-              name: "1",
+      }),
+      [
+        {
+          index: 1,
+          context: { arguments: { id: "1" }, source: {} },
+          expected: {
+            match: {
+              params: {
+                body: {
+                  stateMachineArn: machine.stateMachineArn,
+                },
+              },
             },
           },
         },
-      }
+      ]
     );
   });
 
   test("machine with trace header", () => {
     const machine = new StepFunction(stack, "machine", () => {});
+
     new AppsyncResolver<{ id: string }, void>((context) => {
       machine({ traceHeader: context.arguments.id });
     });
@@ -180,55 +125,16 @@ $util.qr($v1.put('stateMachineArn', '${machine.stateMachineArn}'))
   test("machine describe exec", () => {
     const machine = new StepFunction(stack, "machine", () => {});
 
-    const func = reflect(() => {
-      const exec = "exec1";
-      machine.describeExecution(exec);
-    });
-
     appsyncTestCase(
-      func,
-      "{}",
-      `${VTL.CircuitBreaker}
-#set($context.stash.exec = 'exec1')
-{
-  "version": "2018-05-29",
-  "method": "POST",
-  "resourcePath": "/",
-  "params": {
-    "headers": {
-      "content-type": "application/x-amz-json-1.0",
-      "x-amz-target": "AWSStepFunctions.DescribeExecution"
-    },
-    "body": {
-      "executionArn": $util.toJson($context.stash.exec)
-    }
-  }
-}`,
-      "{}",
-      VTL.CircuitBreaker
-    );
-
-    const templates = getAppSyncTemplates(func);
-
-    appsyncVelocityJsonTestCase(
-      templates[1],
-      { arguments: {}, source: {} },
-      {
-        result: {
-          version: "2018-05-29",
-          method: "POST",
-          resourcePath: "/",
-          params: {
-            headers: {
-              "content-type": "application/x-amz-json-1.0",
-              "x-amz-target": "AWSStepFunctions.DescribeExecution",
-            },
-            body: {
-              executionArn: "exec1",
-            },
-          },
+      reflect(() => {
+        const exec = "exec1";
+        machine.describeExecution(exec);
+      }),
+      [
+        {
+          index: 1,
         },
-      }
+      ]
     );
   });
 });
@@ -241,50 +147,11 @@ describe("step function describe execution", () => {
       machine.describeExecution("exec1");
     });
 
-    appsyncTestCase(
-      func,
-      "{}",
-      `${VTL.CircuitBreaker}
-{
-  "version": "2018-05-29",
-  "method": "POST",
-  "resourcePath": "/",
-  "params": {
-    "headers": {
-      "content-type": "application/x-amz-json-1.0",
-      "x-amz-target": "AWSStepFunctions.DescribeExecution"
-    },
-    "body": {
-      "executionArn": $util.toJson('exec1')
-    }
-  }
-}`,
-      "{}",
-      VTL.CircuitBreaker
-    );
-
-    const templates = getAppSyncTemplates(func);
-
-    appsyncVelocityJsonTestCase(
-      templates[1],
-      { arguments: {}, source: {} },
+    appsyncTestCase(func, [
       {
-        result: {
-          version: "2018-05-29",
-          method: "POST",
-          resourcePath: "/",
-          params: {
-            headers: {
-              "content-type": "application/x-amz-json-1.0",
-              "x-amz-target": "AWSStepFunctions.DescribeExecution",
-            },
-            body: {
-              executionArn: "exec1",
-            },
-          },
-        },
-      }
-    );
+        index: 1,
+      },
+    ]);
   });
 
   test("machine with trace header", () => {

--- a/test/function.test.ts
+++ b/test/function.test.ts
@@ -3,13 +3,12 @@ import "jest";
 import {
   Function,
   AppsyncContext,
-  reflect,
   EventBus,
   AsyncFunctionResponseEvent,
   AsyncResponseSuccess,
   AsyncResponseFailure,
 } from "../src";
-import { VTL } from "../src/vtl";
+import { reflect } from "../src/reflect";
 import { appsyncTestCase } from "./util";
 
 interface Item {
@@ -39,21 +38,7 @@ test("call function", () => {
   return appsyncTestCase(
     reflect((context: AppsyncContext<{ arg: string }>) => {
       return fn1(context.arguments);
-    }),
-    // pipeline's request mapping template
-    "{}",
-    // function's request mapping template
-    `${VTL.CircuitBreaker}
-#set($v1 = {\"version\": \"2018-05-29\", \"operation\": \"Invoke\", \"payload\": $context.arguments})
-$util.toJson($v1)`,
-    // function's response mapping template
-    `#set( $context.stash.return__flag = true )
-#set( $context.stash.return__val = $context.result )
-{}`,
-    // response mapping template
-    `#if($context.stash.return__flag)
-  #return($context.stash.return__val)
-#end`
+    })
   );
 });
 
@@ -69,30 +54,7 @@ test("call function and conditional return", () => {
       } else {
         return false;
       }
-    }),
-    // pipeline's request mapping template
-    "{}",
-    // function's request mapping template
-    `${VTL.CircuitBreaker}
-#set($v1 = {\"version\": \"2018-05-29\", \"operation\": \"Invoke\", \"payload\": $context.arguments})
-$util.toJson($v1)`,
-    // function's response mapping template
-    `#set( $context.stash.result = $context.result )
-{}`,
-    // response mapping template
-    `#if($context.stash.return__flag)
-  #return($context.stash.return__val)
-#end
-#set($v1 = $context.stash.result.id == 'sam')
-#if($v1)
-#set($context.stash.return__val = true)
-#set($context.stash.return__flag = true)
-#return($context.stash.return__val)
-#else
-#set($context.stash.return__val = false)
-#set($context.stash.return__flag = true)
-#return($context.stash.return__val)
-#end`
+    })
   );
 });
 
@@ -103,21 +65,7 @@ test("call function omitting optional arg", () => {
   appsyncTestCase(
     reflect((context: AppsyncContext<{ arg: string }>) => {
       return fn2(context.arguments);
-    }),
-    // pipeline's request mapping template
-    "{}",
-    // function's request mapping template
-    `${VTL.CircuitBreaker}
-#set($v1 = {\"version\": \"2018-05-29\", \"operation\": \"Invoke\", \"payload\": $context.arguments})
-$util.toJson($v1)`,
-    // function's response mapping template
-    `#set( $context.stash.return__flag = true )
-#set( $context.stash.return__val = $context.result )
-{}`,
-    // response mapping template
-    `#if($context.stash.return__flag)
-  #return($context.stash.return__val)
-#end`
+    })
   );
 });
 
@@ -129,24 +77,7 @@ test("call function including optional arg", () => {
   appsyncTestCase(
     reflect((context: AppsyncContext<{ arg: string }>) => {
       return fn2({ arg: context.arguments.arg, optional: "hello" });
-    }),
-    // pipeline's request mapping template
-    "{}",
-    // function's request mapping template
-    `${VTL.CircuitBreaker}
-#set($v1 = {})
-$util.qr($v1.put('arg', $context.arguments.arg))
-$util.qr($v1.put('optional', 'hello'))
-#set($v2 = {\"version\": \"2018-05-29\", \"operation\": \"Invoke\", \"payload\": $v1})
-$util.toJson($v2)`,
-    // function's response mapping template
-    `#set( $context.stash.return__flag = true )
-#set( $context.stash.return__val = $context.result )
-{}`,
-    // response mapping template
-    `#if($context.stash.return__flag)
-  #return($context.stash.return__val)
-#end`
+    })
   );
 });
 
@@ -156,21 +87,7 @@ test("call function including with no parameters", () => {
   return appsyncTestCase(
     reflect(() => {
       return fn3();
-    }),
-    // pipeline's request mapping template
-    "{}",
-    // function's request mapping template
-    `${VTL.CircuitBreaker}
-#set($v1 = {\"version\": \"2018-05-29\", \"operation\": \"Invoke\", \"payload\": $null})
-$util.toJson($v1)`,
-    // function's response mapping template
-    `#set( $context.stash.return__flag = true )
-#set( $context.stash.return__val = $context.result )
-{}`,
-    // response mapping template
-    `#if($context.stash.return__flag)
-  #return($context.stash.return__val)
-#end`
+    })
   );
 });
 
@@ -180,21 +97,7 @@ test("call function including with void result", () => {
   return appsyncTestCase(
     reflect((context: AppsyncContext<{ arg: string }>) => {
       return fn4(context.arguments);
-    }),
-    // pipeline's request mapping template
-    "{}",
-    // function's request mapping template
-    `${VTL.CircuitBreaker}
-#set($v1 = {\"version\": \"2018-05-29\", \"operation\": \"Invoke\", \"payload\": $context.arguments})
-$util.toJson($v1)`,
-    // function's response mapping template
-    `#set( $context.stash.return__flag = true )
-#set( $context.stash.return__val = $context.result )
-{}`,
-    // response mapping template
-    `#if($context.stash.return__flag)
-  #return($context.stash.return__val)
-#end`
+    })
   );
 });
 

--- a/test/step-function.test.ts
+++ b/test/step-function.test.ts
@@ -10,18 +10,13 @@ import {
   SyncExecutionResult,
 } from "../src";
 import { StateMachine, States, Task } from "../src/asl";
-import { initStepFunctionApp, Person } from "./util";
+import { initStepFunctionApp, normalizeCDKJson, Person } from "./util";
 
 /**
  * Removes randomized values (CDK token strings) form the definitions.
  */
 const normalizeDefinition = (definition: StateMachine<States>): any => {
-  return JSON.parse(
-    JSON.stringify(definition).replace(
-      /\$\{Token\[[a-zA-Z0-9.]*\]\}/g,
-      "__REPLACED_TOKEN"
-    )
-  );
+  return normalizeCDKJson(definition);
 };
 
 /**

--- a/test/table.test.ts
+++ b/test/table.test.ts
@@ -1,7 +1,6 @@
 import { App, aws_dynamodb, Stack } from "aws-cdk-lib";
 import "jest";
 import { Table, $util, AppsyncContext, reflect } from "../src";
-import { VTL } from "../src/vtl";
 import { appsyncTestCase } from "./util";
 
 interface Item {
@@ -31,31 +30,7 @@ test("get item", () =>
           },
         },
       });
-    }),
-    // pipeline's request mapping template
-    "{}",
-    // function's request mapping template
-    `${VTL.CircuitBreaker}
-#set($v1 = {})
-#set($v2 = {})
-#set($v3 = {})
-$util.qr($v3.put('S', $context.arguments.id))
-$util.qr($v2.put('id', $v3))
-$util.qr($v1.put('key', $v2))
-#set($v4 = {\"operation\": \"GetItem\", \"version\": \"2018-05-29\"})
-$util.qr($v4.put('key', $v1.get('key')))
-#if($v1.containsKey('consistentRead'))
-$util.qr($v4.put('consistentRead', $v1.get('consistentRead')))
-#end
-$util.toJson($v4)`,
-    // function's response mapping template
-    `#set( $context.stash.return__flag = true )
-#set( $context.stash.return__val = $context.result )
-{}`,
-    // response mapping template
-    `#if($context.stash.return__flag)
-  #return($context.stash.return__val)
-#end`
+    })
   ));
 
 test("get item and set consistentRead:true", () =>
@@ -69,32 +44,7 @@ test("get item and set consistentRead:true", () =>
         },
         consistentRead: true,
       });
-    }),
-    // pipeline's request mapping template
-    "{}",
-    // function's request mapping template
-    `${VTL.CircuitBreaker}
-#set($v1 = {})
-#set($v2 = {})
-#set($v3 = {})
-$util.qr($v3.put('S', $context.arguments.id))
-$util.qr($v2.put('id', $v3))
-$util.qr($v1.put('key', $v2))
-$util.qr($v1.put('consistentRead', true))
-#set($v4 = {\"operation\": \"GetItem\", \"version\": \"2018-05-29\"})
-$util.qr($v4.put('key', $v1.get('key')))
-#if($v1.containsKey('consistentRead'))
-$util.qr($v4.put('consistentRead', $v1.get('consistentRead')))
-#end
-$util.toJson($v4)`,
-    // function's response mapping template
-    `#set( $context.stash.return__flag = true )
-#set( $context.stash.return__val = $context.result )
-{}`,
-    // pipeline's response mapping template
-    `#if($context.stash.return__flag)
-  #return($context.stash.return__val)
-#end`
+    })
   ));
 
 test("put item", () =>
@@ -127,51 +77,7 @@ test("put item", () =>
           },
         });
       }
-    ),
-    // pipeline's request mapping template
-    "{}",
-    // function's request mapping template
-    `${VTL.CircuitBreaker}
-#set($v1 = {})
-#set($v2 = {})
-#set($v3 = {})
-$util.qr($v3.put('S', $context.arguments.id))
-$util.qr($v2.put('id', $v3))
-$util.qr($v1.put('key', $v2))
-#set($v4 = {})
-#set($v5 = {})
-$util.qr($v5.put('N', \"\${context.arguments.name}\"))
-$util.qr($v4.put('name', $v5))
-$util.qr($v1.put('attributeValues', $v4))
-#set($v6 = {})
-$util.qr($v6.put('expression', '#name = :val'))
-#set($v7 = {})
-$util.qr($v7.put('#name', 'name'))
-$util.qr($v6.put('expressionNames', $v7))
-#set($v8 = {})
-#set($v9 = {})
-$util.qr($v9.put('S', $context.arguments.id))
-$util.qr($v8.put(':val', $v9))
-$util.qr($v6.put('expressionValues', $v8))
-$util.qr($v1.put('condition', $v6))
-#set($v10 = {\"operation\": \"PutItem\", \"version\": \"2018-05-29\"})
-$util.qr($v10.put('key', $v1.get('key')))
-$util.qr($v10.put('attributeValues', $v1.get('attributeValues')))
-#if($v1.containsKey('condition'))
-$util.qr($v10.put('condition', $v1.get('condition')))
-#end
-#if($v1.containsKey('_version'))
-$util.qr($v10.put('_version', $v1.get('_version')))
-#end
-$util.toJson($v10)`,
-    // function's response mapping template
-    `#set( $context.stash.return__flag = true )
-#set( $context.stash.return__val = $context.result )
-{}`,
-    // pipeline's response mapping template
-    `#if($context.stash.return__flag)
-  #return($context.stash.return__val)
-#end`
+    )
   ));
 
 test("update item", () =>
@@ -190,41 +96,7 @@ test("update item", () =>
           },
         },
       });
-    }),
-    // pipeline's request mapping template
-    "{}",
-    // function's request mapping template
-    `${VTL.CircuitBreaker}
-#set($v1 = {})
-#set($v2 = {})
-#set($v3 = {})
-$util.qr($v3.put('S', $context.arguments.id))
-$util.qr($v2.put('id', $v3))
-$util.qr($v1.put('key', $v2))
-#set($v4 = {})
-$util.qr($v4.put('expression', '#name = #name + 1'))
-#set($v5 = {})
-$util.qr($v5.put('#name', 'name'))
-$util.qr($v4.put('expressionNames', $v5))
-$util.qr($v1.put('update', $v4))
-#set($v6 = {\"operation\": \"UpdateItem\", \"version\": \"2018-05-29\"})
-$util.qr($v6.put('key', $v1.get('key')))
-$util.qr($v6.put('update', $v1.get('update')))
-#if($v1.containsKey('condition'))
-$util.qr($v6.put('condition', $v1.get('condition')))
-#end
-#if($v1.containsKey('_version'))
-$util.qr($v6.put('_version', $v1.get('_version')))
-#end
-$util.toJson($v6)`,
-    // function's response mapping template
-    `#set( $context.stash.return__flag = true )
-#set( $context.stash.return__val = $context.result )
-{}`,
-    // pipeline's response mapping template
-    `#if($context.stash.return__flag)
-  #return($context.stash.return__val)
-#end`
+    })
   ));
 
 test("delete item", () =>
@@ -243,40 +115,7 @@ test("delete item", () =>
           },
         },
       });
-    }),
-    // pipeline's request mapping template
-    "{}",
-    // function's request mapping template
-    `${VTL.CircuitBreaker}
-#set($v1 = {})
-#set($v2 = {})
-#set($v3 = {})
-$util.qr($v3.put('S', $context.arguments.id))
-$util.qr($v2.put('id', $v3))
-$util.qr($v1.put('key', $v2))
-#set($v4 = {})
-$util.qr($v4.put('expression', '#name = #name + 1'))
-#set($v5 = {})
-$util.qr($v5.put('#name', 'name'))
-$util.qr($v4.put('expressionNames', $v5))
-$util.qr($v1.put('condition', $v4))
-#set($v6 = {\"operation\": \"DeleteItem\", \"version\": \"2018-05-29\"})
-$util.qr($v6.put('key', $v1.get('key')))
-#if($v1.containsKey('condition'))
-$util.qr($v6.put('condition', $v1.get('condition')))
-#end
-#if($v1.containsKey('_version'))
-$util.qr($v6.put('_version', $v1.get('_version')))
-#end
-$util.toJson($v6)`,
-    // function's response mapping template
-    `#set( $context.stash.return__flag = true )
-#set( $context.stash.return__val = $context.result )
-{}`,
-    // pipeline's response mapping template
-    `#if($context.stash.return__flag)
-  #return($context.stash.return__val)
-#end`
+    })
   ));
 
 test("query", () =>
@@ -294,49 +133,5 @@ test("query", () =>
           },
         },
       }).items;
-    }),
-    // pipeline's request mapping template
-    "{}",
-    // function's request mapping template
-    `${VTL.CircuitBreaker}
-#set($v1 = {})
-#set($v2 = {})
-$util.qr($v2.put('expression', 'id = :id and #name = :val'))
-#set($v3 = {})
-$util.qr($v3.put('#name', 'name'))
-$util.qr($v2.put('expressionNames', $v3))
-#set($v4 = {})
-$util.qr($v4.put(':id', $util.dynamodb.toDynamoDB($context.arguments.id)))
-$util.qr($v4.put(':val', $util.dynamodb.toDynamoDB($context.arguments.sort)))
-$util.qr($v2.put('expressionValues', $v4))
-$util.qr($v1.put('query', $v2))
-#set($v5 = {\"operation\": \"Query\", \"version\": \"2018-05-29\"})
-$util.qr($v5.put('query', $v1.get('query')))
-#if($v1.containsKey('index'))
-$util.qr($v5.put('index', $v1.get('index')))
-#end
-#if($v1.containsKey('nextToken'))
-$util.qr($v5.put('nextToken', $v1.get('nextToken')))
-#end
-#if($v1.containsKey('limit'))
-$util.qr($v5.put('limit', $v1.get('limit')))
-#end
-#if($v1.containsKey('scanIndexForward'))
-$util.qr($v5.put('scanIndexForward', $v1.get('scanIndexForward')))
-#end
-#if($v1.containsKey('consistentRead'))
-$util.qr($v5.put('consistentRead', $v1.get('consistentRead')))
-#end
-#if($v1.containsKey('select'))
-$util.qr($v5.put('select', $v1.get('select')))
-#end
-$util.toJson($v5)`,
-    // function's response mapping template
-    `#set( $context.stash.return__flag = true )
-#set( $context.stash.return__val = $context.result.items )
-{}`,
-    // pipeline's response mapping template
-    `#if($context.stash.return__flag)
-  #return($context.stash.return__val)
-#end`
+    })
   ));


### PR DESCRIPTION
Part of #202 

* Reduces the size and fragility of the app sync tests by outputting a snapshot instead of hand written evaluation.
* Wraps the template execution into a app sync single test method to support simpler tests
* Support matchObject to test granular cases like CDK tokens without the previous verbosity