### PR TITLE
feat: error code urls.

### DIFF
--- a/src/error-code.ts
+++ b/src/error-code.ts
@@ -3,14 +3,23 @@
  */
 export class SynthError extends Error {
   constructor(readonly code: ErrorCode, message: string) {
-    super(`${message} ${formatErrorUrl(code)}`);
+    super(formatErrorMessage(code, message));
   }
 }
+const baseUrl = process.env.FUNCTIONLESS_LOCAL
+  ? `http://localhost:3000`
+  : `https://functionless.org`;
+
+export const formatErrorMessage = (code: ErrorCode, messageText?: string) => `${
+  messageText ?? code.messageText
+}
+
+${formatErrorUrl(code)}`;
 
 const formatErrorUrl = (code: ErrorCode) => {
-  return `https://functionless.org/docs/error-codes/#${code.messageText
+  return `${baseUrl}/docs/error-codes#${code.messageText
     .toLowerCase()
-    .replace(/\s+/g, "-")}`;
+    .replace(/\s/g, "-")}`;
 };
 
 export interface ErrorCode {

--- a/src/error-code.ts
+++ b/src/error-code.ts
@@ -3,9 +3,15 @@
  */
 export class SynthError extends Error {
   constructor(readonly code: ErrorCode, message: string) {
-    super(message);
+    super(`${message} ${formatErrorUrl(code)}`);
   }
 }
+
+const formatErrorUrl = (code: ErrorCode) => {
+  return `https://functionless.org/docs/error-codes/#${code.messageText
+    .toLowerCase()
+    .replace(/\s+/g, "-")}`;
+};
 
 export interface ErrorCode {
   code: number;

--- a/src/error-code.ts
+++ b/src/error-code.ts
@@ -1,3 +1,7 @@
+const BASE_URL = process.env.FUNCTIONLESS_LOCAL
+  ? `http://localhost:3000`
+  : `https://functionless.org`;
+
 /**
  * Error to throw during synth failures
  */
@@ -6,21 +10,33 @@ export class SynthError extends Error {
     super(formatErrorMessage(code, message));
   }
 }
-const baseUrl = process.env.FUNCTIONLESS_LOCAL
-  ? `http://localhost:3000`
-  : `https://functionless.org`;
 
+/**
+ * Formats an error message consistently across Functionless.
+ *
+ * Includes a deep link url to functionless.org's error code page.
+ *
+ * ```
+ * [messageText | code.MessageText]
+ *
+ * http://functionless.org/docs/error-codes/#[Anchor from Message Text]
+ * ```
+ */
 export const formatErrorMessage = (code: ErrorCode, messageText?: string) => `${
   messageText ?? code.messageText
 }
 
 ${formatErrorUrl(code)}`;
 
-const formatErrorUrl = (code: ErrorCode) => {
-  return `${baseUrl}/docs/error-codes#${code.messageText
+/**
+ * Deep link to functionless.org's error code page.
+ *
+ * `http://functionless.org/docs/error-codes/#[Anchor from Message Text]`
+ */
+export const formatErrorUrl = (code: ErrorCode) =>
+  `${BASE_URL}/docs/error-codes#${code.messageText
     .toLowerCase()
     .replace(/\s/g, "-")}`;
-};
 
 export interface ErrorCode {
   code: number;

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -1,6 +1,6 @@
 import type * as typescript from "typescript";
 import { FunctionlessChecker, isArithmeticToken } from "./checker";
-import { ErrorCode, ErrorCodes } from "./error-code";
+import { ErrorCode, ErrorCodes, formatErrorMessage } from "./error-code";
 
 /**
  * Validates a TypeScript SourceFile containing Functionless primitives does not
@@ -79,16 +79,10 @@ export function validate(
     error: ErrorCode,
     messageText?: string
   ): ts.Diagnostic {
-    const baseUrl = process.env.FUNCTIONLESS_LOCAL
-      ? `http://localhost:3000`
-      : `https://functionless.org`;
-
     return {
       source: "Functionless",
       code: error.code,
-      messageText: `${messageText ?? error.messageText}
-
-${baseUrl}/docs/error-codes#${error.messageText.replace(/ /g, "-")}"`,
+      messageText: formatErrorMessage(error, messageText),
       category: ts.DiagnosticCategory.Error,
       file: invalidNode.getSourceFile(),
       start: invalidNode.pos,

--- a/test-app/tsconfig.json
+++ b/test-app/tsconfig.json
@@ -19,6 +19,7 @@
     "noUnusedLocals": true,
     "noUnusedParameters": true,
     "resolveJsonModule": true,
+    "skipLibCheck": true,
     "strict": true,
     "strictNullChecks": true,
     "strictPropertyInitialization": true,

--- a/test/__snapshots__/validate.test.ts.snap
+++ b/test/__snapshots__/validate.test.ts.snap
@@ -3,31 +3,31 @@
 exports[`step-function.ts 1`] = `
 "[96mtest/test-files/step-function.ts[0m:[93m10[0m:[93m65[0m - [91merror[0m[90m Functionless(100): [0mCannot perform arithmetic on variables in Step Function
 
-https://functionless.org/docs/error-codes#Cannot-perform-arithmetic-on-variables-in-Step-Function\\"
+https://functionless.org/docs/error-codes#cannot-perform-arithmetic-on-variables-in-step-function
 
 [7m10[0m new StepFunction(stack, \\"input.i + 2\\", (input: { i: number }) => input.i + 2);
 [7m  [0m [91m                                                                ~~~~~~~~~~~~[0m
 [96mtest/test-files/step-function.ts[0m:[93m11[0m:[93m65[0m - [91merror[0m[90m Functionless(100): [0mCannot perform arithmetic on variables in Step Function
 
-https://functionless.org/docs/error-codes#Cannot-perform-arithmetic-on-variables-in-Step-Function\\"
+https://functionless.org/docs/error-codes#cannot-perform-arithmetic-on-variables-in-step-function
 
 [7m11[0m new StepFunction(stack, \\"input.i - 2\\", (input: { i: number }) => input.i - 2);
 [7m  [0m [91m                                                                ~~~~~~~~~~~~[0m
 [96mtest/test-files/step-function.ts[0m:[93m13[0m:[93m65[0m - [91merror[0m[90m Functionless(100): [0mCannot perform arithmetic on variables in Step Function
 
-https://functionless.org/docs/error-codes#Cannot-perform-arithmetic-on-variables-in-Step-Function\\"
+https://functionless.org/docs/error-codes#cannot-perform-arithmetic-on-variables-in-step-function
 
 [7m13[0m new StepFunction(stack, \\"input.i / 2\\", (input: { i: number }) => input.i / 2);
 [7m  [0m [91m                                                                ~~~~~~~~~~~~[0m
 [96mtest/test-files/step-function.ts[0m:[93m14[0m:[93m62[0m - [91merror[0m[90m Functionless(100): [0mCannot perform arithmetic on variables in Step Function
 
-https://functionless.org/docs/error-codes#Cannot-perform-arithmetic-on-variables-in-Step-Function\\"
+https://functionless.org/docs/error-codes#cannot-perform-arithmetic-on-variables-in-step-function
 
 [7m14[0m new StepFunction(stack, \\"-input.i\\", (input: { i: number }) => -input.i);
 [7m  [0m [91m                                                             ~~~~~~~~~[0m
 [96mtest/test-files/step-function.ts[0m:[93m19[0m:[93m14[0m - [91merror[0m[90m Functionless(100): [0mCannot perform arithmetic on variables in Step Function
 
-https://functionless.org/docs/error-codes#Cannot-perform-arithmetic-on-variables-in-Step-Function\\"
+https://functionless.org/docs/error-codes#cannot-perform-arithmetic-on-variables-in-step-function
 
 [7m19[0m     const a = input.i + 1;
 [7m  [0m [91m             ~~~~~~~~~~~~[0m


### PR DESCRIPTION
Related to #220 

Automatically add functionless.org error code urls (auto generated) to synth errors with codes.

> SynthError: Expected input function to AppsyncResolver to be compiled by Functionless. Make sure you have the Functionless compiler plugin configured correctly.
>
> https://functionless.org/docs/error-codes#function-not-compiled-by-functionless-plugin