### PR TITLE
chore(refactor): use type assertions instead of string comparisons

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -4,34 +4,31 @@ import {
   APIGatewayProxyResult,
   APIGatewayEventRequestContext,
 } from "aws-lambda";
-import {
-  FunctionDecl,
-  isFunctionDecl,
-  isParameterDecl,
-  validateFunctionDecl,
-} from "./declaration";
+import { FunctionDecl, validateFunctionDecl } from "./declaration";
 import { ErrorCodes, SynthError } from "./error-code";
-import {
-  CallExpr,
-  Expr,
-  Identifier,
-  isArgument,
-  isArrayLiteralExpr,
-  isBooleanLiteralExpr,
-  isCallExpr,
-  isElementAccessExpr,
-  isIdentifier,
-  isNullLiteralExpr,
-  isNumberLiteralExpr,
-  isObjectLiteralExpr,
-  isPropAccessExpr,
-  isPropAssignExpr,
-  isStringLiteralExpr,
-  isUndefinedLiteralExpr,
-} from "./expression";
+import { CallExpr, Expr, Identifier } from "./expression";
 import { Function } from "./function";
+import {
+  isReturnStmt,
+  isPropAccessExpr,
+  isNullLiteralExpr,
+  isUndefinedLiteralExpr,
+  isBooleanLiteralExpr,
+  isNumberLiteralExpr,
+  isStringLiteralExpr,
+  isArrayLiteralExpr,
+  isArgument,
+  isCallExpr,
+  isParameterDecl,
+  isFunctionDecl,
+  isElementAccessExpr,
+  isObjectLiteralExpr,
+  isPropAssignExpr,
+  isVariableStmt,
+  isIdentifier,
+} from "./guards";
 import { findIntegration, IntegrationImpl } from "./integration";
-import { isReturnStmt, isVariableStmt, Stmt } from "./statement";
+import { Stmt } from "./statement";
 import { AnyFunction, singletonConstruct } from "./util";
 import { VTL } from "./vtl";
 

--- a/src/appsync.ts
+++ b/src/appsync.ts
@@ -13,10 +13,22 @@ import {
   ConditionExpr,
   Expr,
   Identifier,
-  isBinaryExpr,
   PropAccessExpr,
   StringLiteralExpr,
 } from "./expression";
+import {
+  isVariableStmt,
+  isParameterDecl,
+  isFunctionDecl,
+  isBinaryExpr,
+  isExprStmt,
+  isReturnStmt,
+  isCallExpr,
+  isReferenceExpr,
+  isPropAccessExpr,
+  isElementAccessExpr,
+  isIfStmt,
+} from "./guards";
 import { findDeepIntegration, IntegrationImpl } from "./integration";
 import { Literal } from "./literal";
 import { FunctionlessNode } from "./node";
