### PR TITLE
fix: add _brand to ITable and BaseTable to fix type inference of$ AWS.DynamoDB.Table

### DIFF
--- a/src/table.ts
+++ b/src/table.ts
@@ -59,11 +59,7 @@ export interface TableProps<
     : undefined;
 }
 
-export type AnyTable = ITable<
-  Record<string | number | symbol, any>,
-  string | number | symbol,
-  string | number | symbol | undefined
->;
+export type AnyTable = ITable<Record<string, any>, string, string | undefined>;
 
 /**
  * Wraps an {@link aws_dynamodb.Table} with a type-safe interface that can be

--- a/src/table.ts
+++ b/src/table.ts
@@ -59,7 +59,11 @@ export interface TableProps<
     : undefined;
 }
 
-export type AnyTable = ITable<object, keyof object, keyof object | undefined>;
+export type AnyTable = ITable<
+  Record<string | number | symbol, any>,
+  string | number | symbol,
+  string | number | symbol | undefined
+>;
 
 /**
  * Wraps an {@link aws_dynamodb.Table} with a type-safe interface that can be
@@ -106,7 +110,21 @@ export interface ITable<
   RangeKey extends keyof Item | undefined = undefined
 > {
   readonly kind: "Table";
+  /**
+   * The underlying {@link aws_dynamodb.ITable} Resource.
+   */
   readonly resource: aws_dynamodb.ITable;
+
+  /**
+   * Brands this type with easy-access to the type parameters, Item, PartitionKey and RangeKey
+   *
+   * @note this value will never exist at runtime - it is purely compile-time information
+   */
+  readonly _brand?: {
+    Item: Item;
+    PartitionKey: PartitionKey;
+    RangeKey: RangeKey;
+  };
 
   /**
    * @see https://docs.aws.amazon.com/appsync/latest/devguide/resolver-mapping-template-reference-dynamodb.html#aws-appsync-resolver-mapping-template-reference-dynamodb-getitem
@@ -228,6 +246,12 @@ class BaseTable<
 {
   readonly kind = "Table";
 
+  readonly _brand?: {
+    Item: Item;
+    PartitionKey: PartitionKey;
+    RangeKey: RangeKey;
+  };
+
   constructor(readonly resource: aws_dynamodb.ITable) {}
 
   public getItem = this.makeTableIntegration("getItem", {
@@ -345,7 +369,7 @@ class BaseTable<
   private makeTableIntegration<
     K extends Exclude<
       keyof ITable<Item, PartitionKey, RangeKey>,
-      "kind" | "resource"
+      "kind" | "resource" | "_brand"
     >
   >(
     methodName: K,

--- a/test/table.test.ts
+++ b/test/table.test.ts
@@ -43,19 +43,51 @@ const newTable = new Table<Item, "id">(stack, "NewTable", {
  * We use @ts-expect-error to validate that types are inferred properly.
  */
 export function typeCheck() {
-  let t1: ITable<any, any, any> | undefined;
-  let t2: ITable<Item, "id"> | undefined;
-  let t3: AnyTable | undefined;
+  let t1: Table<any, any, any> | undefined;
+  let t2: Table<Item, "id"> | undefined;
+  let t3:
+    | Table<
+        Record<string | number | symbol, any>,
+        string | number | symbol,
+        string | number | symbol | undefined
+      >
+    | undefined;
 
   t1 = t2;
   t1 = t3;
 
-  t2 = t1; // ITable<any, any, any> should short-circuit
-  // @ts-expect-error
-  t2 = t3; // ITable<Item, "id"> is a sub-type of AnyTable
+  // type checks because Table<any, any, any> short circuits
+  t2 = t1;
+  // @ts-expect-error - Table<Record<string | number | symbol, any>, string | number | symbol, string | number | symbol | undefined> | undefined' is not assignable to type 'Table<Item, "id", undefined> | undefined
+  t2 = t3;
 
   t3 = t1;
   t3 = t2;
+
+  let t4: ITable<any, any, any> | undefined;
+  let t5: ITable<Item, "id"> | undefined;
+  let t6: AnyTable | undefined;
+
+  t4 = t1;
+  t4 = t2;
+  t4 = t3;
+  t4 = t5;
+  t4 = t6;
+
+  // type checks because Table<any, any, any> short circuits
+  t5 = t2;
+  // @ts-expect-error - Table<Record<string | number | symbol, any>, string | number | symbol, string | number | symbol | undefined> | undefined' is not assignable to type 'ITable<Item, "id", undefined> | undefined
+  t5 = t3;
+  // type checks because ITable<any, any, any> short circuits
+  t5 = t4;
+  // @ts-expect-error - 'AnyTable | undefined' is not assignable to type 'ITable<Item, "id", undefined> | undefined'
+  t5 = t6;
+
+  t6 = t1;
+  t6 = t2;
+  t6 = t3;
+  t6 = t4;
+  t6 = t5;
 
   // Test1: type checking should work for Table
   $AWS.DynamoDB.GetItem({

--- a/test/table.test.ts
+++ b/test/table.test.ts
@@ -45,13 +45,7 @@ const newTable = new Table<Item, "id">(stack, "NewTable", {
 export function typeCheck() {
   let t1: Table<any, any, any> | undefined;
   let t2: Table<Item, "id"> | undefined;
-  let t3:
-    | Table<
-        Record<string | number | symbol, any>,
-        string | number | symbol,
-        string | number | symbol | undefined
-      >
-    | undefined;
+  let t3: Table<Record<string, any>, string, string | undefined> | undefined;
 
   t1 = t2;
   t1 = t3;


### PR DESCRIPTION
Fixes #253 

The `Table` and `ITable` types had a problem where type inference worked for `ITable` but not for `Table`. 

Also, `ITable<any, any, any>` was properly short-circuiting types.

Adding a `_brand` property to both `ITable` and `BaseTable` containing the type parameters fixed the error. I believe this is because it makes the type information readily accessible to the compiler which is maybe struggling to infer them out of the `getItem` calls.