### PR TITLE
feat(appsync): remove addResolver from AppsyncResolver and lazy template evaluation

### DIFF
--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -201,7 +201,7 @@
           "exec": "./scripts/localstack"
         },
         {
-          "exec": "cd ./test-app && yarn && yarn build && yarn synth"
+          "exec": "cd ./test-app && yarn && yarn build && yarn synth --quiet"
         },
         {
           "exec": "jest --passWithNoTests --all --updateSnapshot"

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -169,7 +169,7 @@ project.compileTask.prependExec(
 );
 
 project.testTask.prependExec(
-  "cd ./test-app && yarn && yarn build && yarn synth"
+  "cd ./test-app && yarn && yarn build && yarn synth --quiet"
 );
 project.testTask.prependExec("./scripts/localstack");
 project.testTask.exec("localstack stop");

--- a/src/appsync.ts
+++ b/src/appsync.ts
@@ -180,7 +180,7 @@ export class AppsyncResolver<
   Arguments extends ResolverArguments,
   Result,
   Source = undefined
-> extends Construct {
+> {
   /**
    * This static property identifies this class as an AppsyncResolver to the TypeScript plugin.
    */
@@ -238,14 +238,13 @@ export class AppsyncResolver<
         }),
     resolve: ResolverFunction<Arguments, Result, Source>
   ) {
-    super(scope, id);
     this.decl = validateFunctionDecl(resolve, "AppsyncResolver");
 
     const api = props.api ?? (scope as unknown as appsync.GraphqlApi);
 
     this.resolvers = memoize(() => synthResolvers(api, this.decl));
 
-    this.resource = new aws_appsync.CfnResolver(this, "Resource", {
+    this.resource = new aws_appsync.CfnResolver(scope, id, {
       apiId: api.apiId,
       typeName: props.typeName,
       fieldName: props.fieldName,

--- a/src/appsync.ts
+++ b/src/appsync.ts
@@ -147,14 +147,13 @@ export interface AppsyncResolverProps<>extends Pick<
 /**
  * An AWS AppSync Resolver Function derived from TypeScript syntax.
  *
- * First, you must wrap a CDK L2 Construct in the corresponding Functionless type-safe interfaces.
- * ```ts
- * const table = Table.fromTable<Person, "id">(new aws_dynamodb.Table(scope, "id", props));
- * ```
- *
- * Then, call the table from within the new AppsyncResolver:
  * ```ts
  * const getPerson = new AppsyncResolver<{id: string}, Person | undefined>(
+ *   scope, id, {
+ *      api,
+ *      typeName: "Query",
+ *      fieldName: "getPerson"
+ *   },
  *   ($context, id) => {
  *     const person = table.get({
  *       key: {
@@ -163,18 +162,6 @@ export interface AppsyncResolverProps<>extends Pick<
  *     });
  *     return person;
  *   });
- * ```
- *
- * Finally, the `getPerson` function can be used to create resolvers on a GraphQL API
- * ```ts
- * import * as appsync from "@aws-cdk/aws-appsync-alpha";
- *
- * const api = new appsync.GraphQLApi(..);
- *
- * getPerson.createResolver(api, {
- *   typeName: "Query",
- *   fieldName: "getPerson"
- * });
  * ```
  *
  * @functionless AppsyncFunction
@@ -259,7 +246,14 @@ export interface AppsyncFieldOptions
  * const api = new appsync.GraphQLApi(..);
  *
  * ```ts
- * const getPerson = new AppsyncResolver<{id: string}, Person | undefined>(
+ * const getPersonField = new AppsyncField<{id: string}, Person | undefined>(
+ *   {
+ *     api,
+ *     returnType: appsync.Field.string(),
+ *     args: {
+ *       argName: appsync.Field.string()
+ *     }
+ *   },
  *   ($context, id) => {
  *     const person = table.get({
  *       key: {
@@ -273,11 +267,7 @@ export interface AppsyncFieldOptions
  * // code first person type
  * const personType = api.addType(appsync.ObjectType(...));
  *
- * api.addQuery("getPerson", getPerson.getField(api, personType))
- * getPerson.createResolver(api, {
- *   typeName: "Query",
- *   fieldName: "getPerson"
- * });
+ * api.addQuery("getPerson", getPersonField)
  * ```
  *
  * @param api app sync API which the data sources construct will be added under.

--- a/src/checker.ts
+++ b/src/checker.ts
@@ -1,7 +1,7 @@
 import * as ts from "typescript";
 import * as tsserver from "typescript/lib/tsserverlibrary";
 import { ApiMethod, ApiMethodKind, isApiMethodKind } from "./api";
-import { AppsyncResolver } from "./appsync";
+import { AppsyncField, AppsyncResolver } from "./appsync";
 import { EventBus, Rule } from "./event-bridge";
 import { EventTransform } from "./event-bridge/transform";
 import { Function } from "./function";
@@ -77,6 +77,7 @@ export function makeFunctionlessChecker(
     getApiMethodKind,
     getFunctionlessTypeKind,
     isApiIntegration,
+    isAppsyncField,
     isAppsyncResolver,
     isCDKConstruct,
     isConstant,
@@ -175,12 +176,34 @@ export function makeFunctionlessChecker(
   }
 
   function isAppsyncResolver(node: ts.Node): node is ts.NewExpression & {
-    arguments: [TsFunctionParameter, ...ts.Expression[]];
+    arguments: [
+      ts.Expression,
+      ts.Expression,
+      ts.Expression,
+      // the inline function
+      TsFunctionParameter
+    ];
   } {
     if (ts.isNewExpression(node)) {
       return isFunctionlessClassOfKind(
         node.expression,
         AppsyncResolver.FunctionlessType
+      );
+    }
+    return false;
+  }
+
+  function isAppsyncField(node: ts.Node): node is ts.NewExpression & {
+    arguments: [
+      ts.Expression,
+      // the inline function
+      TsFunctionParameter
+    ];
+  } {
+    if (ts.isNewExpression(node)) {
+      return isFunctionlessClassOfKind(
+        node.expression,
+        AppsyncField.FunctionlessType
       );
     }
     return false;

--- a/src/util.ts
+++ b/src/util.ts
@@ -27,6 +27,24 @@ import { FunctionlessNode } from "./node";
 
 export type AnyFunction = (...args: any[]) => any;
 
+/**
+ * Create a memoized function.
+ *
+ * @param f the function that produces the value
+ * @returns a function that computes a value on demand at most once.
+ */
+export function memoize<T>(f: () => T): () => T {
+  let isComputed = false;
+  let t: T;
+  return () => {
+    if (!isComputed) {
+      t = f();
+      isComputed = true;
+    }
+    return t!;
+  };
+}
+
 export function isInTopLevelScope(expr: FunctionlessNode): boolean {
   if (expr.parent === undefined) {
     return true;

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -34,6 +34,8 @@ export function validate(
       return validateApi(node);
     } else if (checker.isNewFunctionlessFunction(node)) {
       return validateFunctionNode(node);
+    } else if (checker.isAppsyncResolver(node)) {
+      return validateAppsync(node);
     } else {
       return collectEachChild(node, visit);
     }
@@ -94,6 +96,20 @@ export function validate(
           ErrorCodes.Cannot_perform_arithmetic_on_variables_in_Step_Function
         ),
       ];
+    }
+    return [];
+  }
+
+  function validateAppsync(node: ts.NewExpression): ts.Diagnostic[] {
+    if (node.arguments) {
+      const [, , , resolver] = node.arguments;
+      if (
+        !(ts.isArrowFunction(resolver) || ts.isFunctionExpression(resolver))
+      ) {
+        return [
+          newError(resolver, ErrorCodes.Argument_must_be_an_inline_Function),
+        ];
+      }
     }
     return [];
   }

--- a/test-app/cdk.json
+++ b/test-app/cdk.json
@@ -1,3 +1,3 @@
 {
-  "app": "ts-node ./src/api-test.ts"
+  "app": "ts-node ./src/message-board.ts"
 }

--- a/test-app/message-board.gql
+++ b/test-app/message-board.gql
@@ -1,3 +1,8 @@
+schema {
+  query: Query
+  mutation: Mutation
+}
+
 type Post {
   postId: ID!
   title: String!

--- a/test-app/src/app.ts
+++ b/test-app/src/app.ts
@@ -28,32 +28,8 @@ const api = new appsync.GraphqlApi(stack, "Api", {
 });
 
 // @ts-ignore
-const peopleDb = new PeopleDatabase(stack, "PeopleDB");
-
-peopleDb.getPerson.addResolver(api, {
-  typeName: "Query",
-  fieldName: "getPerson",
-});
-
-peopleDb.addPerson.addResolver(api, {
-  typeName: "Mutation",
-  fieldName: "addPerson",
-});
-
-// add a duplicate addPerson API to test duplicates
-peopleDb.addPerson.addResolver(api, {
-  typeName: "Mutation",
-  fieldName: "addPerson2",
-});
-
-peopleDb.updateName.addResolver(api, {
-  typeName: "Mutation",
-  fieldName: "updateName",
-});
-
-peopleDb.deletePerson.addResolver(api, {
-  typeName: "Mutation",
-  fieldName: "deletePerson",
+const peopleDb = new PeopleDatabase(stack, "PeopleDB", {
+  api,
 });
 
 interface MyEventDetails {

--- a/test-app/src/people-db.ts
+++ b/test-app/src/people-db.ts
@@ -114,11 +114,15 @@ export class PeopleDatabase extends Construct {
     this.getPerson = new AppsyncResolver<
       QueryResolvers["getPerson"]["args"],
       QueryResolvers["getPerson"]["result"]
-    >(this, "getPerson", {
-      api,
-      typeName: "Query",
-      fieldName: "getPerson",
-      resolve: ($context) => {
+    >(
+      this,
+      "getPerson",
+      {
+        api,
+        typeName: "Query",
+        fieldName: "getPerson",
+      },
+      ($context) => {
         let person;
         // example of integrating with an Express Step Function from Appsync
         person = this.getPersonMachine({
@@ -130,17 +134,21 @@ export class PeopleDatabase extends Construct {
         } else {
           $util.error(person.cause, person.error);
         }
-      },
-    });
+      }
+    );
 
     this.addPerson = new AppsyncResolver<
       MutationResolvers["addPerson"]["args"],
       MutationResolvers["addPerson"]["result"]
-    >(this, "addPerson", {
-      api,
-      typeName: "Query",
-      fieldName: "addPerson",
-      resolve: ($context) => {
+    >(
+      this,
+      "addPerson",
+      {
+        api,
+        typeName: "Query",
+        fieldName: "addPerson",
+      },
+      ($context) => {
         const person = this.personTable.putItem({
           key: {
             id: {
@@ -155,17 +163,19 @@ export class PeopleDatabase extends Construct {
         });
 
         return person;
-      },
-    });
+      }
+    );
 
     // example of inferring the TArguments and TResult from the function signature
-    this.updateName = new AppsyncResolver(this, "updateName", {
-      api,
-      typeName: "Mutation",
-      fieldName: "updateName",
-      resolve: (
-        $context: AppsyncContext<MutationResolvers["updateName"]["args"]>
-      ) =>
+    this.updateName = new AppsyncResolver(
+      this,
+      "updateName",
+      {
+        api,
+        typeName: "Mutation",
+        fieldName: "updateName",
+      },
+      ($context: AppsyncContext<MutationResolvers["updateName"]["args"]>) =>
         this.personTable.updateItem({
           key: {
             id: $util.dynamodb.toDynamoDB($context.arguments.id),
@@ -179,23 +189,27 @@ export class PeopleDatabase extends Construct {
               ":name": $util.dynamodb.toDynamoDB($context.arguments.name),
             },
           },
-        }),
-    });
+        })
+    );
 
     // example of explicitly specifying TArguments and TResult
     this.deletePerson = new AppsyncResolver<
       MutationResolvers["deletePerson"]["args"],
       MutationResolvers["deletePerson"]["result"]
-    >(this, "deletePerson", {
-      api,
-      typeName: "Mutation",
-      fieldName: "deletePerson",
-      resolve: ($context) =>
+    >(
+      this,
+      "deletePerson",
+      {
+        api,
+        typeName: "Mutation",
+        fieldName: "deletePerson",
+      },
+      ($context) =>
         this.personTable.deleteItem({
           key: {
             id: $util.dynamodb.toDynamoDB($context.arguments.id),
           },
-        }),
-    });
+        })
+    );
   }
 }

--- a/test-app/src/people-events.ts
+++ b/test-app/src/people-events.ts
@@ -48,7 +48,7 @@ export class PeopleEvents extends Construct {
 
     const bus = new functionless.EventBus<UserEvent>(this, "myBus");
 
-    // Create and update events are sent to a spcific lambda function.
+    // Create and update events are sent to a specific lambda function.
     bus
       .when(
         this,

--- a/test/__snapshots__/validate.test.ts.snap
+++ b/test/__snapshots__/validate.test.ts.snap
@@ -45,6 +45,33 @@ https://functionless.org/docs/error-codes#api-gateway-response-mapping-template-
 "
 `;
 
+exports[`appsync.ts 1`] = `
+"[96mtest/test-files/appsync.ts[0m:[93m48[0m:[93m5[0m - [91merror[0m[90m Functionless(10002): [0mArgument must be an inline Function
+
+https://functionless.org/docs/error-codes#argument-must-be-an-inline-function
+
+[7m48[0m   },
+[7m  [0m [91m    [0m
+[7m49[0m   // invalid - must be an inline function
+[7m  [0m [91m~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~[0m
+[7m50[0m   f
+[7m  [0m [91m~~~[0m
+[96mtest/test-files/appsync.ts[0m:[93m60[0m:[93m5[0m - [91merror[0m[90m Functionless(10002): [0mArgument must be an inline Function
+
+https://functionless.org/docs/error-codes#argument-must-be-an-inline-function
+
+[7m 60[0m   },
+[7m   [0m [91m    [0m
+[7m 61[0m   // invalid - must be an inline function
+[7m   [0m [91m~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~[0m
+[7m...[0m 
+[7m 64[0m       null
+[7m   [0m [91m~~~~~~~~~~[0m
+[7m 65[0m   )()
+[7m   [0m [91m~~~~~[0m
+"
+`;
+
 exports[`function.ts 1`] = `
 "[96mtest/test-files/function.ts[0m:[93m28[0m:[93m51[0m - [91merror[0m[90m Functionless(10009): [0mCannot use infrastructure Resource in Function closure
 

--- a/test/__snapshots__/vtl.test.ts.snap
+++ b/test/__snapshots__/vtl.test.ts.snap
@@ -3,8 +3,8 @@
 exports[`$util.log.error(message) 1`] = `
 Array [
   "{
-  \\"version\\": \\"2018-05-29\\",
-  \\"payload\\": null
+\\"version\\": \\"2018-05-29\\",
+\\"payload\\": null
 }",
   "#return($util.log.error('hello world'))",
 ]
@@ -13,8 +13,8 @@ Array [
 exports[`$util.log.error(message, ...Object) 1`] = `
 Array [
   "{
-  \\"version\\": \\"2018-05-29\\",
-  \\"payload\\": null
+\\"version\\": \\"2018-05-29\\",
+\\"payload\\": null
 }",
   "#set($v1 = {})
 $util.qr($v1.put('a', 1))
@@ -27,8 +27,8 @@ $util.qr($v2.put('b', 2))
 exports[`$util.log.info(message) 1`] = `
 Array [
   "{
-  \\"version\\": \\"2018-05-29\\",
-  \\"payload\\": null
+\\"version\\": \\"2018-05-29\\",
+\\"payload\\": null
 }",
   "#return($util.log.info('hello world'))",
 ]
@@ -37,8 +37,8 @@ Array [
 exports[`$util.log.info(message, ...Object) 1`] = `
 Array [
   "{
-  \\"version\\": \\"2018-05-29\\",
-  \\"payload\\": null
+\\"version\\": \\"2018-05-29\\",
+\\"payload\\": null
 }",
   "#set($v1 = {})
 $util.qr($v1.put('a', 1))
@@ -51,8 +51,8 @@ $util.qr($v2.put('b', 2))
 exports[`$util.time.nowISO8601 1`] = `
 Array [
   "{
-  \\"version\\": \\"2018-05-29\\",
-  \\"payload\\": null
+\\"version\\": \\"2018-05-29\\",
+\\"payload\\": null
 }",
   "#return($util.time.nowISO8601())",
 ]
@@ -61,8 +61,8 @@ Array [
 exports[`BinaryExpr and UnaryExpr are evaluated to temporary variables 1`] = `
 Array [
   "{
-  \\"version\\": \\"2018-05-29\\",
-  \\"payload\\": null
+\\"version\\": \\"2018-05-29\\",
+\\"payload\\": null
 }",
   "#set($v1 = {})
 #set($v2 = 0 - 1)
@@ -80,8 +80,8 @@ $util.qr($v1.put('z', $v6))
 exports[`binary expr = 1`] = `
 Array [
   "{
-  \\"version\\": \\"2018-05-29\\",
-  \\"payload\\": null
+\\"version\\": \\"2018-05-29\\",
+\\"payload\\": null
 }",
   "#set($v1 = $context.arguments.key == 'help me')
 #if($v1)
@@ -122,8 +122,8 @@ Object {
 exports[`binary expr == 1`] = `
 Array [
   "{
-  \\"version\\": \\"2018-05-29\\",
-  \\"payload\\": null
+\\"version\\": \\"2018-05-29\\",
+\\"payload\\": null
 }",
   "#set($v1 = {})
 #set($v2 = $context.arguments.key == 'key')
@@ -145,8 +145,8 @@ Object {
 exports[`binary expr in 1`] = `
 Array [
   "{
-  \\"version\\": \\"2018-05-29\\",
-  \\"payload\\": null
+\\"version\\": \\"2018-05-29\\",
+\\"payload\\": null
 }",
   "#set($v2 = $context.arguments.class.name.startsWith('[L') || $context.arguments.class.name.contains('ArrayList'))
 #if($v2)
@@ -230,8 +230,8 @@ Object {
 exports[`binary expr in map 1`] = `
 Array [
   "{
-  \\"version\\": \\"2018-05-29\\",
-  \\"payload\\": null
+\\"version\\": \\"2018-05-29\\",
+\\"payload\\": null
 }",
   "#set($v1 = {})
 $util.qr($v1.put('key', 'value'))
@@ -277,8 +277,8 @@ Object {
 exports[`binary exprs logical 1`] = `
 Array [
   "{
-  \\"version\\": \\"2018-05-29\\",
-  \\"payload\\": null
+\\"version\\": \\"2018-05-29\\",
+\\"payload\\": null
 }",
   "#set($context.stash.a = $context.arguments.a)
 #set($context.stash.b = $context.arguments.b)
@@ -315,8 +315,8 @@ Object {
 exports[`binary exprs math 1`] = `
 Array [
   "{
-  \\"version\\": \\"2018-05-29\\",
-  \\"payload\\": null
+\\"version\\": \\"2018-05-29\\",
+\\"payload\\": null
 }",
   "#set($context.stash.a = $context.arguments.a)
 #set($context.stash.b = $context.arguments.b)
@@ -345,8 +345,8 @@ Object {
 exports[`binary exprs value comparison 1`] = `
 Array [
   "{
-  \\"version\\": \\"2018-05-29\\",
-  \\"payload\\": null
+\\"version\\": \\"2018-05-29\\",
+\\"payload\\": null
 }",
   "#set($context.stash.a = $context.arguments.a)
 #set($context.stash.b = $context.arguments.b)
@@ -413,8 +413,8 @@ Object {
 exports[`break from for-loop 1`] = `
 Array [
   "{
-  \\"version\\": \\"2018-05-29\\",
-  \\"payload\\": null
+\\"version\\": \\"2018-05-29\\",
+\\"payload\\": null
 }",
   "#set($context.stash.newList = [])
 #foreach($item in $context.arguments.list)
@@ -431,8 +431,8 @@ $util.qr($context.stash.newList.addAll([$item]))
 exports[`call function and return its value 1`] = `
 Array [
   "{
-  \\"version\\": \\"2018-05-29\\",
-  \\"payload\\": null
+\\"version\\": \\"2018-05-29\\",
+\\"payload\\": null
 }",
   "#return($util.autoId())",
 ]
@@ -441,8 +441,8 @@ Array [
 exports[`call function, assign to variable and return variable reference 1`] = `
 Array [
   "{
-  \\"version\\": \\"2018-05-29\\",
-  \\"payload\\": null
+\\"version\\": \\"2018-05-29\\",
+\\"payload\\": null
 }",
   "#set($context.stash.id = $util.autoId())
 #return($context.stash.id)",
@@ -452,8 +452,8 @@ Array [
 exports[`chain map over list 1`] = `
 Array [
   "{
-  \\"version\\": \\"2018-05-29\\",
-  \\"payload\\": null
+\\"version\\": \\"2018-05-29\\",
+\\"payload\\": null
 }",
   "#set($v1 = [])
 #foreach($item in $context.arguments.list)
@@ -468,8 +468,8 @@ $util.qr($v1.add($v2))
 exports[`chain map over list complex 1`] = `
 Array [
   "{
-  \\"version\\": \\"2018-05-29\\",
-  \\"payload\\": null
+\\"version\\": \\"2018-05-29\\",
+\\"payload\\": null
 }",
   "#set($v1 = [])
 #foreach($item in $context.arguments.list)
@@ -489,8 +489,8 @@ $util.qr($v1.add($v3))
 exports[`chain map over list multiple array 1`] = `
 Array [
   "{
-  \\"version\\": \\"2018-05-29\\",
-  \\"payload\\": null
+\\"version\\": \\"2018-05-29\\",
+\\"payload\\": null
 }",
   "#set($v1 = [])
 #set($v2 = [])
@@ -513,8 +513,8 @@ $util.qr($v1.add($v4))
 exports[`computed property names 1`] = `
 Array [
   "{
-  \\"version\\": \\"2018-05-29\\",
-  \\"payload\\": null
+\\"version\\": \\"2018-05-29\\",
+\\"payload\\": null
 }",
   "#set($context.stash.name = $context.arguments.arg)
 #set($v1 = $context.stash.name + '_test')
@@ -529,8 +529,8 @@ $util.qr($v2.put($context.stash.value, $context.arguments.arg))
 exports[`conditional expression in template expression 1`] = `
 Array [
   "{
-  \\"version\\": \\"2018-05-29\\",
-  \\"payload\\": null
+\\"version\\": \\"2018-05-29\\",
+\\"payload\\": null
 }",
   "#set($v2 = $context.arguments.a == 'hello')
 #if($v2)
@@ -545,8 +545,8 @@ Array [
 exports[`empty function returning an argument 1`] = `
 Array [
   "{
-  \\"version\\": \\"2018-05-29\\",
-  \\"payload\\": null
+\\"version\\": \\"2018-05-29\\",
+\\"payload\\": null
 }",
   "#return($context.arguments.a)",
 ]
@@ -555,8 +555,8 @@ Array [
 exports[`for-in loop and element access 1`] = `
 Array [
   "{
-  \\"version\\": \\"2018-05-29\\",
-  \\"payload\\": null
+\\"version\\": \\"2018-05-29\\",
+\\"payload\\": null
 }",
   "#set($context.stash.newList = [])
 #foreach($key in $context.arguments.record.keySet())
@@ -569,8 +569,8 @@ $util.qr($context.stash.newList.addAll([$context.arguments.record[$key]]))
 exports[`for-of loop 1`] = `
 Array [
   "{
-  \\"version\\": \\"2018-05-29\\",
-  \\"payload\\": null
+\\"version\\": \\"2018-05-29\\",
+\\"payload\\": null
 }",
   "#set($context.stash.newList = [])
 #foreach($item in $context.arguments.list)
@@ -583,8 +583,8 @@ $util.qr($context.stash.newList.addAll([$item]))
 exports[`forEach over list 1`] = `
 Array [
   "{
-  \\"version\\": \\"2018-05-29\\",
-  \\"payload\\": null
+\\"version\\": \\"2018-05-29\\",
+\\"payload\\": null
 }",
   "#foreach($item in $context.arguments.list)
 $util.qr($util.error($item))
@@ -596,8 +596,8 @@ $util.qr($util.error($item))
 exports[`if statement 1`] = `
 Array [
   "{
-  \\"version\\": \\"2018-05-29\\",
-  \\"payload\\": null
+\\"version\\": \\"2018-05-29\\",
+\\"payload\\": null
 }",
   "#set($v1 = $context.arguments.list.length > 0)
 #if($v1)
@@ -615,8 +615,8 @@ Array [
 exports[`local variable inside for-of loop is declared as a local variable 1`] = `
 Array [
   "{
-  \\"version\\": \\"2018-05-29\\",
-  \\"payload\\": null
+\\"version\\": \\"2018-05-29\\",
+\\"payload\\": null
 }",
   "#set($context.stash.newList = [])
 #foreach($item in $context.arguments.list)
@@ -630,8 +630,8 @@ $util.qr($context.stash.newList.addAll([$i]))
 exports[`map and reduce and map and reduce over list with initial value 1`] = `
 Array [
   "{
-  \\"version\\": \\"2018-05-29\\",
-  \\"payload\\": null
+\\"version\\": \\"2018-05-29\\",
+\\"payload\\": null
 }",
   "#set($v2 = [])
 #foreach($item in $context.arguments.list)
@@ -660,8 +660,8 @@ $util.qr($v6.add($item))
 exports[`map and reduce over list with initial value 1`] = `
 Array [
   "{
-  \\"version\\": \\"2018-05-29\\",
-  \\"payload\\": null
+\\"version\\": \\"2018-05-29\\",
+\\"payload\\": null
 }",
   "#set($v1 = [])
 #foreach($item in $context.arguments.list)
@@ -680,8 +680,8 @@ $util.qr($v3.add($item))
 exports[`map and reduce with array over list with initial value 1`] = `
 Array [
   "{
-  \\"version\\": \\"2018-05-29\\",
-  \\"payload\\": null
+\\"version\\": \\"2018-05-29\\",
+\\"payload\\": null
 }",
   "#set($v2 = [])
 #foreach($item in $context.arguments.list)
@@ -706,8 +706,8 @@ $util.qr($v5.add($item))
 exports[`map over list 1`] = `
 Array [
   "{
-  \\"version\\": \\"2018-05-29\\",
-  \\"payload\\": null
+\\"version\\": \\"2018-05-29\\",
+\\"payload\\": null
 }",
   "#set($v1 = [])
 #foreach($item in $context.arguments.list)
@@ -721,8 +721,8 @@ $util.qr($v1.add($v2))
 exports[`map over list with in-line return 1`] = `
 Array [
   "{
-  \\"version\\": \\"2018-05-29\\",
-  \\"payload\\": null
+\\"version\\": \\"2018-05-29\\",
+\\"payload\\": null
 }",
   "#set($v1 = [])
 #foreach($item in $context.arguments.list)
@@ -736,8 +736,8 @@ $util.qr($v1.add($v2))
 exports[`null and undefined 1`] = `
 Array [
   "{
-  \\"version\\": \\"2018-05-29\\",
-  \\"payload\\": null
+\\"version\\": \\"2018-05-29\\",
+\\"payload\\": null
 }",
   "#set($v1 = {})
 $util.qr($v1.put('name', $null))
@@ -749,8 +749,8 @@ $util.qr($v1.put('value', $null))
 exports[`property assignment of conditional expression 1`] = `
 Array [
   "{
-  \\"version\\": \\"2018-05-29\\",
-  \\"payload\\": null
+\\"version\\": \\"2018-05-29\\",
+\\"payload\\": null
 }",
   "#set($v1 = {})
 #set($v3 = $context.arguments.list.length > 0)
@@ -767,8 +767,8 @@ $util.qr($v1.put('prop', $v2))
 exports[`push element to array is renamed to add 1`] = `
 Array [
   "{
-  \\"version\\": \\"2018-05-29\\",
-  \\"payload\\": null
+\\"version\\": \\"2018-05-29\\",
+\\"payload\\": null
 }",
   "$util.qr($context.arguments.list.addAll(['hello']))
 #return($context.arguments.list)",
@@ -778,8 +778,8 @@ Array [
 exports[`reduce over list with initial value 1`] = `
 Array [
   "{
-  \\"version\\": \\"2018-05-29\\",
-  \\"payload\\": null
+\\"version\\": \\"2018-05-29\\",
+\\"payload\\": null
 }",
   "#set($v1 = [])
 #foreach($item in $context.arguments.list)
@@ -797,8 +797,8 @@ $util.qr($v3.add($item))
 exports[`reduce over list without initial value 1`] = `
 Array [
   "{
-  \\"version\\": \\"2018-05-29\\",
-  \\"payload\\": null
+\\"version\\": \\"2018-05-29\\",
+\\"payload\\": null
 }",
   "#if($context.arguments.list.isEmpty())
 $util.error('Reduce of empty array with no initial value')
@@ -819,8 +819,8 @@ $util.error('Reduce of empty array with no initial value')
 exports[`return conditional expression 1`] = `
 Array [
   "{
-  \\"version\\": \\"2018-05-29\\",
-  \\"payload\\": null
+\\"version\\": \\"2018-05-29\\",
+\\"payload\\": null
 }",
   "#set($v2 = $context.arguments.list.length > 0)
 #if($v2)
@@ -835,8 +835,8 @@ Array [
 exports[`return in-line list literal 1`] = `
 Array [
   "{
-  \\"version\\": \\"2018-05-29\\",
-  \\"payload\\": null
+\\"version\\": \\"2018-05-29\\",
+\\"payload\\": null
 }",
   "#return([$context.arguments.a, $context.arguments.b])",
 ]
@@ -845,8 +845,8 @@ Array [
 exports[`return in-line spread object 1`] = `
 Array [
   "{
-  \\"version\\": \\"2018-05-29\\",
-  \\"payload\\": null
+\\"version\\": \\"2018-05-29\\",
+\\"payload\\": null
 }",
   "#set($v1 = {})
 $util.qr($v1.put('id', $util.autoId()))
@@ -858,8 +858,8 @@ $util.qr($v1.putAll($context.arguments.obj))
 exports[`return list element 1`] = `
 Array [
   "{
-  \\"version\\": \\"2018-05-29\\",
-  \\"payload\\": null
+\\"version\\": \\"2018-05-29\\",
+\\"payload\\": null
 }",
   "#set($context.stash.list = [$context.arguments.a, $context.arguments.b])
 #return($context.stash.list[0])",
@@ -869,8 +869,8 @@ Array [
 exports[`return list literal variable 1`] = `
 Array [
   "{
-  \\"version\\": \\"2018-05-29\\",
-  \\"payload\\": null
+\\"version\\": \\"2018-05-29\\",
+\\"payload\\": null
 }",
   "#set($context.stash.list = [$context.arguments.a, $context.arguments.b])
 #return($context.stash.list)",
@@ -880,8 +880,8 @@ Array [
 exports[`return literal object with values 1`] = `
 Array [
   "{
-  \\"version\\": \\"2018-05-29\\",
-  \\"payload\\": null
+\\"version\\": \\"2018-05-29\\",
+\\"payload\\": null
 }",
   "#set($context.stash.arg = $context.arguments.arg)
 #set($context.stash.obj = $context.arguments.obj)
@@ -903,8 +903,8 @@ $util.qr($v1.putAll($context.stash.obj))
 exports[`template expression 1`] = `
 Array [
   "{
-  \\"version\\": \\"2018-05-29\\",
-  \\"payload\\": null
+\\"version\\": \\"2018-05-29\\",
+\\"payload\\": null
 }",
   "#set($context.stash.local = $context.arguments.a)
 #return(\\"head \${context.arguments.a} \${context.stash.local}\${context.arguments.a}\\")",

--- a/test/appsync.test.ts
+++ b/test/appsync.test.ts
@@ -106,14 +106,18 @@ describe("step function integration", () => {
   test("machine with trace header", () => {
     const machine = new StepFunction(stack, "machine", () => {});
 
-    new AppsyncResolver<{ id: string }, void>(stack, "resolver", {
-      api,
-      fieldName: "field",
-      typeName: "type",
-      resolve: (context) => {
-        machine({ traceHeader: context.arguments.id });
+    new AppsyncResolver<{ id: string }, void>(
+      stack,
+      "resolver",
+      {
+        api,
+        fieldName: "field",
+        typeName: "type",
       },
-    });
+      (context) => {
+        machine({ traceHeader: context.arguments.id });
+      }
+    );
   });
 
   test("machine describe exec", () => {
@@ -145,14 +149,18 @@ describe("step function describe execution", () => {
 
   test("machine with trace header", () => {
     const machine = new StepFunction(stack, "machine", () => {});
-    new AppsyncResolver<{ id: string }, void>(stack, "resolver", {
-      api,
-      fieldName: "field",
-      typeName: "type",
-      resolve: (context) => {
-        machine({ traceHeader: context.arguments.id });
+    new AppsyncResolver<{ id: string }, void>(
+      stack,
+      "resolver",
+      {
+        api,
+        fieldName: "field",
+        typeName: "type",
       },
-    });
+      (context) => {
+        machine({ traceHeader: context.arguments.id });
+      }
+    );
   });
 });
 

--- a/test/appsync.test.ts
+++ b/test/appsync.test.ts
@@ -1,10 +1,15 @@
+import { GraphqlApi } from "@aws-cdk/aws-appsync-alpha";
 import { Stack } from "aws-cdk-lib";
 import { AppsyncContext, AppsyncResolver, reflect, StepFunction } from "../src";
 import { appsyncTestCase, testAppsyncVelocity } from "./util";
 
 let stack: Stack;
+let api: GraphqlApi;
 beforeEach(() => {
   stack = new Stack();
+  api = new GraphqlApi(stack, "api", {
+    name: "api",
+  });
 });
 
 describe("step function integration", () => {
@@ -101,8 +106,13 @@ describe("step function integration", () => {
   test("machine with trace header", () => {
     const machine = new StepFunction(stack, "machine", () => {});
 
-    new AppsyncResolver<{ id: string }, void>((context) => {
-      machine({ traceHeader: context.arguments.id });
+    new AppsyncResolver<{ id: string }, void>(stack, "resolver", {
+      api,
+      fieldName: "field",
+      typeName: "type",
+      resolve: (context) => {
+        machine({ traceHeader: context.arguments.id });
+      },
     });
   });
 
@@ -135,8 +145,13 @@ describe("step function describe execution", () => {
 
   test("machine with trace header", () => {
     const machine = new StepFunction(stack, "machine", () => {});
-    new AppsyncResolver<{ id: string }, void>((context) => {
-      machine({ traceHeader: context.arguments.id });
+    new AppsyncResolver<{ id: string }, void>(stack, "resolver", {
+      api,
+      fieldName: "field",
+      typeName: "type",
+      resolve: (context) => {
+        machine({ traceHeader: context.arguments.id });
+      },
     });
   });
 });

--- a/test/appsync.test.ts
+++ b/test/appsync.test.ts
@@ -134,6 +134,22 @@ describe("step function integration", () => {
   });
 });
 
+test("if first argument is a GraphQLApi, then api can be omitted from the props", () => {
+  const machine = new StepFunction(stack, "machine", () => {});
+
+  new AppsyncResolver<{ id: string }, void>(
+    api,
+    "resolver",
+    {
+      fieldName: "field",
+      typeName: "type",
+    },
+    (context) => {
+      machine({ traceHeader: context.arguments.id });
+    }
+  );
+});
+
 describe("step function describe execution", () => {
   test("machine describe exec string", () => {
     const machine = new StepFunction(stack, "machine", () => {});

--- a/test/test-files/appsync.ts
+++ b/test/test-files/appsync.ts
@@ -1,0 +1,66 @@
+import * as appsync from "@aws-cdk/aws-appsync-alpha";
+import { App, Stack } from "aws-cdk-lib";
+import { AppsyncResolver } from "../../src";
+
+const app = new App({
+  autoSynth: false,
+});
+const stack = new Stack(app, "stack");
+
+const api = new appsync.GraphqlApi(stack, "API", {
+  name: "api",
+});
+
+new AppsyncResolver(
+  stack,
+  "getPost",
+  {
+    api,
+    typeName: "Query",
+    fieldName: "getPost",
+  },
+  // valid - inline arrow function
+  () => null
+);
+
+new AppsyncResolver(
+  stack,
+  "getPost",
+  {
+    api,
+    typeName: "Query",
+    fieldName: "getPost",
+  },
+  // valid - inline function expression
+  function () {
+    return null;
+  }
+);
+
+const f = () => null;
+new AppsyncResolver(
+  stack,
+  "getPost",
+  {
+    api,
+    typeName: "Query",
+    fieldName: "getPost",
+  },
+  // invalid - must be an inline function
+  f
+);
+
+new AppsyncResolver(
+  stack,
+  "getPost",
+  {
+    api,
+    typeName: "Query",
+    fieldName: "getPost",
+  },
+  // invalid - must be an inline function
+  (
+    () => () =>
+      null
+  )()
+);

--- a/test/util.ts
+++ b/test/util.ts
@@ -58,12 +58,16 @@ export function getAppSyncTemplates(decl: FunctionDecl | Err): string[] {
     xrayEnabled: true,
   });
 
-  const appsyncFunction = new AppsyncResolver(stack, "Resolver", {
-    api,
-    typeName: "Query",
-    fieldName: "getPerson",
-    resolve: decl as any,
-  });
+  const appsyncFunction = new AppsyncResolver(
+    stack,
+    "Resolver",
+    {
+      api,
+      typeName: "Query",
+      fieldName: "getPerson",
+    },
+    decl as any
+  );
   return appsyncFunction.resolvers().templates;
 }
 

--- a/test/util.ts
+++ b/test/util.ts
@@ -58,11 +58,13 @@ export function getAppSyncTemplates(decl: FunctionDecl | Err): string[] {
     xrayEnabled: true,
   });
 
-  const appsyncFunction = new AppsyncResolver(decl as any);
-  return appsyncFunction.addResolver(api, {
+  const appsyncFunction = new AppsyncResolver(stack, "Resolver", {
+    api,
     typeName: "Query",
     fieldName: "getPerson",
-  }).templates;
+    resolve: decl as any,
+  });
+  return appsyncFunction.resolvers().templates;
 }
 
 export type DeepPartial<T extends object> = {
@@ -77,16 +79,6 @@ export interface AppSyncVTLRenderContext<
   source?: Source;
 }
 
-/**
- *
- * @param decl
- * @param executeTemplates an array of templates to execute using the {@link AmplifyAppSyncSimulator}
- *                         `context` can be used to pass inputs
- *                         a snapshot will be taken of the results
- *                         to test specific contents like CDK Tokens (arns, attr, etc) use
- *                         `expected.match` with a partial output.
- *                         To assert that the template returns, pass `expected.returned: true`.
- */
 export function appsyncTestCase<
   Arguments extends ResolverArguments,
   Result,

--- a/test/validate.test.ts
+++ b/test/validate.test.ts
@@ -25,6 +25,8 @@ test("step-function.ts", () => runTest("step-function.ts"));
 
 test("function.ts", () => runTest("function.ts"));
 
+test("appsync.ts", () => runTest("appsync.ts"));
+
 function runTest(fileName: string) {
   const diagnostics = validate(
     ts,

--- a/website/docs/concepts/appsync/code-generation.md
+++ b/website/docs/concepts/appsync/code-generation.md
@@ -77,22 +77,30 @@ export class PeopleDatabase extends Construct {
     this.getPerson = new AppsyncResolver<
       QueryResolvers["addPerson"]["args"],
       QueryResolvers["addPerson"]["result"]
-    >(($context) => {
-      const person = this.personTable.putItem({
-        key: {
-          id: {
-            S: $util.autoId(),
+    >(
+      scope,
+      id,
+      {
+        typeName: "Query",
+        fieldName: "addPerson",
+      },
+      ($context) => {
+        const person = this.personTable.putItem({
+          key: {
+            id: {
+              S: $util.autoId(),
+            },
           },
-        },
-        attributeValues: {
-          name: {
-            S: $context.arguments.input.name,
+          attributeValues: {
+            name: {
+              S: $context.arguments.input.name,
+            },
           },
-        },
-      });
+        });
 
-      return person;
-    });
+        return person;
+      }
+    );
   }
 }
 ```

--- a/website/docs/concepts/appsync/supported-integrations.md
+++ b/website/docs/concepts/appsync/supported-integrations.md
@@ -11,7 +11,7 @@ A `Function` can be called directly from an [`AppsyncResolver`](./usage.md).
 ```ts
 const myFunc = new Function(scope, "id", (input: {name: string}) => { .. });
 
-new AppsyncResolver(() => {
+new AppsyncResolver(scope, id, props, () => {
   return myFunc({ name: "my name" });
 });
 ```
@@ -31,7 +31,7 @@ A `StepFunction` can be called directly from an [`AppsyncResolver`](./usage.md#i
 ```ts
 const myStepFunc = new StepFunction(scope, "id", (input: {name: string}) => { .. });
 
-new AppsyncResolver(() => {
+new AppsyncResolver(scope, id, props, () => {
   return myStepFunc({ name: "my name" });
 });
 ```
@@ -100,7 +100,7 @@ const myExpressFunc = new ExpressStepFunction(
   }
 );
 
-new AppsyncResolver(() => {
+new AppsyncResolver(scope, id, props, () => {
   const response = myExpressFunc({ name: "my name" });
 });
 ```

--- a/website/docs/concepts/appsync/usage.md
+++ b/website/docs/concepts/appsync/usage.md
@@ -98,11 +98,20 @@ After configuring your schema, the next step is to implement Resolvers for each 
 Functionless's `AppsyncResolver` Construct makes this simple by generating all of the VTL templates, IAM Policies and Resolver configurations from an ordinary TypeScript function.
 
 ```ts
-new AppsyncResolver(($context) => {
-  return table.get({
-    id: $context.arguments.id,
-  });
-});
+new AppsyncResolver(
+  scope,
+  id,
+  {
+    api,
+    typeName: "Query",
+    fieldName: "getItem",
+  },
+  ($context) => {
+    return table.get({
+      id: $context.arguments.id,
+    });
+  }
+);
 ```
 
 ### Type Arguments
@@ -125,6 +134,9 @@ We can define an `AppsyncResolver` for the `getPerson` field like so:
 
 ```ts
 new AppsyncResolver<{ id: string }, Person | undefined, undefined>(
+  scope,
+  id,
+  props,
   ($context) => {
     // ..
   }
@@ -146,16 +158,22 @@ new AppsyncResolver<{ id: string }, Person | undefined>(($context) => {
 `TSource` is only defined when the field being resolved is nested. For example, resolving a `Person`'s `children` field has a `TSource` of `Person`.
 
 ```ts
-new AppsyncResolver<undefined, Person[], Person>(($context) => {
-  return db.query({
-    key: {
-      personId: {
-        // access the parent's personId
-        S: $context.source.personId,
+new AppsyncResolver<undefined, Person[], Person>(
+  scope,
+  id,
+  props,
+  ($context) => {
+    const result = db.query({
+      key: {
+        personId: {
+          // access the parent's personId
+          S: $context.source.personId,
+        },
       },
-    },
-  }).Items;
-});
+    });
+    return result.Items;
+  }
+);
 ```
 
 The following GraphQL query will now trigger this Resolver to fetch the `children` property.
@@ -169,43 +187,34 @@ query {
 }
 ```
 
-## Add Resolvers to a GraphQLApi
-
-When you create a `new AppsyncResolver`, it does not immediately generate an Appsync Resolver. `AppsyncResolver` is more like a template for creating resolvers and can be re-used across more than one API.
-
-**Note**: this is subject to change, see [#137](https://github.com/functionless/functionless/issues/137) to track progress.
-
-Options:
-
-1. Add a resolver to a GraphQL Api with a pre-defined schema
-2. Add a field resolver to a GraphQL Api using CDK's CodeFirst schema
-
-### Add a resolver to a GraphQL Api with a pre-defined schema
-
-To add to an API, use the `addResolver` utility on `AppsyncResolver`.
-
-```ts
-const getPerson = new AppsyncResolver(..);
-
-// use it add resolvers to a GraphqlApi.
-getPerson.addResolver(api, {
-  typeName: "Query",
-  fieldName: "getPerson",
-});
-```
-
 ### Add a field resolver to a GraphQL Api using CDK's CodeFirst schema
 
 To add to a CodeFirst GraphQL schema, use `getField` utility on the `AppsyncResolver`.
 
 ```ts
-const getPerson = new AppsyncResolver(..);
+import * as appsync from "@aws-cdk/aws-appsync-alpha";
+
+const getPerson = new AppsyncField({
+  api,
+  returnType: appsync.Field.string(),
+  args: {
+    argName: appsync.Field.string()
+  }
+}, ($context) => {
+  return table.getItem({
+    key: {
+      id: {
+        S: $context.arguments.id
+      }
+    }
+  })
+});
 
 // define the type in code
 const personType = api.addType(appsync.ObjectType(...));
 
 // use it add resolvers to a GraphqlApi.
-api.addQuery("getPerson", getPerson.getField(api, personType));
+api.addQuery("getPerson", getPerson);
 ```
 
 ## $util
@@ -215,7 +224,7 @@ The `$util` object contains Appsync's intrinsic functions.
 For example, it provides intrinsic functions for generating UUIDs, working with timestamps and transforming data from AWS DynamoDB.
 
 ```ts
-new AppsyncResolver(() => {
+new AppsyncResolver(scope, id, props, () => {
   // generate a unique UUID at runtime
   const uuid = $util.autoUuid();
   // get the current timestamp in ISO 8601 format


### PR DESCRIPTION
Fixes #137 
Fixes #65

- [x] AppsyncResolver is now a Construct that takes as props the api, typeName, fieldName and resolve function (#137)
```ts
export const getDeletionStatus = new AppsyncResolver<
  { executionArn: string },
  string | undefined
>(stack, "getDeletionStatus", {
  api,
  typeName: "Query",
  fieldName: "getDeletionStatus",
  resolve: ($context) => {
    const executionStatus = deleteWorkflow.describeExecution(
      $context.arguments.executionArn
    );

    return executionStatus.status;
  },
});
```
- [x] Lazily evaluate VTL interpreters so that fields can be defined in any order (#65)
- [x] Move `addField` to its own class and also apply lazy evaluation

BREAKING CHANGE: AppsyncResolver is now a Construct and creates the resolvers within its constructor