@@ -105,12 +117,9 @@ export class AppsyncVTL extends VTL {
 
   protected dereference(id: Identifier): string {
     const ref = id.lookup();
-    if (ref?.kind === "VariableStmt" && isInTopLevelScope(ref)) {
+    if (isVariableStmt(ref) && isInTopLevelScope(ref)) {
       return `$context.stash.${id.name}`;
-    } else if (
-      ref?.kind === "ParameterDecl" &&
-      ref.parent?.kind === "FunctionDecl"
-    ) {
+    } else if (isParameterDecl(ref) && isFunctionDecl(ref.parent)) {
       // regardless of the name of the first argument in the root FunctionDecl, it is always the intrinsic Appsync `$context`.
       return "$context";
     }
@@ -416,11 +425,11 @@ export class AppsyncResolver<
             const returnValName =
               resultTemplate?.returnVariable ?? resultValName;
 
-            if (stmt.kind === "ExprStmt") {
+            if (isExprStmt(stmt)) {
               const call = findServiceCallExpr(stmt.expr);
               template.call(call);
               return createStage(service, "{}");
-            } else if (stmt.kind === "ReturnStmt") {
+            } else if (isReturnStmt(stmt)) {
               return createStage(
                 service,
                 `${
@@ -429,10 +438,7 @@ export class AppsyncResolver<
 #set( $context.stash.return__val = ${getResult(stmt.expr)} )
 {}`
               );
-            } else if (
-              stmt.kind === "VariableStmt" &&
-              stmt.expr?.kind === "CallExpr"
-            ) {
+            } else if (isVariableStmt(stmt) && isCallExpr(stmt.expr)) {
               return createStage(
                 service,
                 `${pre ? `${pre}\n` : ""}#set( $context.stash.${
@@ -453,10 +459,10 @@ export class AppsyncResolver<
              */
             function findServiceCallExpr(expr: Expr): CallExpr {
               if (
-                expr.kind === "CallExpr" &&
-                (expr.expr.kind === "ReferenceExpr" ||
-                  (expr.expr.kind === "PropAccessExpr" &&
-                    expr.expr.expr.kind === "ReferenceExpr"))
+                isCallExpr(expr) &&
+                (isReferenceExpr(expr.expr) ||
+                  (isPropAccessExpr(expr.expr) &&
+                    isReferenceExpr(expr.expr.expr)))
               ) {
                 // this catches specific cases:
                 // lambdaFunction()
@@ -467,9 +473,9 @@ export class AppsyncResolver<
                 // lambdaFunction().prop
                 // table.query().Items.size() //.size() is still a Call but not a call to a service.
                 return expr;
-              } else if (expr.kind === "PropAccessExpr") {
+              } else if (isPropAccessExpr(expr)) {
                 return findServiceCallExpr(expr.expr);
-              } else if (expr.kind === "CallExpr") {
+              } else if (isCallExpr(expr)) {
                 return findServiceCallExpr(expr.expr);
               } else {
                 throw new Error("");
@@ -494,12 +500,12 @@ export class AppsyncResolver<
              * @returns a VTL expression to be included in the Response Mapping Template to extract the contents from `$context.result`.
              */
             function getResult(expr: Expr): string {
-              if (expr.kind === "CallExpr") {
+              if (isCallExpr(expr)) {
                 template.call(expr);
                 return returnValName;
-              } else if (expr.kind === "PropAccessExpr") {
+              } else if (isPropAccessExpr(expr)) {
                 return `${getResult(expr.expr)}.${expr.name}`;
-              } else if (expr.kind === "ElementAccessExpr") {
+              } else if (isElementAccessExpr(expr)) {
                 return `${getResult(expr.expr)}[${getResult(expr.element)}]`;
               } else {
                 throw new Error(
@@ -531,9 +537,9 @@ export class AppsyncResolver<
               });
             }
           } else if (isLastExpr) {
-            if (stmt.kind === "ReturnStmt") {
+            if (isReturnStmt(stmt)) {
               template.return(stmt.expr);
-            } else if (stmt.kind === "IfStmt") {
+            } else if (isIfStmt(stmt)) {
               template.eval(stmt);
             } else {
               template.return("$null");

--- a/src/asl.ts
+++ b/src/asl.ts
@@ -2,21 +2,13 @@ import { aws_iam, aws_stepfunctions } from "aws-cdk-lib";
 import { Construct } from "constructs";
 
 import { assertNever } from "./assert";
-import { FunctionDecl, isParameterDecl, isFunctionDecl } from "./declaration";
+import { FunctionDecl } from "./declaration";
 import {
   Argument,
   CallExpr,
   ElementAccessExpr,
   Expr,
   Identifier,
-  isBinaryExpr,
-  isCallExpr,
-  isFunctionExpr,
-  isLiteralExpr,
-  isNullLiteralExpr,
-  isReferenceExpr,
-  isTypeOfExpr,
-  isUnaryExpr,
   isVariableReference,
   NewExpr,
   NullLiteralExpr,
@@ -24,6 +16,49 @@ import {
   StringLiteralExpr,
 } from "./expression";
 import { isFunction } from "./function";
+import {
+  isBlockStmt,
+  isFunctionExpr,
+  isFunctionDecl,
+  isExprStmt,
+  isVariableStmt,
+  isReturnStmt,
+  isCallExpr,
+  isBreakStmt,
+  isForOfStmt,
+  isForInStmt,
+  isWhileStmt,
+  isDoStmt,
+  isContinueStmt,
+  isIfStmt,
+  isNullLiteralExpr,
+  isUndefinedLiteralExpr,
+  isThrowStmt,
+  isNewExpr,
+  isTryStmt,
+  isPropAccessExpr,
+  isLiteralExpr,
+  isObjectLiteralExpr,
+  isBinaryExpr,
+  isUnaryExpr,
+  isArgument,
+  isElementAccessExpr,
+  isArrayLiteralExpr,
+  isPropAssignExpr,
+  isComputedPropertyNameExpr,
+  isStringLiteralExpr,
+  isReferenceExpr,
+  isTemplateExpr,
+  isParameterDecl,
+  isBooleanLiteralExpr,
+  isNumberLiteralExpr,
+  isTypeOfExpr,
+  isConditionExpr,
+  isSpreadAssignExpr,
+  isSpreadElementExpr,
+  isCatchClause,
+  isIdentifier,
+} from "./guards";
 import { findIntegration } from "./integration";
 import { FunctionlessNode } from "./node";
 import {
@@ -33,11 +68,6 @@ import {
   ForInStmt,
   ForOfStmt,
   IfStmt,
-  isBlockStmt,
-  isDoStmt,
-  isForInStmt,
-  isForOfStmt,
-  isWhileStmt,
   ReturnStmt,
   Stmt,
   VariableStmt,
@@ -346,9 +376,8 @@ export class ASL {
       | FunctionlessNode
       | FunctionlessNode[] {
       if (
-        node.kind === "BlockStmt" &&
-        (node.parent?.kind === "FunctionExpr" ||
-          node.parent?.kind === "FunctionDecl")
+        isBlockStmt(node) &&
+        (isFunctionExpr(node.parent) || isFunctionDecl(node.parent))
       ) {
         // re-write the AST to include explicit `ReturnStmt(NullLiteral())` statements
         // this simplifies the interpreter code by always having a node to chain onto, even when
@@ -365,19 +394,19 @@ export class ASL {
           ]);
         }
       } else if (
-        node.kind === "ExprStmt" ||
-        node.kind === "VariableStmt" ||
-        node.kind === "ReturnStmt"
+        isExprStmt(node) ||
+        isVariableStmt(node) ||
+        isReturnStmt(node)
       ) {
         const expr = node.expr;
-        if (expr?.kind === "CallExpr") {
+        if (isCallExpr(expr)) {
           // reduce nested Tasks to individual Statements
           const nestedTasks = expr.children.flatMap(function findTasks(
             node: FunctionlessNode
           ): CallExpr[] {
             if (isTask(node)) {
               return [node, ...node.collectChildren(findTasks)];
-            } else if (node.kind === "FunctionExpr") {
+            } else if (isFunctionExpr(node)) {
               // do not recurse into FunctionExpr - they do not need to be hoisted
               return [];
             } else {
@@ -386,9 +415,7 @@ export class ASL {
           });
 
           function isTask(node: FunctionlessNode): node is CallExpr {
-            return (
-              node.kind === "CallExpr" && findIntegration(node) !== undefined
-            );
+            return isCallExpr(node) && findIntegration(node) !== undefined;
           }
 
           if (nestedTasks.length > 0) {
@@ -481,7 +508,7 @@ export class ASL {
   }
 
   public execute(stmt: Stmt): States {
-    if (stmt.kind === "BlockStmt") {
+    if (isBlockStmt(stmt)) {
       return stmt.statements.reduce(
         (states: States, s) => ({
           ...states,
@@ -489,7 +516,7 @@ export class ASL {
         }),
         {}
       );
-    } else if (stmt.kind === "BreakStmt") {
+    } else if (isBreakStmt(stmt)) {
       const loop = stmt.findParent(
         anyOf(isForOfStmt, isForInStmt, isWhileStmt, isDoStmt)
       );
@@ -499,7 +526,7 @@ export class ASL {
 
       return {
         [this.getStateName(stmt)]:
-          loop.kind === "ForInStmt" || loop.kind === "ForOfStmt"
+          isForInStmt(loop) || isForOfStmt(loop)
             ? {
                 Type: "Fail",
                 Error: "Break",
@@ -509,7 +536,7 @@ export class ASL {
                 Next: this.next(loop),
               },
       };
-    } else if (stmt.kind === "ContinueStmt") {
+    } else if (isContinueStmt(stmt)) {
       const loop = stmt.findParent(
         anyOf(isForOfStmt, isForInStmt, isWhileStmt, isDoStmt)
       );
@@ -519,13 +546,13 @@ export class ASL {
 
       return {
         [this.getStateName(stmt)]:
-          loop.kind === "ForInStmt" || loop.kind === "ForOfStmt"
+          isForInStmt(loop) || isForOfStmt(loop)
             ? {
                 Type: "Pass",
                 End: true,
                 ResultPath: null,
               }
-            : loop.kind === "WhileStmt"
+            : isWhileStmt(loop)
             ? {
                 Type: "Pass",
                 Next: this.getStateName(loop),
@@ -537,14 +564,14 @@ export class ASL {
                 ResultPath: null,
               },
       };
-    } else if (stmt.kind === "ExprStmt") {
+    } else if (isExprStmt(stmt)) {
       return {
         [this.getStateName(stmt)]: this.eval(stmt.expr, {
           Next: this.next(stmt),
           ResultPath: null,
         }),
       };
-    } else if (stmt.kind === "ForOfStmt" || stmt.kind === "ForInStmt") {
+    } else if (isForOfStmt(stmt) || isForInStmt(stmt)) {
       const throwTransition = this.throw(stmt);
 
       const Catch = [
@@ -577,7 +604,7 @@ export class ASL {
           Next: this.next(stmt),
           MaxConcurrency: 1,
           Parameters: {
-            ...(stmt.kind === "ForInStmt"
+            ...(isForInStmt(stmt)
               ? {
                   // use special `0_` prefix (impossible variable name in JavaScript)
                   // to store a reference to the value so that we can implement array index
@@ -587,10 +614,9 @@ export class ASL {
                   [`0_${stmt.variableDecl.name}.$`]: "$$.Map.Item.Value",
                 }
               : {}),
-            [`${stmt.variableDecl.name}.$`]:
-              stmt.kind === "ForOfStmt"
-                ? "$$.Map.Item.Value"
-                : "$$.Map.Item.Index",
+            [`${stmt.variableDecl.name}.$`]: isForOfStmt(stmt)
+              ? "$$.Map.Item.Value"
+              : "$$.Map.Item.Index",
           },
           Iterator: {
             StartAt: this.getStateName(stmt.body.step()!),
@@ -598,12 +624,12 @@ export class ASL {
           },
         },
       };
-    } else if (stmt.kind === "IfStmt") {
+    } else if (isIfStmt(stmt)) {
       const states: States = {};
       const choices: Branch[] = [];
 
       let curr: IfStmt | BlockStmt | undefined = stmt;
-      while (curr?.kind === "IfStmt") {
+      while (isIfStmt(curr)) {
         Object.assign(states, this.execute(curr.then));
 
         choices.push({
@@ -612,7 +638,7 @@ export class ASL {
         });
         curr = curr._else;
       }
-      if (curr?.kind === "BlockStmt") {
+      if (isBlockStmt(curr)) {
         Object.assign(states, this.execute(curr));
       }
       const next =
@@ -637,20 +663,17 @@ export class ASL {
           : {}),
         ...states,
       };
-    } else if (stmt.kind === "ReturnStmt") {
+    } else if (isReturnStmt(stmt)) {
       const parent = stmt.findParent(
         anyOf(isFunctionExpr, isForInStmt, isForOfStmt)
       );
-      if (parent?.kind === "ForInStmt" || parent?.kind === "ForOfStmt") {
+      if (isForInStmt(parent) || isForOfStmt(parent)) {
         throw new Error(
           "a 'return' statement is not allowed within a for loop"
         );
       }
 
-      if (
-        stmt.expr.kind === "NullLiteralExpr" ||
-        stmt.expr.kind === "UndefinedLiteralExpr"
-      ) {
+      if (isNullLiteralExpr(stmt.expr) || isUndefinedLiteralExpr(stmt.expr)) {
         return {
           [this.getStateName(stmt)]: {
             Type: "Pass",
@@ -676,7 +699,7 @@ export class ASL {
           End: true,
         }),
       };
-    } else if (stmt.kind === "VariableStmt") {
+    } else if (isVariableStmt(stmt)) {
       if (stmt.expr === undefined) {
         return {};
       }
@@ -687,8 +710,8 @@ export class ASL {
           Next: this.next(stmt),
         }),
       };
-    } else if (stmt.kind === "ThrowStmt") {
-      if (stmt.expr.kind !== "NewExpr" && stmt.expr.kind !== "CallExpr") {
+    } else if (isThrowStmt(stmt)) {
+      if (!isNewExpr(stmt.expr) && !isCallExpr(stmt.expr)) {
         throw new Error(
           "the expr of a ThrowStmt must be a NewExpr or CallExpr"
         );
@@ -722,7 +745,7 @@ export class ASL {
           },
         } as const;
       }
-    } else if (stmt.kind === "TryStmt") {
+    } else if (isTryStmt(stmt)) {
       const tryFlow = analyzeFlow(stmt.tryBlock);
 
       const errorVariableName = stmt.catchClause.variableDecl?.name;
@@ -798,9 +821,9 @@ export class ASL {
             }
           : {}),
       };
-    } else if (stmt.kind === "CatchClause") {
+    } else if (isCatchClause(stmt)) {
       return this.execute(stmt.block);
-    } else if (stmt.kind === "WhileStmt" || stmt.kind === "DoStmt") {
+    } else if (isWhileStmt(stmt) || isDoStmt(stmt)) {
       const whenTrue = this.transition(stmt.block);
       if (whenTrue === undefined) {
         throw new Error(`a ${stmt.kind} block must have at least one Stmt`);
@@ -844,11 +867,11 @@ export class ASL {
       delete props.Next;
       props.End = true;
     }
-    if (expr.kind === "CallExpr") {
+    if (isCallExpr(expr)) {
       const serviceCall = findIntegration(expr);
       if (serviceCall) {
         if (
-          expr.expr.kind === "PropAccessExpr" &&
+          isPropAccessExpr(expr.expr) &&
           (expr.expr.name === "waitFor" || expr.expr.name === "waitUntil")
         ) {
           delete (props as any).ResultPath;
@@ -882,7 +905,7 @@ export class ASL {
         const throwTransition = this.throw(expr);
 
         const callbackfn = expr.getArgument("callbackfn")?.expr;
-        if (callbackfn !== undefined && callbackfn.kind === "FunctionExpr") {
+        if (callbackfn !== undefined && isFunctionExpr(callbackfn)) {
           const callbackStates = this.execute(callbackfn.body);
           const callbackStart = this.getStateName(callbackfn.body.step()!);
 
@@ -927,7 +950,7 @@ export class ASL {
         };
       } else if (isFilter(expr)) {
         const predicate = expr.getArgument("predicate")?.expr;
-        if (predicate !== undefined && predicate.kind === "FunctionExpr") {
+        if (predicate !== undefined && isFunctionExpr(predicate)) {
           try {
             // first try to implement filter optimally with JSON Path
             return {
@@ -952,7 +975,7 @@ export class ASL {
         OutputPath: "$.result",
         ...props,
       };
-    } else if (expr.kind === "ObjectLiteralExpr") {
+    } else if (isObjectLiteralExpr(expr)) {
       return {
         Type: "Pass",
         Parameters: ASL.toJson(expr),
@@ -965,7 +988,7 @@ export class ASL {
         ...props,
       };
     } else if (
-      expr.kind === "BinaryExpr" &&
+      isBinaryExpr(expr) &&
       expr.op === "=" &&
       isVariableReference(expr.left)
     ) {
@@ -1004,7 +1027,7 @@ export class ASL {
           ResultPath: ASL.toJsonPath(expr.left),
         });
       }
-    } else if (expr.kind === "BinaryExpr") {
+    } else if (isBinaryExpr(expr)) {
       // TODO
     }
     debugger;
@@ -1020,7 +1043,7 @@ export class ASL {
   private transition(stmt: Stmt | undefined): string | undefined {
     if (stmt === undefined) {
       return undefined;
-    } else if (stmt.kind === "CatchClause") {
+    } else if (isCatchClause(stmt)) {
       // CatchClause has special logic depending on whether the tryBlock contains a Task
       const { hasTask } = analyzeFlow(stmt.parent.tryBlock);
       if (hasTask && stmt.variableDecl) {
@@ -1032,7 +1055,7 @@ export class ASL {
         // so just transition into the catch block
         return this.transition(stmt.block);
       }
-    } else if (stmt.kind === "BlockStmt") {
+    } else if (isBlockStmt(stmt)) {
       // a BlockStmt does not have a state representing itself, so we instead step into it
       return this.transition(stmt.step());
     } else {
@@ -1049,7 +1072,7 @@ export class ASL {
    * TODO: can we simplify the logic here, make more use of {@link this.step} and {@link Stmt.step}?
    */
   private next(node: Stmt): string | undefined {
-    if (node.kind === "ReturnStmt") {
+    if (isReturnStmt(node)) {
       return this.return(node);
     } else if (node.next) {
       return this.transition(node.next);
@@ -1079,7 +1102,7 @@ export class ASL {
 
       if (scope && !scope.contains(exit)) {
         // we exited out of the loop
-        if (scope.kind === "ForInStmt" || scope.kind === "ForOfStmt") {
+        if (isForInStmt(scope) || isForOfStmt(scope)) {
           // if we're exiting a for-loop, then we return undefined
           // to indicate that the State should have Next:undefined and End: true
           return undefined;
@@ -1098,9 +1121,9 @@ export class ASL {
   private return(node: FunctionlessNode | undefined): string {
     if (node === undefined) {
       throw new Error("Stack Underflow");
-    } else if (node.kind === "FunctionDecl" || node.kind === "FunctionExpr") {
+    } else if (isFunctionDecl(node) || isFunctionExpr(node)) {
       return this.getStateName(node.body.lastStmt!);
-    } else if (node.kind === "ForInStmt" || node.kind === "ForOfStmt") {
+    } else if (isForInStmt(node) || isForOfStmt(node)) {
       return this.getStateName(node);
     } else {
       return this.return(node.parent);
@@ -1146,9 +1169,9 @@ export class ASL {
       return {
         Next: this.transition(catchOrFinally),
         ResultPath:
-          catchOrFinally.kind === "CatchClause" && catchOrFinally.variableDecl
+          isCatchClause(catchOrFinally) && catchOrFinally.variableDecl
             ? `$.${catchOrFinally.variableDecl.name}`
-            : catchOrFinally.kind === "BlockStmt" &&
+            : isBlockStmt(catchOrFinally) &&
               catchOrFinally.isFinallyBlock() &&
               canThrow(catchOrFinally.parent.catchClause) &&
               // we only store the error thrown from the catchClause if the finallyBlock is not terminal
@@ -1171,7 +1194,7 @@ export function isMapOrForEach(expr: CallExpr): expr is CallExpr & {
   expr: PropAccessExpr;
 } {
   return (
-    expr.expr.kind === "PropAccessExpr" &&
+    isPropAccessExpr(expr.expr) &&
     (expr.expr.name === "map" || expr.expr.name === "forEach")
   );
 }
@@ -1181,7 +1204,7 @@ function isSlice(expr: CallExpr): expr is CallExpr & {
     name: "slice";
   };
 } {
-  return expr.expr.kind === "PropAccessExpr" && expr.expr.name === "slice";
+  return isPropAccessExpr(expr.expr) && expr.expr.name === "slice";
 }
 
 function isFilter(expr: CallExpr): expr is CallExpr & {
@@ -1189,7 +1212,7 @@ function isFilter(expr: CallExpr): expr is CallExpr & {
     name: "filter";
   };
 } {
-  return expr.expr.kind === "PropAccessExpr" && expr.expr.name === "filter";
+  return isPropAccessExpr(expr.expr) && expr.expr.name === "filter";
 }
 
 function canThrow(node: FunctionlessNode): boolean {
@@ -1210,12 +1233,12 @@ function analyzeFlow(node: FunctionlessNode): FlowResult {
     .map(analyzeFlow)
     .reduce(
       (a, b) => ({ ...a, ...b }),
-      (node.kind === "CallExpr" &&
+      (isCallExpr(node) &&
         (findIntegration(node) !== undefined || isMapOrForEach(node))) ||
-        node.kind === "ForInStmt" ||
-        node.kind === "ForOfStmt"
+        isForInStmt(node) ||
+        isForOfStmt(node)
         ? { hasTask: true }
-        : node.kind === "ThrowStmt"
+        : isThrowStmt(node)
         ? { hasThrow: true }
         : {}
     );
@@ -1231,13 +1254,13 @@ function hasBreak(loop: ForInStmt | ForOfStmt | WhileStmt | DoStmt): boolean {
 
   function hasBreak(node: FunctionlessNode): boolean {
     if (
-      node.kind === "ForInStmt" ||
-      node.kind === "ForOfStmt" ||
-      node.kind === "WhileStmt" ||
-      node.kind === "DoStmt"
+      isForInStmt(node) ||
+      isForOfStmt(node) ||
+      isWhileStmt(node) ||
+      isDoStmt(node)
     ) {
       return false;
-    } else if (node.kind === "BreakStmt") {
+    } else if (isBreakStmt(node)) {
       return true;
     } else {
       for (const child of node.children) {
@@ -1267,47 +1290,47 @@ export namespace ASL {
         return constant.constant.resource.tableName;
       }
       return constant.constant;
-    } else if (expr.kind === "Argument") {
+    } else if (isArgument(expr)) {
       return toJson(expr.expr);
-    } else if (expr.kind === "BinaryExpr") {
-    } else if (expr.kind === "CallExpr") {
+    } else if (isBinaryExpr(expr)) {
+    } else if (isCallExpr(expr)) {
       if (isSlice(expr)) {
         return sliceToJsonPath(expr);
       } else if (isFilter(expr)) {
         return filterToJsonPath(expr);
       }
-    } else if (expr.kind === "Identifier") {
+    } else if (isIdentifier(expr)) {
       return toJsonPath(expr);
-    } else if (expr.kind === "PropAccessExpr") {
+    } else if (isPropAccessExpr(expr)) {
       return `${toJson(expr.expr)}.${expr.name}`;
-    } else if (expr.kind === "ElementAccessExpr") {
+    } else if (isElementAccessExpr(expr)) {
       return toJsonPath(expr);
-    } else if (expr.kind === "ArrayLiteralExpr") {
+    } else if (isArrayLiteralExpr(expr)) {
       if (expr.items.find(isVariableReference) !== undefined) {
         return `States.Array(${expr.items
           .map((item) => toJsonPath(item))
           .join(", ")})`;
       }
       return expr.items.map((item) => toJson(item));
-    } else if (expr.kind === "ObjectLiteralExpr") {
+    } else if (isObjectLiteralExpr(expr)) {
       const payload: any = {};
       for (const prop of expr.properties) {
-        if (prop.kind !== "PropAssignExpr") {
+        if (!isPropAssignExpr(prop)) {
           throw new Error(
             `${prop.kind} is not supported in Amazon States Language`
           );
         }
         if (
-          (prop.name.kind === "ComputedPropertyNameExpr" &&
-            prop.name.expr.kind === "StringLiteralExpr") ||
-          prop.name.kind === "Identifier" ||
-          prop.name.kind === "StringLiteralExpr"
+          (isComputedPropertyNameExpr(prop.name) &&
+            isStringLiteralExpr(prop.name.expr)) ||
+          isIdentifier(prop.name) ||
+          isStringLiteralExpr(prop.name)
         ) {
           payload[
             `${
-              prop.name.kind === "Identifier"
+              isIdentifier(prop.name)
                 ? prop.name.name
-                : prop.name.kind === "StringLiteralExpr"
+                : isStringLiteralExpr(prop.name)
                 ? prop.name.value
                 : (prop.name.expr as StringLiteralExpr).value
             }${
@@ -1323,7 +1346,7 @@ export namespace ASL {
       return payload;
     } else if (isLiteralExpr(expr)) {
       return expr.value ?? null;
-    } else if (expr.kind === "TemplateExpr") {
+    } else if (isTemplateExpr(expr)) {
       return `States.Format('${expr.exprs
         .map((e) => (isLiteralExpr(e) ? toJson(e) : "{}"))
         .join("")}',${expr.exprs
@@ -1335,17 +1358,17 @@ export namespace ASL {
   }
 
   export function toJsonPath(expr: Expr): string {
-    if (expr.kind === "ArrayLiteralExpr") {
+    if (isArrayLiteralExpr(expr)) {
       return aws_stepfunctions.JsonPath.array(
         ...expr.items.map((item) => toJsonPath(item))
       );
-    } else if (expr.kind === "CallExpr") {
+    } else if (isCallExpr(expr)) {
       if (isSlice(expr)) {
         return sliceToJsonPath(expr);
       } else if (isFilter(expr)) {
         return filterToJsonPath(expr);
       }
-    } else if (expr.kind === "Identifier") {
+    } else if (isIdentifier(expr)) {
       const ref = expr.lookup();
       // If the identifier references a parameter expression and that parameter expression
       // is in a FunctionDecl and that Function is at the top (no parent).
@@ -1354,9 +1377,9 @@ export namespace ASL {
         return "$";
       }
       return `$.${expr.name}`;
-    } else if (expr.kind === "PropAccessExpr") {
+    } else if (isPropAccessExpr(expr)) {
       return `${toJsonPath(expr.expr)}.${expr.name}`;
-    } else if (expr.kind === "ElementAccessExpr") {
+    } else if (isElementAccessExpr(expr)) {
       return elementAccessExprToJsonPath(expr);
     }
 
@@ -1431,7 +1454,7 @@ export namespace ASL {
 
   function filterToJsonPath(expr: CallExpr & { expr: PropAccessExpr }): string {
     const predicate = expr.getArgument("predicate")?.expr;
-    if (predicate?.kind !== "FunctionExpr") {
+    if (!isFunctionExpr(predicate)) {
       throw new Error(
         "the 'predicate' argument of slice must be a FunctionExpr"
       );
@@ -1440,7 +1463,7 @@ export namespace ASL {
     const stmt = predicate.body.statements[0];
     if (
       stmt === undefined ||
-      stmt.kind !== "ReturnStmt" ||
+      !isReturnStmt(stmt) ||
       predicate.body.statements.length !== 1
     ) {
       throw new Error(
@@ -1451,17 +1474,17 @@ export namespace ASL {
     return `${toJsonPath(expr.expr.expr)}[?(${toFilterCondition(stmt.expr)})]`;
 
     function toFilterCondition(expr: Expr): string {
-      if (expr.kind === "BinaryExpr") {
+      if (isBinaryExpr(expr)) {
         return `${toFilterCondition(expr.left)}${expr.op}${toFilterCondition(
           expr.right
         )}`;
-      } else if (expr.kind === "UnaryExpr") {
+      } else if (isUnaryExpr(expr)) {
         return `${expr.op}${toFilterCondition(expr.expr)}`;
-      } else if (expr.kind === "Identifier") {
+      } else if (isIdentifier(expr)) {
         const ref = expr.lookup();
         if (ref === undefined) {
           throw new Error(`unresolved identifier: ${expr.name}`);
-        } else if (ref.kind === "ParameterDecl") {
+        } else if (isParameterDecl(ref)) {
           if (ref.parent !== predicate) {
             throw new Error(
               "cannot reference a ParameterDecl other than those in .filter((item, index) =>) in a JSONPath filter expression"
@@ -1478,22 +1501,22 @@ export namespace ASL {
               "the 'array' parameter in a .filter expression is not supported"
             );
           }
-        } else if (ref.kind === "VariableStmt") {
+        } else if (isVariableStmt(ref)) {
           throw new Error(
             "cannot reference a VariableStmt within a JSONPath .filter expression"
           );
         }
-      } else if (expr.kind === "StringLiteralExpr") {
+      } else if (isStringLiteralExpr(expr)) {
         return `'${expr.value.replace(/'/g, "\\'")}'`;
       } else if (
-        expr.kind === "BooleanLiteralExpr" ||
-        expr.kind === "NumberLiteralExpr" ||
-        expr.kind === "NullLiteralExpr"
+        isBooleanLiteralExpr(expr) ||
+        isNumberLiteralExpr(expr) ||
+        isNullLiteralExpr(expr)
       ) {
         return `${expr.value}`;
-      } else if (expr.kind === "PropAccessExpr") {
+      } else if (isPropAccessExpr(expr)) {
         return `${toFilterCondition(expr.expr)}.${expr.name}`;
-      } else if (expr.kind === "ElementAccessExpr") {
+      } else if (isElementAccessExpr(expr)) {
         return `${toFilterCondition(expr.expr)}[${elementToJsonPath(
           expr.element
         )}]`;
@@ -1526,11 +1549,11 @@ export namespace ASL {
    * ```
    */
   function elementAccessExprToJsonPath(expr: ElementAccessExpr): string {
-    if (expr.element.kind === "Identifier" && expr.expr.kind === "Identifier") {
+    if (isIdentifier(expr.element) && isIdentifier(expr.expr)) {
       const element = expr.element.lookup();
       if (
-        element?.kind === "VariableStmt" &&
-        element?.parent?.kind === "ForInStmt" &&
+        isVariableStmt(element) &&
+        isForInStmt(element.parent) &&
         expr.findParent(isForInStmt) === element.parent
       ) {
         return `$.0_${element.name}`;
@@ -1660,16 +1683,16 @@ export namespace ASL {
   });
 
   export function toCondition(expr: Expr): Condition {
-    if (expr.kind === "BooleanLiteralExpr") {
+    if (isBooleanLiteralExpr(expr)) {
       return {
         IsPresent: !expr.value,
         Variable: `$.0_${expr.value}`,
       };
-    } else if (expr.kind === "UnaryExpr") {
+    } else if (isUnaryExpr(expr)) {
       return {
         Not: toCondition(expr.expr),
       };
-    } else if (expr.kind === "BinaryExpr") {
+    } else if (isBinaryExpr(expr)) {
       if (expr.op === "&&") {
         return {
           And: [toCondition(expr.left), toCondition(expr.right)],
@@ -1698,7 +1721,7 @@ export namespace ASL {
             ? [expr.left, expr.right]
             : [expr.right, expr.left];
 
-          if (val.kind === "TypeOfExpr") {
+          if (isTypeOfExpr(val)) {
             const supportedTypeNames = [
               "undefined",
               "boolean",
@@ -1707,7 +1730,7 @@ export namespace ASL {
               "bigint",
             ] as const;
 
-            if (literalExpr.kind !== "StringLiteralExpr") {
+            if (!isStringLiteralExpr(literalExpr)) {
               throw new Error(
                 'typeof expression can only be compared against a string literal, such as typeof x === "string"'
               );
@@ -1749,8 +1772,8 @@ export namespace ASL {
               );
             }
           } else if (
-            literalExpr.kind === "NullLiteralExpr" ||
-            literalExpr.kind === "UndefinedLiteralExpr"
+            isNullLiteralExpr(literalExpr) ||
+            isUndefinedLiteralExpr(literalExpr)
           ) {
             if (expr.op === "!=") {
               return {
@@ -1779,7 +1802,7 @@ export namespace ASL {
                 ],
               };
             }
-          } else if (literalExpr.kind === "StringLiteralExpr") {
+          } else if (isStringLiteralExpr(literalExpr)) {
             const [variable, value] = [
               toJsonPath(val),
               literalExpr.value,
@@ -1817,7 +1840,7 @@ export namespace ASL {
                 StringGreaterThanEquals: value,
               };
             }
-          } else if (literalExpr.kind === "NumberLiteralExpr") {
+          } else if (isNumberLiteralExpr(literalExpr)) {
             const [variable, value] = [
               toJsonPath(val),
               literalExpr.value,
@@ -1857,10 +1880,7 @@ export namespace ASL {
             }
           }
         }
-        if (
-          expr.left.kind === "StringLiteralExpr" ||
-          expr.right.kind === "StringLiteralExpr"
-        ) {
+        if (isStringLiteralExpr(expr.left) || isStringLiteralExpr(expr.right)) {
         }
         // need typing information
         // return aws_stepfunctions.Condition.str
@@ -1873,49 +1893,49 @@ export namespace ASL {
 }
 
 function toStateName(stmt: Stmt): string | undefined {
-  if (stmt.kind === "IfStmt") {
+  if (isIfStmt(stmt)) {
     return `if(${exprToString(stmt.when)})`;
-  } else if (stmt.kind === "ExprStmt") {
+  } else if (isExprStmt(stmt)) {
     return exprToString(stmt.expr);
-  } else if (stmt.kind === "BlockStmt") {
+  } else if (isBlockStmt(stmt)) {
     if (stmt.isFinallyBlock()) {
       return "finally";
     } else {
       return undefined;
     }
-  } else if (stmt.kind === "BreakStmt") {
+  } else if (isBreakStmt(stmt)) {
     return "break";
-  } else if (stmt.kind === "ContinueStmt") {
+  } else if (isContinueStmt(stmt)) {
     return "continue";
-  } else if (stmt.kind === "CatchClause") {
+  } else if (isCatchClause(stmt)) {
     return `catch${
       stmt.variableDecl?.name ? `(${stmt.variableDecl?.name})` : ""
     }`;
-  } else if (stmt.kind === "DoStmt") {
+  } else if (isDoStmt(stmt)) {
     return `while (${exprToString(stmt.condition)})`;
-  } else if (stmt.kind === "ForInStmt") {
+  } else if (isForInStmt(stmt)) {
     return `for(${stmt.variableDecl.name} in ${exprToString(stmt.expr)})`;
-  } else if (stmt.kind === "ForOfStmt") {
+  } else if (isForOfStmt(stmt)) {
     return `for(${stmt.variableDecl.name} of ${exprToString(stmt.expr)})`;
-  } else if (stmt.kind === "ReturnStmt") {
+  } else if (isReturnStmt(stmt)) {
     if (stmt.expr) {
       return `return ${exprToString(stmt.expr)}`;
     } else {
       return "return";
     }
-  } else if (stmt.kind === "ThrowStmt") {
+  } else if (isThrowStmt(stmt)) {
     return `throw ${exprToString(stmt.expr)}`;
-  } else if (stmt.kind === "TryStmt") {
+  } else if (isTryStmt(stmt)) {
     return "try";
-  } else if (stmt.kind === "VariableStmt") {
-    if (stmt.parent?.kind === "CatchClause") {
+  } else if (isVariableStmt(stmt)) {
+    if (isCatchClause(stmt.parent)) {
       return `catch(${stmt.name})`;
     } else {
       return `${stmt.name} = ${
         stmt.expr ? exprToString(stmt.expr) : "undefined"
       }`;
     }
-  } else if (stmt.kind === "WhileStmt") {
+  } else if (isWhileStmt(stmt)) {
     return `while (${exprToString(stmt.condition)})`;
   } else {
     return assertNever(stmt);
@@ -1925,73 +1945,73 @@ function toStateName(stmt: Stmt): string | undefined {
 function exprToString(expr?: Expr): string {
   if (!expr) {
     return "";
-  } else if (expr.kind === "Argument") {
+  } else if (isArgument(expr)) {
     return exprToString(expr.expr);
-  } else if (expr.kind === "ArrayLiteralExpr") {
+  } else if (isArrayLiteralExpr(expr)) {
     return `[${expr.items.map(exprToString).join(", ")}]`;
-  } else if (expr.kind === "BinaryExpr") {
+  } else if (isBinaryExpr(expr)) {
     return `${exprToString(expr.left)} ${expr.op} ${exprToString(expr.right)}`;
-  } else if (expr.kind === "BooleanLiteralExpr") {
+  } else if (isBooleanLiteralExpr(expr)) {
     return `${expr.value}`;
-  } else if (expr.kind === "CallExpr" || expr.kind === "NewExpr") {
-    return `${expr.kind === "NewExpr" ? "new " : ""}${exprToString(
+  } else if (isCallExpr(expr) || isNewExpr(expr)) {
+    return `${isNewExpr(expr) ? "new " : ""}${exprToString(
       expr.expr
     )}(${expr.args
       // Assume that undefined args are in order.
       .filter(
         (arg) =>
           arg.expr &&
-          !(arg.name === "thisArg" && arg.expr.kind === "UndefinedLiteralExpr")
+          !(arg.name === "thisArg" && isUndefinedLiteralExpr(arg.expr))
       )
       .map((arg) => exprToString(arg.expr))
       .join(", ")})`;
-  } else if (expr.kind === "ConditionExpr") {
+  } else if (isConditionExpr(expr)) {
     return `if(${exprToString(expr.when)})`;
-  } else if (expr.kind === "ComputedPropertyNameExpr") {
+  } else if (isComputedPropertyNameExpr(expr)) {
     return `[${exprToString(expr.expr)}]`;
-  } else if (expr.kind === "ElementAccessExpr") {
+  } else if (isElementAccessExpr(expr)) {
     return `${exprToString(expr.expr)}[${exprToString(expr.element)}]`;
-  } else if (expr.kind === "FunctionExpr") {
+  } else if (isFunctionExpr(expr)) {
     return `function(${expr.parameters.map((param) => param.name).join(", ")})`;
-  } else if (expr.kind === "Identifier") {
+  } else if (isIdentifier(expr)) {
     return expr.name;
-  } else if (expr.kind === "NullLiteralExpr") {
+  } else if (isNullLiteralExpr(expr)) {
     return "null";
-  } else if (expr.kind === "NumberLiteralExpr") {
+  } else if (isNumberLiteralExpr(expr)) {
     return `${expr.value}`;
-  } else if (expr.kind === "ObjectLiteralExpr") {
+  } else if (isObjectLiteralExpr(expr)) {
     return `{${expr.properties.map(exprToString).join(", ")}}`;
-  } else if (expr.kind === "PropAccessExpr") {
+  } else if (isPropAccessExpr(expr)) {
     return `${exprToString(expr.expr)}.${expr.name}`;
-  } else if (expr.kind === "PropAssignExpr") {
+  } else if (isPropAssignExpr(expr)) {
     return `${
-      expr.name.kind === "Identifier"
+      isIdentifier(expr.name)
         ? expr.name.name
-        : expr.name.kind === "StringLiteralExpr"
+        : isStringLiteralExpr(expr.name)
         ? expr.name.value
-        : expr.name.kind === "ComputedPropertyNameExpr"
-        ? expr.name.expr.kind === "StringLiteralExpr"
+        : isComputedPropertyNameExpr(expr.name)
+        ? isStringLiteralExpr(expr.name.expr)
           ? expr.name.expr.value
           : exprToString(expr.name.expr)
         : assertNever(expr.name)
     }: ${exprToString(expr.expr)}`;
-  } else if (expr.kind === "ReferenceExpr") {
+  } else if (isReferenceExpr(expr)) {
     return expr.name;
-  } else if (expr.kind === "SpreadAssignExpr") {
+  } else if (isSpreadAssignExpr(expr)) {
     return `...${exprToString(expr.expr)}`;
-  } else if (expr.kind === "SpreadElementExpr") {
+  } else if (isSpreadElementExpr(expr)) {
     return `...${exprToString(expr.expr)}`;
-  } else if (expr.kind === "StringLiteralExpr") {
+  } else if (isStringLiteralExpr(expr)) {
     return `"${expr.value}"`;
-  } else if (expr.kind === "TemplateExpr") {
+  } else if (isTemplateExpr(expr)) {
     return `\`${expr.exprs
-      .map((e) => (e.kind === "StringLiteralExpr" ? e.value : exprToString(e)))
+      .map((e) => (isStringLiteralExpr(e) ? e.value : exprToString(e)))
       .join("")}\``;
-  } else if (expr.kind === "TypeOfExpr") {
+  } else if (isTypeOfExpr(expr)) {
     return `typeof ${exprToString(expr.expr)}`;
-  } else if (expr.kind === "UnaryExpr") {
+  } else if (isUnaryExpr(expr)) {
     return `${expr.op}${exprToString(expr.expr)}`;
-  } else if (expr.kind === "UndefinedLiteralExpr") {
+  } else if (isUndefinedLiteralExpr(expr)) {
     return "undefined";
   } else {
     return assertNever(expr);

--- a/src/aws.ts
+++ b/src/aws.ts
@@ -17,17 +17,7 @@ import {
 } from "typesafe-dynamodb/lib/update-item";
 import { ASL } from "./asl";
 import { ErrorCodes, SynthError } from "./error-code";
-import {
-  Argument,
-  Expr,
-  isArgument,
-  isIdentifier,
-  isObjectLiteralExpr,
-  isPropAssignExpr,
-  isReferenceExpr,
-  isStringLiteralExpr,
-  isVariableReference,
-} from "./expression";
+import { Argument, Expr, isVariableReference } from "./expression";
 import {
   Function,
   isFunction,
@@ -35,6 +25,14 @@ import {
   NativePreWarmContext,
   PrewarmClients,
 } from "./function";
+import {
+  isArgument,
+  isIdentifier,
+  isObjectLiteralExpr,
+  isPropAssignExpr,
+  isReferenceExpr,
+  isStringLiteralExpr,
+} from "./guards";
 import {
   IntegrationCall,
   IntegrationInput,

--- a/src/declaration.ts
+++ b/src/declaration.ts
@@ -1,9 +1,9 @@
-import { isErr } from "./error";
 import { ErrorCodes, SynthError } from "./error-code";
 import { Argument, FunctionExpr } from "./expression";
 import { NativePreWarmContext } from "./function";
+import { isErr, isFunctionDecl, isNode, isParameterDecl } from "./guards";
 import { Integration } from "./integration";
-import { BaseNode, FunctionlessNode, isNode, typeGuard } from "./node";
+import { BaseNode, FunctionlessNode } from "./node";
 import { BlockStmt } from "./statement";
 import { AnyFunction } from "./util";
 
@@ -12,8 +12,6 @@ export type Decl = FunctionDecl | ParameterDecl | NativeFunctionDecl;
 export function isDecl(a: any): a is Decl {
   return isNode(a) && (isFunctionDecl(a) || isParameterDecl(a));
 }
-
-export const isFunctionDecl = typeGuard("FunctionDecl");
 
 abstract class BaseDecl<
   Kind extends FunctionlessNode["kind"],
@@ -46,8 +44,6 @@ export interface IntegrationInvocation {
   args: Argument[];
 }
 
-export const isNativeFunctionDecl = typeGuard("NativeFunctionDecl");
-
 /**
  * A function declaration which contains the original closure instead of Functionless expressions.
  */
@@ -73,8 +69,6 @@ export class NativeFunctionDecl<
     ) as this;
   }
 }
-
-export const isParameterDecl = typeGuard("ParameterDecl");
 
 export class ParameterDecl extends BaseDecl<
   "ParameterDecl",

--- a/src/error.ts
+++ b/src/error.ts
@@ -1,6 +1,4 @@
-import { BaseNode, typeGuard } from "./node";
-
-export const isErr = typeGuard("Err");
+import { BaseNode } from "./node";
 
 export class Err extends BaseNode<"Err"> {
   readonly nodeKind: "Err" = "Err";

--- a/src/event-bridge/event-bus.ts
+++ b/src/event-bridge/event-bus.ts
@@ -5,16 +5,18 @@ import {
   CallExpr,
   Expr,
   Identifier,
-  isArrayLiteralExpr,
-  isComputedPropertyNameExpr,
-  isIdentifier,
-  isObjectLiteralExpr,
-  isSpreadAssignExpr,
   ObjectLiteralExpr,
   PropAssignExpr,
   StringLiteralExpr,
 } from "../expression";
 import { Function, NativePreWarmContext, PrewarmClients } from "../function";
+import {
+  isArrayLiteralExpr,
+  isComputedPropertyNameExpr,
+  isIdentifier,
+  isObjectLiteralExpr,
+  isSpreadAssignExpr,
+} from "../guards";
 import {
   Integration,
   IntegrationCall,

--- a/src/event-bridge/event-pattern/synth.ts
+++ b/src/event-bridge/event-pattern/synth.ts
@@ -1,31 +1,33 @@
 import {
-  BinaryOp,
-  isBinaryExpr,
-  isCallExpr,
-  isElementAccessExpr,
-  isNullLiteralExpr,
-  isPropAccessExpr,
-  isUnaryExpr,
-} from "../..";
-import {
   assertDefined,
   assertNever,
   assertNumber,
   assertPrimitive,
   assertString,
 } from "../../assert";
-import { FunctionDecl, isFunctionDecl } from "../../declaration";
-import { Err, isErr } from "../../error";
+import { FunctionDecl } from "../../declaration";
+import { Err } from "../../error";
 import {
+  BinaryOp,
   BinaryExpr,
   CallExpr,
   ElementAccessExpr,
   Expr,
-  isBooleanLiteralExpr,
-  isUndefinedLiteralExpr,
   PropAccessExpr,
   UnaryExpr,
 } from "../../expression";
+import {
+  isBinaryExpr,
+  isBooleanLiteralExpr,
+  isCallExpr,
+  isElementAccessExpr,
+  isErr,
+  isFunctionDecl,
+  isNullLiteralExpr,
+  isPropAccessExpr,
+  isUnaryExpr,
+  isUndefinedLiteralExpr,
+} from "../../guards";
 import { evalToConstant } from "../../util";
 import * as functionless_event_bridge from "../types";
 import {

--- a/src/event-bridge/target-input.ts
+++ b/src/event-bridge/target-input.ts
@@ -4,9 +4,8 @@ import { validateFunctionDecl } from "..";
 import { assertConstantValue, assertString } from "../assert";
 import { FunctionDecl } from "../declaration";
 import { Err } from "../error";
+import { ArrayLiteralExpr, Expr, ObjectLiteralExpr } from "../expression";
 import {
-  ArrayLiteralExpr,
-  Expr,
   isArrayLiteralExpr,
   isBinaryExpr,
   isElementAccessExpr,
@@ -15,8 +14,7 @@ import {
   isPropAccessExpr,
   isPropAssignExpr,
   isTemplateExpr,
-  ObjectLiteralExpr,
-} from "../expression";
+} from "../guards";
 import { evalToConstant } from "../util";
 import {
   assertValidEventReference,

--- a/src/event-bridge/utils.ts
+++ b/src/event-bridge/utils.ts
@@ -5,18 +5,6 @@ import {
   ElementAccessExpr,
   Expr,
   Identifier,
-  isArrayLiteralExpr,
-  isBinaryExpr,
-  isComputedPropertyNameExpr,
-  isElementAccessExpr,
-  isIdentifier,
-  isObjectLiteralExpr,
-  isPropAccessExpr,
-  isPropAssignExpr,
-  isSpreadElementExpr,
-  isStringLiteralExpr,
-  isTemplateExpr,
-  isUnaryExpr,
   NumberLiteralExpr,
   ObjectLiteralExpr,
   PropAccessExpr,
@@ -25,7 +13,23 @@ import {
   TemplateExpr,
   UnaryExpr,
 } from "../expression";
-import { isReturnStmt, isVariableStmt, Stmt, VariableStmt } from "../statement";
+import {
+  isArrayLiteralExpr,
+  isBinaryExpr,
+  isComputedPropertyNameExpr,
+  isElementAccessExpr,
+  isIdentifier,
+  isObjectLiteralExpr,
+  isPropAccessExpr,
+  isPropAssignExpr,
+  isReturnStmt,
+  isSpreadElementExpr,
+  isStringLiteralExpr,
+  isTemplateExpr,
+  isUnaryExpr,
+  isVariableStmt,
+} from "../guards";
+import { Stmt, VariableStmt } from "../statement";
 import { Constant, evalToConstant } from "../util";
 
 /**

--- a/src/expression.ts
+++ b/src/expression.ts
@@ -1,7 +1,14 @@
 import { $AWS } from "./aws";
 import { ParameterDecl } from "./declaration";
 import { AnyLambda } from "./function";
-import { BaseNode, FunctionlessNode, isNode, typeGuard } from "./node";
+import {
+  isElementAccessExpr,
+  isIdentifier,
+  isPropAccessExpr,
+  isPropAssignExpr,
+  isStringLiteralExpr,
+} from "./guards";
+import { BaseNode, FunctionlessNode } from "./node";
 import type {
   BlockStmt,
   ExprStmt,
@@ -41,52 +48,6 @@ export type Expr =
   | UnaryExpr
   | UndefinedLiteralExpr;
 
-export function isExpr(a: any): a is Expr {
-  return (
-    isNode(a) &&
-    (isArgument(a) ||
-      isArrayLiteralExpr(a) ||
-      isBinaryExpr(a) ||
-      isBooleanLiteralExpr(a) ||
-      isCallExpr(a) ||
-      isConditionExpr(a) ||
-      isComputedPropertyNameExpr(a) ||
-      isFunctionExpr(a) ||
-      isElementAccessExpr(a) ||
-      isFunctionExpr(a) ||
-      isIdentifier(a) ||
-      isNewExpr(a) ||
-      isNullLiteralExpr(a) ||
-      isNumberLiteralExpr(a) ||
-      isObjectLiteralExpr(a) ||
-      isPropAccessExpr(a) ||
-      isPropAssignExpr(a) ||
-      isReferenceExpr(a) ||
-      isStringLiteralExpr(a) ||
-      isTemplateExpr(a) ||
-      isTypeOfExpr(a) ||
-      isUnaryExpr(a) ||
-      isUndefinedLiteralExpr(a))
-  );
-}
-
-export const isLiteralExpr = typeGuard(
-  "ArrayLiteralExpr",
-  "BooleanLiteralExpr",
-  "UndefinedLiteralExpr",
-  "NullLiteralExpr",
-  "NumberLiteralExpr",
-  "ObjectLiteralExpr",
-  "StringLiteralExpr"
-);
-
-export const isLiteralPrimitiveExpr = typeGuard(
-  "BooleanLiteralExpr",
-  "NullLiteralExpr",
-  "NumberLiteralExpr",
-  "StringLiteralExpr"
-);
-
 export abstract class BaseExpr<
   Kind extends FunctionlessNode["kind"],
   Parent extends FunctionlessNode | undefined =
@@ -98,8 +59,6 @@ export abstract class BaseExpr<
 > extends BaseNode<Kind, Parent> {
   readonly nodeKind: "Expr" = "Expr";
 }
-
-export const isFunctionExpr = typeGuard("FunctionExpr");
 
 export class FunctionExpr<
   F extends AnyFunction = AnyFunction
@@ -118,8 +77,6 @@ export class FunctionExpr<
     ) as this;
   }
 }
-
-export const isReferenceExpr = typeGuard("ReferenceExpr");
 
 export type CanReference =
   | AnyTable
@@ -146,8 +103,6 @@ export function isVariableReference(expr: Expr): expr is VariableReference {
   );
 }
 
-export const isIdentifier = typeGuard("Identifier");
-
 export class Identifier extends BaseExpr<"Identifier"> {
   constructor(readonly name: string) {
     super("Identifier");
@@ -161,8 +116,6 @@ export class Identifier extends BaseExpr<"Identifier"> {
     return this.getLexicalScope().get(this.name);
   }
 }
-
-export const isPropAccessExpr = typeGuard("PropAccessExpr");
 
 export class PropAccessExpr extends BaseExpr<"PropAccessExpr"> {
   constructor(
@@ -178,8 +131,6 @@ export class PropAccessExpr extends BaseExpr<"PropAccessExpr"> {
     return new PropAccessExpr(this.expr.clone(), this.name, this.type) as this;
   }
 }
-
-export const isElementAccessExpr = typeGuard("ElementAccessExpr");
 
 export class ElementAccessExpr extends BaseExpr<"ElementAccessExpr"> {
   constructor(
@@ -201,8 +152,6 @@ export class ElementAccessExpr extends BaseExpr<"ElementAccessExpr"> {
   }
 }
 
-export const isArgument = typeGuard("Argument");
-
 export class Argument extends BaseExpr<"Argument", CallExpr | NewExpr> {
   constructor(readonly expr?: Expr, readonly name?: string) {
     super("Argument");
@@ -213,8 +162,6 @@ export class Argument extends BaseExpr<"Argument", CallExpr | NewExpr> {
     return new Argument(this.expr?.clone(), this.name) as this;
   }
 }
-
-export const isCallExpr = typeGuard("CallExpr");
 
 export class CallExpr extends BaseExpr<"CallExpr"> {
   constructor(readonly expr: Expr, readonly args: Argument[]) {
@@ -235,8 +182,6 @@ export class CallExpr extends BaseExpr<"CallExpr"> {
   }
 }
 
-export const isNewExpr = typeGuard("NewExpr");
-
 export class NewExpr extends BaseExpr<"NewExpr"> {
   constructor(readonly expr: Expr, readonly args: Argument[]) {
     super("NewExpr");
@@ -256,8 +201,6 @@ export class NewExpr extends BaseExpr<"NewExpr"> {
   }
 }
 
-export const isConditionExpr = typeGuard("ConditionExpr");
-
 export class ConditionExpr extends BaseExpr<"ConditionExpr"> {
   constructor(readonly when: Expr, readonly then: Expr, readonly _else: Expr) {
     super("ConditionExpr");
@@ -276,8 +219,6 @@ export class ConditionExpr extends BaseExpr<"ConditionExpr"> {
     ) as this;
   }
 }
-
-export const isBinaryExpr = typeGuard("BinaryExpr");
 
 export type ValueComparisonBinaryOp = "==" | "!=" | "<" | "<=" | ">" | ">=";
 export type MathBinaryOp = "/" | "*" | "+" | "-";
@@ -310,8 +251,6 @@ export class BinaryExpr extends BaseExpr<"BinaryExpr"> {
   }
 }
 
-export const isUnaryExpr = typeGuard("UnaryExpr");
-
 export type UnaryOp = "!" | "-";
 
 export class UnaryExpr extends BaseExpr<"UnaryExpr"> {
@@ -327,8 +266,6 @@ export class UnaryExpr extends BaseExpr<"UnaryExpr"> {
 
 // literals
 
-export const isNullLiteralExpr = typeGuard("NullLiteralExpr");
-
 export class NullLiteralExpr extends BaseExpr<"NullLiteralExpr"> {
   readonly value = null;
   constructor() {
@@ -339,8 +276,6 @@ export class NullLiteralExpr extends BaseExpr<"NullLiteralExpr"> {
     return new NullLiteralExpr() as this;
   }
 }
-
-export const isUndefinedLiteralExpr = typeGuard("UndefinedLiteralExpr");
 
 export class UndefinedLiteralExpr extends BaseExpr<"UndefinedLiteralExpr"> {
   readonly value = undefined;
@@ -354,8 +289,6 @@ export class UndefinedLiteralExpr extends BaseExpr<"UndefinedLiteralExpr"> {
   }
 }
 
-export const isBooleanLiteralExpr = typeGuard("BooleanLiteralExpr");
-
 export class BooleanLiteralExpr extends BaseExpr<"BooleanLiteralExpr"> {
   constructor(readonly value: boolean) {
     super("BooleanLiteralExpr");
@@ -365,8 +298,6 @@ export class BooleanLiteralExpr extends BaseExpr<"BooleanLiteralExpr"> {
     return new BooleanLiteralExpr(this.value) as this;
   }
 }
-
-export const isNumberLiteralExpr = typeGuard("NumberLiteralExpr");
 
 export class NumberLiteralExpr extends BaseExpr<"NumberLiteralExpr"> {
   constructor(readonly value: number) {
@@ -378,8 +309,6 @@ export class NumberLiteralExpr extends BaseExpr<"NumberLiteralExpr"> {
   }
 }
 
-export const isStringLiteralExpr = typeGuard("StringLiteralExpr");
-
 export class StringLiteralExpr extends BaseExpr<"StringLiteralExpr"> {
   constructor(readonly value: string) {
     super("StringLiteralExpr");
@@ -389,8 +318,6 @@ export class StringLiteralExpr extends BaseExpr<"StringLiteralExpr"> {
     return new StringLiteralExpr(this.value) as this;
   }
 }
-
-export const isArrayLiteralExpr = typeGuard("ArrayLiteralExpr");
 
 export class ArrayLiteralExpr extends BaseExpr<"ArrayLiteralExpr"> {
   constructor(readonly items: Expr[]) {
@@ -405,13 +332,6 @@ export class ArrayLiteralExpr extends BaseExpr<"ArrayLiteralExpr"> {
 
 export type ObjectElementExpr = PropAssignExpr | SpreadAssignExpr;
 
-export const isObjectElementExpr = typeGuard(
-  "PropAssignExpr",
-  "SpreadAssignExpr"
-);
-
-export const isObjectLiteralExpr = typeGuard("ObjectLiteralExpr");
-
 export class ObjectLiteralExpr extends BaseExpr<"ObjectLiteralExpr"> {
   constructor(readonly properties: ObjectElementExpr[]) {
     super("ObjectLiteralExpr");
@@ -425,12 +345,12 @@ export class ObjectLiteralExpr extends BaseExpr<"ObjectLiteralExpr"> {
   }
   public getProperty(name: string) {
     return this.properties.find((prop) => {
-      if (prop.kind === "PropAssignExpr") {
-        if (prop.name.kind === "Identifier") {
+      if (isPropAssignExpr(prop)) {
+        if (isIdentifier(prop.name)) {
           return prop.name.name === name;
-        } else if (prop.name.kind === "StringLiteralExpr") {
+        } else if (isStringLiteralExpr(prop.name)) {
           return prop.name.value === name;
-        } else if (prop.name.expr.kind === "StringLiteralExpr") {
+        } else if (isStringLiteralExpr(prop.name.expr)) {
           return prop.name.expr.value === name;
         }
       }
@@ -438,8 +358,6 @@ export class ObjectLiteralExpr extends BaseExpr<"ObjectLiteralExpr"> {
     });
   }
 }
-
-export const isPropAssignExpr = typeGuard("PropAssignExpr");
 
 export class PropAssignExpr extends BaseExpr<
   "PropAssignExpr",
@@ -459,8 +377,6 @@ export class PropAssignExpr extends BaseExpr<
   }
 }
 
-export const isComputedPropertyNameExpr = typeGuard("ComputedPropertyNameExpr");
-
 export class ComputedPropertyNameExpr extends BaseExpr<
   "ComputedPropertyNameExpr",
   PropAssignExpr
@@ -474,8 +390,6 @@ export class ComputedPropertyNameExpr extends BaseExpr<
     return new ComputedPropertyNameExpr(this.expr.clone()) as this;
   }
 }
-
-export const isSpreadAssignExpr = typeGuard("SpreadAssignExpr");
 
 export class SpreadAssignExpr extends BaseExpr<
   "SpreadAssignExpr",
@@ -491,8 +405,6 @@ export class SpreadAssignExpr extends BaseExpr<
   }
 }
 
-export const isSpreadElementExpr = typeGuard("SpreadElementExpr");
-
 export class SpreadElementExpr extends BaseExpr<
   "SpreadElementExpr",
   ObjectLiteralExpr
@@ -507,8 +419,6 @@ export class SpreadElementExpr extends BaseExpr<
   }
 }
 
-export const isTemplateExpr = typeGuard("TemplateExpr");
-
 /**
  * Interpolates a TemplateExpr to a string `this ${is} a template expression`
  */
@@ -522,8 +432,6 @@ export class TemplateExpr extends BaseExpr<"TemplateExpr"> {
     return new TemplateExpr(this.exprs.map((expr) => expr.clone())) as this;
   }
 }
-
-export const isTypeOfExpr = typeGuard("TypeOfExpr");
 
 export class TypeOfExpr extends BaseExpr<"TypeOfExpr"> {
   constructor(readonly expr: Expr) {

--- a/src/function.ts
+++ b/src/function.ts
@@ -29,8 +29,7 @@ import { Construct } from "constructs";
 import { ApiGatewayVtlIntegration } from "./api";
 import type { AppSyncVtlIntegration } from "./appsync";
 import { ASL } from "./asl";
-import { isNativeFunctionDecl, validateFunctionlessNode } from "./declaration";
-import { isErr } from "./error";
+import { validateFunctionlessNode } from "./declaration";
 import { ErrorCodes, formatErrorMessage, SynthError } from "./error-code";
 import {
   IEventBus,
@@ -42,6 +41,7 @@ import {
 } from "./event-bridge";
 import { makeEventBusIntegration } from "./event-bridge/event-bus";
 import { CallExpr, Expr, isVariableReference } from "./expression";
+import { isErr, isNativeFunctionDecl } from "./guards";
 import {
   Integration,
   IntegrationImpl,

--- a/src/guards.ts
+++ b/src/guards.ts
@@ -1,0 +1,129 @@
+import type { Expr } from "./expression";
+import type { FunctionlessNode } from "./node";
+import type { Stmt } from "./statement";
+
+export function isNode(a: any): a is FunctionlessNode {
+  return typeof a?.kind === "string";
+}
+
+export const isErr = typeGuard("Err");
+
+export function isExpr(a: any): a is Expr {
+  return (
+    isNode(a) &&
+    (isArgument(a) ||
+      isArrayLiteralExpr(a) ||
+      isBinaryExpr(a) ||
+      isBooleanLiteralExpr(a) ||
+      isCallExpr(a) ||
+      isConditionExpr(a) ||
+      isComputedPropertyNameExpr(a) ||
+      isFunctionExpr(a) ||
+      isElementAccessExpr(a) ||
+      isFunctionExpr(a) ||
+      isIdentifier(a) ||
+      isNewExpr(a) ||
+      isNullLiteralExpr(a) ||
+      isNumberLiteralExpr(a) ||
+      isObjectLiteralExpr(a) ||
+      isPropAccessExpr(a) ||
+      isPropAssignExpr(a) ||
+      isReferenceExpr(a) ||
+      isStringLiteralExpr(a) ||
+      isTemplateExpr(a) ||
+      isTypeOfExpr(a) ||
+      isUnaryExpr(a) ||
+      isUndefinedLiteralExpr(a))
+  );
+}
+
+export const isFunctionExpr = typeGuard("FunctionExpr");
+export const isReferenceExpr = typeGuard("ReferenceExpr");
+export const isIdentifier = typeGuard("Identifier");
+export const isPropAccessExpr = typeGuard("PropAccessExpr");
+export const isElementAccessExpr = typeGuard("ElementAccessExpr");
+export const isArgument = typeGuard("Argument");
+export const isCallExpr = typeGuard("CallExpr");
+export const isNewExpr = typeGuard("NewExpr");
+export const isConditionExpr = typeGuard("ConditionExpr");
+export const isBinaryExpr = typeGuard("BinaryExpr");
+export const isUnaryExpr = typeGuard("UnaryExpr");
+export const isNullLiteralExpr = typeGuard("NullLiteralExpr");
+export const isUndefinedLiteralExpr = typeGuard("UndefinedLiteralExpr");
+export const isBooleanLiteralExpr = typeGuard("BooleanLiteralExpr");
+export const isNumberLiteralExpr = typeGuard("NumberLiteralExpr");
+export const isStringLiteralExpr = typeGuard("StringLiteralExpr");
+export const isArrayLiteralExpr = typeGuard("ArrayLiteralExpr");
+export const isObjectLiteralExpr = typeGuard("ObjectLiteralExpr");
+export const isPropAssignExpr = typeGuard("PropAssignExpr");
+export const isComputedPropertyNameExpr = typeGuard("ComputedPropertyNameExpr");
+export const isSpreadAssignExpr = typeGuard("SpreadAssignExpr");
+export const isSpreadElementExpr = typeGuard("SpreadElementExpr");
+export const isTemplateExpr = typeGuard("TemplateExpr");
+export const isTypeOfExpr = typeGuard("TypeOfExpr");
+
+export const isObjectElementExpr = typeGuard(
+  "PropAssignExpr",
+  "SpreadAssignExpr"
+);
+
+export const isLiteralExpr = typeGuard(
+  "ArrayLiteralExpr",
+  "BooleanLiteralExpr",
+  "UndefinedLiteralExpr",
+  "NullLiteralExpr",
+  "NumberLiteralExpr",
+  "ObjectLiteralExpr",
+  "StringLiteralExpr"
+);
+
+export const isLiteralPrimitiveExpr = typeGuard(
+  "BooleanLiteralExpr",
+  "NullLiteralExpr",
+  "NumberLiteralExpr",
+  "StringLiteralExpr"
+);
+
+export function isStmt(a: any): a is Stmt {
+  return (
+    isNode(a) &&
+    (isBreakStmt(a) ||
+      isBlockStmt(a) ||
+      isCatchClause(a) ||
+      isContinueStmt(a) ||
+      isExprStmt(a) ||
+      isForInStmt(a) ||
+      isForOfStmt(a) ||
+      isIfStmt(a) ||
+      isReturnStmt(a) ||
+      isThrowStmt(a) ||
+      isTryStmt(a) ||
+      isVariableStmt(a))
+  );
+}
+export const isExprStmt = typeGuard("ExprStmt");
+export const isVariableStmt = typeGuard("VariableStmt");
+export const isBlockStmt = typeGuard("BlockStmt");
+export const isReturnStmt = typeGuard("ReturnStmt");
+export const isIfStmt = typeGuard("IfStmt");
+export const isForOfStmt = typeGuard("ForOfStmt");
+export const isForInStmt = typeGuard("ForInStmt");
+export const isBreakStmt = typeGuard("BreakStmt");
+export const isContinueStmt = typeGuard("ContinueStmt");
+export const isTryStmt = typeGuard("TryStmt");
+export const isCatchClause = typeGuard("CatchClause");
+export const isThrowStmt = typeGuard("ThrowStmt");
+export const isWhileStmt = typeGuard("WhileStmt");
+export const isDoStmt = typeGuard("DoStmt");
+
+export const isFunctionDecl = typeGuard("FunctionDecl");
+export const isNativeFunctionDecl = typeGuard("NativeFunctionDecl");
+export const isParameterDecl = typeGuard("ParameterDecl");
+
+// generates type guards
+export function typeGuard<Kind extends FunctionlessNode["kind"]>(
+  ...kinds: Kind[]
+): (a: any) => a is Extract<FunctionlessNode, { kind: Kind }> {
+  return (a: any): a is Extract<FunctionlessNode, { kind: Kind }> =>
+    kinds.find((kind) => a?.kind === kind) !== undefined;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ export * from "./error-code";
 export * from "./event-bridge";
 export * from "./expression";
 export * from "./function";
+export * from "./guards";
 export { Integration } from "./integration";
 export * from "./reflect";
 export * from "./statement";

--- a/src/integration.ts
+++ b/src/integration.ts
@@ -4,6 +4,15 @@ import { ASL, State } from "./asl";
 import { EventBus, EventBusTargetIntegration } from "./event-bridge";
 import { CallExpr } from "./expression";
 import { Function, NativeIntegration } from "./function";
+import {
+  isCallExpr,
+  isExprStmt,
+  isIdentifier,
+  isPropAccessExpr,
+  isReferenceExpr,
+  isReturnStmt,
+  isVariableStmt,
+} from "./guards";
 import { FunctionlessNode } from "./node";
 import { AnyFunction } from "./util";
 import { VTL } from "./vtl";
@@ -246,11 +255,11 @@ export function findIntegration(call: CallExpr): IntegrationImpl | undefined {
   return integration ? new IntegrationImpl(integration) : undefined;
 
   function find(expr: FunctionlessNode): any {
-    if (expr.kind === "PropAccessExpr") {
+    if (isPropAccessExpr(expr)) {
       return find(expr.expr)?.[expr.name];
-    } else if (expr.kind === "Identifier") {
+    } else if (isIdentifier(expr)) {
       return undefined;
-    } else if (expr.kind === "ReferenceExpr") {
+    } else if (isReferenceExpr(expr)) {
       return expr.ref();
     } else {
       return undefined;
@@ -266,15 +275,15 @@ export type CallContext = ASL | VTL | Function<any, any> | EventBus<any>;
 export function findDeepIntegration(
   expr: FunctionlessNode
 ): IntegrationImpl | undefined {
-  if (expr.kind === "PropAccessExpr") {
+  if (isPropAccessExpr(expr)) {
     return findDeepIntegration(expr.expr);
-  } else if (expr.kind === "CallExpr") {
+  } else if (isCallExpr(expr)) {
     return findIntegration(expr);
-  } else if (expr.kind === "VariableStmt" && expr.expr) {
+  } else if (isVariableStmt(expr) && expr.expr) {
     return findDeepIntegration(expr.expr);
-  } else if (expr.kind === "ReturnStmt" && expr.expr) {
+  } else if (isReturnStmt(expr) && expr.expr) {
     return findDeepIntegration(expr.expr);
-  } else if (expr.kind === "ExprStmt") {
+  } else if (isExprStmt(expr)) {
     return findDeepIntegration(expr.expr);
   }
   return undefined;

--- a/src/statement.ts
+++ b/src/statement.ts
@@ -1,6 +1,7 @@
 import { FunctionDecl } from "./declaration";
 import { Expr, FunctionExpr } from "./expression";
-import { BaseNode, FunctionlessNode, isNode, typeGuard } from "./node";
+import { isTryStmt } from "./guards";
+import { BaseNode, FunctionlessNode } from "./node";
 
 /**
  * A {@link Stmt} (Statement) is unit of execution that does not yield any value. They are translated
@@ -22,24 +23,6 @@ export type Stmt =
   | VariableStmt
   | WhileStmt;
 
-export function isStmt(a: any): a is Stmt {
-  return (
-    isNode(a) &&
-    (isBreakStmt(a) ||
-      isBlockStmt(a) ||
-      isCatchClause(a) ||
-      isContinueStmt(a) ||
-      isExprStmt(a) ||
-      isForInStmt(a) ||
-      isForOfStmt(a) ||
-      isIfStmt(a) ||
-      isReturnStmt(a) ||
-      isThrowStmt(a) ||
-      isTryStmt(a) ||
-      isVariableStmt(a))
-  );
-}
-
 export abstract class BaseStmt<
   Kind extends FunctionlessNode["kind"],
   Parent extends FunctionlessNode | undefined = BlockStmt | IfStmt
@@ -56,8 +39,6 @@ export abstract class BaseStmt<
   next: Stmt | undefined;
 }
 
-export const isExprStmt = typeGuard("ExprStmt");
-
 export class ExprStmt extends BaseStmt<"ExprStmt"> {
   constructor(readonly expr: Expr) {
     super("ExprStmt");
@@ -68,8 +49,6 @@ export class ExprStmt extends BaseStmt<"ExprStmt"> {
     return new ExprStmt(this.expr.clone()) as this;
   }
 }
-
-export const isVariableStmt = typeGuard("VariableStmt");
 
 export type VariableStmtParent =
   | ForInStmt
@@ -92,8 +71,6 @@ export class VariableStmt<
     return new VariableStmt(this.name, this.expr?.clone()) as this;
   }
 }
-
-export const isBlockStmt = typeGuard("BlockStmt");
 
 export type BlockStmtParent =
   | CatchClause
@@ -121,7 +98,7 @@ export class BlockStmt extends BaseStmt<"BlockStmt", BlockStmtParent> {
   }
 
   public isFinallyBlock(): this is FinallyBlock {
-    return this.parent.kind === "TryStmt" && this.parent.finallyBlock === this;
+    return isTryStmt(this.parent) && this.parent.finallyBlock === this;
   }
 
   public isEmpty(): this is {
@@ -149,8 +126,6 @@ export class BlockStmt extends BaseStmt<"BlockStmt", BlockStmtParent> {
   }
 }
 
-export const isReturnStmt = typeGuard("ReturnStmt");
-
 export class ReturnStmt extends BaseStmt<"ReturnStmt"> {
   constructor(readonly expr: Expr) {
     super("ReturnStmt");
@@ -161,8 +136,6 @@ export class ReturnStmt extends BaseStmt<"ReturnStmt"> {
     return new ReturnStmt(this.expr.clone()) as this;
   }
 }
-
-export const isIfStmt = typeGuard("IfStmt");
 
 export class IfStmt extends BaseStmt<"IfStmt"> {
   constructor(
@@ -187,8 +160,6 @@ export class IfStmt extends BaseStmt<"IfStmt"> {
   }
 }
 
-export const isForOfStmt = typeGuard("ForOfStmt");
-
 export class ForOfStmt extends BaseStmt<"ForOfStmt"> {
   constructor(
     readonly variableDecl: VariableStmt,
@@ -209,8 +180,6 @@ export class ForOfStmt extends BaseStmt<"ForOfStmt"> {
     ) as this;
   }
 }
-
-export const isForInStmt = typeGuard("ForInStmt");
 
 export class ForInStmt extends BaseStmt<"ForInStmt"> {
   constructor(
@@ -233,8 +202,6 @@ export class ForInStmt extends BaseStmt<"ForInStmt"> {
   }
 }
 
-export const isBreakStmt = typeGuard("BreakStmt");
-
 export class BreakStmt extends BaseStmt<"BreakStmt"> {
   constructor() {
     super("BreakStmt");
@@ -244,8 +211,6 @@ export class BreakStmt extends BaseStmt<"BreakStmt"> {
     return new BreakStmt() as this;
   }
 }
-
-export const isContinueStmt = typeGuard("ContinueStmt");
 
 export class ContinueStmt extends BaseStmt<"ContinueStmt"> {
   constructor() {
@@ -262,8 +227,6 @@ export interface FinallyBlock extends BlockStmt {
     finallyBlock: FinallyBlock;
   };
 }
-
-export const isTryStmt = typeGuard("TryStmt");
 
 export class TryStmt extends BaseStmt<"TryStmt"> {
   constructor(
@@ -290,8 +253,6 @@ export class TryStmt extends BaseStmt<"TryStmt"> {
   }
 }
 
-export const isCatchClause = typeGuard("CatchClause");
-
 export class CatchClause extends BaseStmt<"CatchClause", TryStmt> {
   constructor(
     readonly variableDecl: VariableStmt | undefined,
@@ -312,8 +273,6 @@ export class CatchClause extends BaseStmt<"CatchClause", TryStmt> {
   }
 }
 
-export const isThrowStmt = typeGuard("ThrowStmt");
-
 export class ThrowStmt extends BaseStmt<"ThrowStmt"> {
   constructor(readonly expr: Expr) {
     super("ThrowStmt");
@@ -324,8 +283,6 @@ export class ThrowStmt extends BaseStmt<"ThrowStmt"> {
     return new ThrowStmt(this.expr.clone()) as this;
   }
 }
-
-export const isWhileStmt = typeGuard("WhileStmt");
 
 export class WhileStmt extends BaseStmt<"WhileStmt"> {
   constructor(readonly condition: Expr, readonly block: BlockStmt) {
@@ -338,8 +295,6 @@ export class WhileStmt extends BaseStmt<"WhileStmt"> {
     return new WhileStmt(this.condition.clone(), this.block.clone()) as this;
   }
 }
-
-export const isDoStmt = typeGuard("DoStmt");
 
 export class DoStmt extends BaseStmt<"DoStmt"> {
   constructor(readonly block: BlockStmt, readonly condition: Expr) {

--- a/src/step-function.ts
+++ b/src/step-function.ts
@@ -19,12 +19,7 @@ import {
   Task,
 } from "./asl";
 import { assertDefined } from "./assert";
-import {
-  validateFunctionDecl,
-  FunctionDecl,
-  isFunctionDecl,
-} from "./declaration";
-import { isErr } from "./error";
+import { validateFunctionDecl, FunctionDecl } from "./declaration";
 import { ErrorCodes, SynthError } from "./error-code";
 import { EventBus, PredicateRuleBase, Rule } from "./event-bridge";
 import {
@@ -32,14 +27,19 @@ import {
   makeEventBusIntegration,
 } from "./event-bridge/event-bus";
 import { Event } from "./event-bridge/types";
-import {
-  CallExpr,
-  isComputedPropertyNameExpr,
-  isFunctionExpr,
-  isObjectLiteralExpr,
-  isSpreadAssignExpr,
-} from "./expression";
+import { CallExpr } from "./expression";
 import { NativeIntegration, PrewarmClients } from "./function";
+import {
+  isComputedPropertyNameExpr,
+  isErr,
+  isFunctionDecl,
+  isFunctionExpr,
+  isNumberLiteralExpr,
+  isObjectLiteralExpr,
+  isPropAssignExpr,
+  isSpreadAssignExpr,
+  isStringLiteralExpr,
+} from "./guards";
 import {
   Integration,
   IntegrationCall,
@@ -74,7 +74,7 @@ export namespace $SFN {
         throw new Error("the 'seconds' argument is required");
       }
 
-      if (seconds.kind === "NumberLiteralExpr") {
+      if (isNumberLiteralExpr(seconds)) {
         return {
           Type: "Wait" as const,
           Seconds: seconds.value,
@@ -107,7 +107,7 @@ export namespace $SFN {
         throw new Error("the 'timestamp' argument is required");
       }
 
-      if (timestamp.kind === "StringLiteralExpr") {
+      if (isStringLiteralExpr(timestamp)) {
         return {
           Type: "Wait",
           Timestamp: timestamp.value,
@@ -231,11 +231,11 @@ export namespace $SFN {
       const props = call.getArgument("props")?.expr;
       let maxConcurrency: number | undefined;
       if (props !== undefined) {
-        if (props.kind === "ObjectLiteralExpr") {
+        if (isObjectLiteralExpr(props)) {
           const maxConcurrencyProp = props.getProperty("maxConcurrency");
           if (
-            maxConcurrencyProp?.kind === "PropAssignExpr" &&
-            maxConcurrencyProp.expr.kind === "NumberLiteralExpr"
+            isPropAssignExpr(maxConcurrencyProp) &&
+            isNumberLiteralExpr(maxConcurrencyProp.expr)
           ) {
             maxConcurrency = maxConcurrencyProp.expr.value;
             if (maxConcurrency <= 0) {

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,11 +1,15 @@
 import { Construct } from "constructs";
 import ts from "typescript";
+import { Expr } from "./expression";
 import {
-  Expr,
   isArrayLiteralExpr,
   isBinaryExpr,
   isBooleanLiteralExpr,
   isComputedPropertyNameExpr,
+  isForInStmt,
+  isForOfStmt,
+  isFunctionDecl,
+  isFunctionExpr,
   isIdentifier,
   isNullLiteralExpr,
   isNumberLiteralExpr,
@@ -18,7 +22,7 @@ import {
   isStringLiteralExpr,
   isUnaryExpr,
   isUndefinedLiteralExpr,
-} from "./expression";
+} from "./guards";
 import { FunctionlessNode } from "./node";
 
 export type AnyFunction = (...args: any[]) => any;
@@ -30,9 +34,9 @@ export function isInTopLevelScope(expr: FunctionlessNode): boolean {
   return walk(expr.parent);
 
   function walk(expr: FunctionlessNode): boolean {
-    if (expr.kind === "FunctionDecl" || expr.kind === "FunctionExpr") {
+    if (isFunctionDecl(expr) || isFunctionExpr(expr)) {
       return expr.parent === undefined;
-    } else if (expr.kind === "ForInStmt" || expr.kind === "ForOfStmt") {
+    } else if (isForInStmt(expr) || isForOfStmt(expr)) {
       return false;
     } else if (expr.parent === undefined) {
       return true;

--- a/test/util.ts
+++ b/test/util.ts
@@ -19,13 +19,14 @@ import {
   ResolverArguments,
 } from "../src";
 
-import { Err, isErr } from "../src/error";
+import { Err } from "../src/error";
 import {
   synthesizeEventPattern,
   synthesizePatternDocument,
 } from "../src/event-bridge/event-pattern/synth";
 import { synthesizeEventBridgeTargets } from "../src/event-bridge/target-input";
 import { EventTransformFunction } from "../src/event-bridge/transform";
+import { isErr } from "../src/guards";
 
 // generates boilerplate for the circuit-breaker logic for implementing early return
 export function returnExpr(varName: string) {

--- a/website/docs/extending-functionless.md
+++ b/website/docs/extending-functionless.md
@@ -19,11 +19,11 @@ const functionDecl = reflect((arg: string) => {
 Then, write a recursive function to process the representation:
 
 ```ts
-import { FunctionlessNode } from "functionless";
+import { FunctionlessNode, isFunctionDecl } from "functionless";
 
 function processExpr(node: FunctionlessNode) {
   // do work
-  if (node.kind === "FunctionDecl") {
+  if (isFunctionDecl(node)) {
     // blah
   }
 }


### PR DESCRIPTION
Fixes #177

Move all type assertion functions to `src/guards.ts` to avoid circular imports.

Replace all uses of `.kind === "<kind>"` with the corresponding type assertion function.