### PR TITLE
chore: jest launch config

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -69,6 +69,25 @@
       "env": {
         "TS_NODE_PROJECT": "${workspaceRoot}/test-app/tsconfig.json"
       }
+    },
+    {
+      "type": "node",
+      "name": "vscode-jest-tests.v2",
+      "request": "launch",
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen",
+      "disableOptimisticBPs": true,
+      "program": "${workspaceFolder}/node_modules/.bin/jest",
+      "cwd": "${workspaceFolder}",
+      "args": [
+        "--runInBand",
+        "--watchAll=false",
+        "--testNamePattern",
+        "${jest.testNamePattern}",
+        "--runTestsByPath",
+        "${jest.testFile}",
+        "--coverage=false"
+      ]
     }
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -34,5 +34,6 @@
   "editor.insertSpaces": true,
   "editor.formatOnSave": true,
   "eslint.format.enable": false,
-  "typescript.tsdk": "node_modules/typescript/lib"
+  "typescript.tsdk": "node_modules/typescript/lib",
+  "jest.jestCommandLine": "node_modules/.bin/jest"
 }


### PR DESCRIPTION
Jest vscode plugin should reduce latency in debugging with jest. Turns off coverage during debugging.