### PR TITLE
fix: appsync and step function visitor hoist refactor

### DIFF
--- a/src/appsync.ts
+++ b/src/appsync.ts
@@ -28,12 +28,26 @@ import {
   isPropAccessExpr,
   isElementAccessExpr,
   isIfStmt,
+  isBlockStmt,
+  isStmt,
+  isForInStmt,
+  isForOfStmt,
 } from "./guards";
-import { findDeepIntegration, IntegrationImpl } from "./integration";
+import {
+  findDeepIntegration,
+  IntegrationImpl,
+  isIntegrationCall,
+} from "./integration";
 import { Literal } from "./literal";
 import { FunctionlessNode } from "./node";
-import { AnyFunction, isInTopLevelScope, singletonConstruct } from "./util";
-import { visitEachChild } from "./visit";
+import { BlockStmt } from "./statement";
+import {
+  AnyFunction,
+  DeterministicNameGenerator,
+  isInTopLevelScope,
+  singletonConstruct,
+} from "./util";
+import { visitBlock, visitEachChild } from "./visit";
 import { VTL } from "./vtl";
 
 /**
@@ -180,6 +194,8 @@ export class AppsyncResolver<
     ResolverFunction<Arguments, Result, Source>
   >;
 
+  private generatedNames = new DeterministicNameGenerator();
+
   constructor(fn: ResolverFunction<Arguments, Result, Source>) {
     this.decl = validateFunctionDecl(fn, "AppsyncResolver");
   }
@@ -295,20 +311,267 @@ export class AppsyncResolver<
     });
   }
 
-  private getResolvableFields(api: appsync.GraphqlApi) {
-    const resolverCount = countResolvers(this.decl);
+  private synthesizeFunctions(
+    api: appsync.GraphqlApi,
+    decl: FunctionDecl<ResolverFunction<Arguments, Result, Source>>
+  ) {
+    const self = this;
+    let resolverCount = 0;
+    /**
+     * Update some nodes.
+     */
+    const updatedDecl = visitEachChild(
+      decl,
+      function normalizeAST(
+        node,
+        hoist?: (expr: Expr) => Expr
+      ): FunctionlessNode | FunctionlessNode[] {
+        if (isIntegrationCall(node)) {
+          resolverCount++;
+        }
+        // just counting, don'r do anything
+        if (isBlockStmt(node)) {
+          return new BlockStmt([
+            // for each block statement
+            ...visitBlock(
+              node,
+              function normalizeBlock(stmt, hoist) {
+                return visitEachChild(stmt, (expr) =>
+                  normalizeAST(expr, hoist)
+                );
+              },
+              self.generatedNames
+            ).statements,
+          ]);
+        } else if (hoist && self.doHoist(node)) {
+          const updatedChild = visitEachChild(node, (expr) =>
+            normalizeAST(expr, hoist)
+          );
+          // when we find an integration call,
+          // if it is nested, hoist it up (create variable, add above, replace expr with variable)
+          return hoist(updatedChild);
+        } else if (isBinaryExpr(node)) {
+          /**
+           * rewrite `in` to a conditional statement to support both arrays and maps
+           * var v = left in right;
+           *
+           * var v = right.class.name.startsWith("[L") || right.class.name.contains("ArrayList") ?
+           *    right.length >= left :
+           *    right.containsKey(left);
+           */
+          if (node.op === "in") {
+            const updatedNode = visitEachChild(node, (expr) =>
+              normalizeAST(expr, hoist)
+            );
 
+            const rightClassName = new PropAccessExpr(
+              new PropAccessExpr(updatedNode.right, "class"),
+              "name"
+            );
+
+            return new ConditionExpr(
+              new BinaryExpr(
+                new CallExpr(new PropAccessExpr(rightClassName, "startsWith"), [
+                  new Argument(new StringLiteralExpr("[L")),
+                ]),
+                "||",
+                new CallExpr(new PropAccessExpr(rightClassName, "contains"), [
+                  new Argument(new StringLiteralExpr("ArrayList")),
+                ])
+              ),
+              new BinaryExpr(
+                new PropAccessExpr(updatedNode.right, "length"),
+                ">=",
+                updatedNode.left
+              ),
+              new CallExpr(
+                new PropAccessExpr(updatedNode.right, "containsKey"),
+                [new Argument(updatedNode.left)]
+              )
+            );
+          }
+        }
+        return visitEachChild(node, (expr) => normalizeAST(expr, hoist));
+      }
+    );
+    const templates: string[] = [];
+    let template =
+      resolverCount === 0
+        ? new AppsyncVTL()
+        : new AppsyncVTL(AppsyncVTL.CircuitBreaker);
+    const functions = updatedDecl.body.statements
+      .map((stmt, i) => {
+        const isLastExpr = i + 1 === updatedDecl.body.statements.length;
+        const service = findDeepIntegration(stmt);
+        if (service) {
+          // we must now render a resolver with request mapping template
+          const dataSource = singletonConstruct(
+            api,
+            service.appSyncVtl.dataSourceId(),
+            (scope, id) => service.appSyncVtl.dataSource(scope, id)
+          );
+
+          const resultValName = "$context.result";
+
+          // The integration can optionally transform the result into a new variable.
+          const resultTemplate = service.appSyncVtl.result?.(resultValName);
+          const pre = resultTemplate?.template;
+          const returnValName = resultTemplate?.returnVariable ?? resultValName;
+
+          if (isExprStmt(stmt)) {
+            const call = findServiceCallExpr(stmt.expr);
+            template.call(call);
+            return createStage(service, "{}");
+          } else if (isReturnStmt(stmt)) {
+            return createStage(
+              service,
+              `${
+                pre ? `${pre}\n` : ""
+              }#set( $context.stash.return__flag = true )
+#set( $context.stash.return__val = ${getResult(stmt.expr)} )
+{}`
+            );
+          } else if (isVariableStmt(stmt) && isCallExpr(stmt.expr)) {
+            return createStage(
+              service,
+              `${pre ? `${pre}\n` : ""}#set( $context.stash.${
+                stmt.name
+              } = ${getResult(stmt.expr)} )\n{}`
+            );
+          } else {
+            throw new Error(
+              "only a 'VariableDecl', 'Call' or 'Return' expression may call a service"
+            );
+          }
+
+          /**
+           * Recursively resolve the {@link expr} to the {@link CallExpr} that is calling the service.
+           *
+           * @param expr an Expression that contains (somewhere nested within) a {@link CallExpr} to an external service.
+           * @returns the {@link CallExpr} that
+           */
+          function findServiceCallExpr(expr: Expr): CallExpr {
+            if (
+              isCallExpr(expr) &&
+              (isReferenceExpr(expr.expr) ||
+                (isPropAccessExpr(expr.expr) &&
+                  isReferenceExpr(expr.expr.expr)))
+            ) {
+              // this catches specific cases:
+              // lambdaFunction()
+              // table.get()
+              // table.<method-name>()
+
+              // all other Calls or PropAccessExpr are considered "after" the service call, e.g.
+              // lambdaFunction().prop
+              // table.query().Items.size() //.size() is still a Call but not a call to a service.
+              return expr;
+            } else if (isPropAccessExpr(expr)) {
+              return findServiceCallExpr(expr.expr);
+            } else if (isCallExpr(expr)) {
+              return findServiceCallExpr(expr.expr);
+            } else {
+              throw new Error("");
+            }
+          }
+
+          /**
+           * Resolve a VTL expression that applies in-line expressions such as PropAccessExpr to
+           * the result from `$context.result` in a Response Mapping template.
+           *
+           * Example:
+           * ```ts
+           * const items = table.query().items
+           * ```
+           *
+           * The Response Mapping Template will include:
+           * ```
+           * #set($context.stash.items = $context.result.items)
+           * ```
+           *
+           * @param expr the {@link Expr} which is triggering a call to an external service, such as a Table or Function.
+           * @returns a VTL expression to be included in the Response Mapping Template to extract the contents from `$context.result`.
+           */
+          function getResult(expr: Expr): string {
+            if (isCallExpr(expr)) {
+              template.call(expr);
+              return returnValName;
+            } else if (isPropAccessExpr(expr)) {
+              return `${getResult(expr.expr)}.${expr.name}`;
+            } else if (isElementAccessExpr(expr)) {
+              return `${getResult(expr.expr)}[${getResult(expr.element)}]`;
+            } else {
+              throw new Error(
+                `invalid Expression in-lined with Service Call: ${expr.kind}`
+              );
+            }
+          }
+
+          function createStage(
+            integration: IntegrationImpl,
+            responseMappingTemplate: string
+          ) {
+            const requestMappingTemplateString = template.toVTL();
+            templates.push(requestMappingTemplateString);
+            templates.push(responseMappingTemplate);
+            template = new AppsyncVTL(AppsyncVTL.CircuitBreaker);
+            const name = getUniqueName(api, appsyncSafeName(integration.kind));
+            return dataSource.createFunction({
+              name,
+              requestMappingTemplate: appsync.MappingTemplate.fromString(
+                requestMappingTemplateString
+              ),
+              responseMappingTemplate: appsync.MappingTemplate.fromString(
+                responseMappingTemplate
+              ),
+            });
+          }
+        } else if (isLastExpr) {
+          if (isReturnStmt(stmt)) {
+            template.return(stmt.expr);
+          } else if (isIfStmt(stmt)) {
+            template.eval(stmt);
+          } else {
+            template.return("$null");
+          }
+        } else {
+          // this expression should be appended to the current mapping template
+          template.eval(stmt);
+        }
+
+        return undefined;
+      })
+      .filter(
+        (func): func is Exclude<typeof func, undefined> => func !== undefined
+      );
+
+    return [functions, template.toVTL(), templates] as const;
+  }
+
+  /**
+   * Determines of an expression should be hoisted
+   * Hoisted - Add new variable to the current block above the
+   */
+  private doHoist(node: FunctionlessNode): node is CallExpr {
+    const parent = node.parent;
+    return (
+      isIntegrationCall(node) &&
+      // const v = task()
+      (!isStmt(parent) ||
+        // for(const i in task())
+        isForInStmt(parent) ||
+        isForOfStmt(parent)) &&
+      // v = task()
+      !(isBinaryExpr(parent) && parent.op === "=")
+    );
+  }
+
+  private getResolvableFields(api: appsync.GraphqlApi) {
     const [pipelineConfig, responseMappingTemplate, innerTemplates] =
-      synthesizeFunctions(api, this.decl);
+      this.synthesizeFunctions(api, this.decl);
 
     // mock integration
-    if (resolverCount === 0) {
-      if (pipelineConfig.length !== 0) {
-        throw new Error(
-          `expected 0 functions in pipelineConfig, but found ${pipelineConfig.length}`
-        );
-      }
-
+    if (pipelineConfig.length === 0) {
       const requestMappingTemplate = `{
   "version": "2018-05-29",
   "payload": null
@@ -348,222 +611,6 @@ export class AppsyncResolver<
           responseMappingTemplate
         ),
       };
-    }
-
-    function synthesizeFunctions(
-      api: appsync.GraphqlApi,
-      decl: FunctionDecl<ResolverFunction<Arguments, Result, Source>>
-    ) {
-      /**
-       * Update some nodes.
-       */
-      const updatedDecl = visitEachChild(
-        decl,
-        function visit(node): FunctionlessNode {
-          if (isBinaryExpr(node)) {
-            /**
-             * rewrite `in` to a conditional statement to support both arrays and maps
-             * var v = left in right;
-             *
-             * var v = right.class.name.startsWith("[L") || right.class.name.contains("ArrayList") ?
-             *    right.length >= left :
-             *    right.containsKey(left);
-             */
-            if (node.op === "in") {
-              const left = visitEachChild(node.left, visit);
-              const right = visitEachChild(node.right, visit);
-
-              const rightClassName = new PropAccessExpr(
-                new PropAccessExpr(right, "class"),
-                "name"
-              );
-
-              return new ConditionExpr(
-                new BinaryExpr(
-                  new CallExpr(
-                    new PropAccessExpr(rightClassName, "startsWith"),
-                    [new Argument(new StringLiteralExpr("[L"))]
-                  ),
-                  "||",
-                  new CallExpr(new PropAccessExpr(rightClassName, "contains"), [
-                    new Argument(new StringLiteralExpr("ArrayList")),
-                  ])
-                ),
-                new BinaryExpr(new PropAccessExpr(right, "length"), ">=", left),
-                new CallExpr(new PropAccessExpr(right, "containsKey"), [
-                  new Argument(left),
-                ])
-              );
-            }
-          }
-
-          return visitEachChild(node, visit);
-        }
-      );
-      const templates: string[] = [];
-      let template =
-        resolverCount === 0
-          ? new AppsyncVTL()
-          : new AppsyncVTL(AppsyncVTL.CircuitBreaker);
-      const functions = updatedDecl.body.statements
-        .map((stmt, i) => {
-          const isLastExpr = i + 1 === updatedDecl.body.statements.length;
-          const service = findDeepIntegration(stmt);
-          if (service) {
-            // we must now render a resolver with request mapping template
-            const dataSource = singletonConstruct(
-              api,
-              service.appSyncVtl.dataSourceId(),
-              (scope, id) => service.appSyncVtl.dataSource(scope, id)
-            );
-
-            const resultValName = "$context.result";
-
-            // The integration can optionally transform the result into a new variable.
-            const resultTemplate = service.appSyncVtl.result?.(resultValName);
-            const pre = resultTemplate?.template;
-            const returnValName =
-              resultTemplate?.returnVariable ?? resultValName;
-
-            if (isExprStmt(stmt)) {
-              const call = findServiceCallExpr(stmt.expr);
-              template.call(call);
-              return createStage(service, "{}");
-            } else if (isReturnStmt(stmt)) {
-              return createStage(
-                service,
-                `${
-                  pre ? `${pre}\n` : ""
-                }#set( $context.stash.return__flag = true )
-#set( $context.stash.return__val = ${getResult(stmt.expr)} )
-{}`
-              );
-            } else if (isVariableStmt(stmt) && isCallExpr(stmt.expr)) {
-              return createStage(
-                service,
-                `${pre ? `${pre}\n` : ""}#set( $context.stash.${
-                  stmt.name
-                } = ${getResult(stmt.expr)} )\n{}`
-              );
-            } else {
-              throw new Error(
-                "only a 'VariableDecl', 'Call' or 'Return' expression may call a service"
-              );
-            }
-
-            /**
-             * Recursively resolve the {@link expr} to the {@link CallExpr} that is calling the service.
-             *
-             * @param expr an Expression that contains (somewhere nested within) a {@link CallExpr} to an external service.
-             * @returns the {@link CallExpr} that
-             */
-            function findServiceCallExpr(expr: Expr): CallExpr {
-              if (
-                isCallExpr(expr) &&
-                (isReferenceExpr(expr.expr) ||
-                  (isPropAccessExpr(expr.expr) &&
-                    isReferenceExpr(expr.expr.expr)))
-              ) {
-                // this catches specific cases:
-                // lambdaFunction()
-                // table.get()
-                // table.<method-name>()
-
-                // all other Calls or PropAccessExpr are considered "after" the service call, e.g.
-                // lambdaFunction().prop
-                // table.query().Items.size() //.size() is still a Call but not a call to a service.
-                return expr;
-              } else if (isPropAccessExpr(expr)) {
-                return findServiceCallExpr(expr.expr);
-              } else if (isCallExpr(expr)) {
-                return findServiceCallExpr(expr.expr);
-              } else {
-                throw new Error("");
-              }
-            }
-
-            /**
-             * Resolve a VTL expression that applies in-line expressions such as PropAccessExpr to
-             * the result from `$context.result` in a Response Mapping template.
-             *
-             * Example:
-             * ```ts
-             * const items = table.query().items
-             * ```
-             *
-             * The Response Mapping Template will include:
-             * ```
-             * #set($context.stash.items = $context.result.items)
-             * ```
-             *
-             * @param expr the {@link Expr} which is triggering a call to an external service, such as a Table or Function.
-             * @returns a VTL expression to be included in the Response Mapping Template to extract the contents from `$context.result`.
-             */
-            function getResult(expr: Expr): string {
-              if (isCallExpr(expr)) {
-                template.call(expr);
-                return returnValName;
-              } else if (isPropAccessExpr(expr)) {
-                return `${getResult(expr.expr)}.${expr.name}`;
-              } else if (isElementAccessExpr(expr)) {
-                return `${getResult(expr.expr)}[${getResult(expr.element)}]`;
-              } else {
-                throw new Error(
-                  `invalid Expression in-lined with Service Call: ${expr.kind}`
-                );
-              }
-            }
-
-            function createStage(
-              integration: IntegrationImpl,
-              responseMappingTemplate: string
-            ) {
-              const requestMappingTemplateString = template.toVTL();
-              templates.push(requestMappingTemplateString);
-              templates.push(responseMappingTemplate);
-              template = new AppsyncVTL(AppsyncVTL.CircuitBreaker);
-              const name = getUniqueName(
-                api,
-                appsyncSafeName(integration.kind)
-              );
-              return dataSource.createFunction({
-                name,
-                requestMappingTemplate: appsync.MappingTemplate.fromString(
-                  requestMappingTemplateString
-                ),
-                responseMappingTemplate: appsync.MappingTemplate.fromString(
-                  responseMappingTemplate
-                ),
-              });
-            }
-          } else if (isLastExpr) {
-            if (isReturnStmt(stmt)) {
-              template.return(stmt.expr);
-            } else if (isIfStmt(stmt)) {
-              template.eval(stmt);
-            } else {
-              template.return("$null");
-            }
-          } else {
-            // this expression should be appended to the current mapping template
-            template.eval(stmt);
-          }
-
-          return undefined;
-        })
-        .filter(
-          (func): func is Exclude<typeof func, undefined> => func !== undefined
-        );
-
-      return [functions, template.toVTL(), templates] as const;
-    }
-
-    function countResolvers(
-      decl: FunctionDecl<ResolverFunction<Arguments, Result, Source>>
-    ): number {
-      return decl.body.statements.filter(
-        (expr) => findDeepIntegration(expr) !== undefined
-      ).length;
     }
   }
 }

--- a/src/asl.ts
+++ b/src/asl.ts
@@ -2,7 +2,7 @@ import { aws_iam, aws_stepfunctions } from "aws-cdk-lib";
 import { Construct } from "constructs";
 import { assertNever } from "./assert";
 import { FunctionDecl } from "./declaration";
-import { ErrorCodes, SyncError } from "./error-code";
+import { ErrorCodes, SynthError } from "./error-code";
 import {
   Argument,
   CallExpr,
@@ -860,7 +860,7 @@ export class ASL {
             return taskState;
           }
         } else {
-          throw new SyncError(
+          throw new SynthError(
             ErrorCodes.Unexpected_Error,
             "Called references are expected to be an integration."
           );

--- a/src/asl.ts
+++ b/src/asl.ts
@@ -2,6 +2,7 @@ import { aws_iam, aws_stepfunctions } from "aws-cdk-lib";
 import { Construct } from "constructs";
 import { assertNever } from "./assert";
 import { FunctionDecl } from "./declaration";
+import { ErrorCodes, SyncError } from "./error-code";
 import {
   Argument,
   CallExpr,
@@ -859,7 +860,10 @@ export class ASL {
             return taskState;
           }
         } else {
-          throw Error("");
+          throw new SyncError(
+            ErrorCodes.Unexpected_Error,
+            "Called references are expected to be an integration."
+          );
         }
       } else if (isMapOrForEach(expr)) {
         const throwTransition = this.throw(expr);

--- a/src/asl.ts
+++ b/src/asl.ts
@@ -1,6 +1,5 @@
 import { aws_iam, aws_stepfunctions } from "aws-cdk-lib";
 import { Construct } from "constructs";
-
 import { assertNever } from "./assert";
 import { FunctionDecl } from "./declaration";
 import {
@@ -8,7 +7,6 @@ import {
   CallExpr,
   ElementAccessExpr,
   Expr,
-  Identifier,
   isVariableReference,
   NewExpr,
   NullLiteralExpr,
@@ -25,9 +23,7 @@ import {
   isReturnStmt,
   isCallExpr,
   isBreakStmt,
-  isForOfStmt,
   isForInStmt,
-  isWhileStmt,
   isDoStmt,
   isContinueStmt,
   isIfStmt,
@@ -47,7 +43,6 @@ import {
   isPropAssignExpr,
   isComputedPropertyNameExpr,
   isStringLiteralExpr,
-  isReferenceExpr,
   isTemplateExpr,
   isParameterDecl,
   isBooleanLiteralExpr,
@@ -58,8 +53,16 @@ import {
   isSpreadElementExpr,
   isCatchClause,
   isIdentifier,
+  isForOfStmt,
+  isWhileStmt,
+  isReferenceExpr,
 } from "./guards";
-import { findIntegration } from "./integration";
+import {
+  Integration,
+  IntegrationImpl,
+  isIntegration,
+  isIntegrationCall,
+} from "./integration";
 import { FunctionlessNode } from "./node";
 import {
   BlockStmt,
@@ -70,13 +73,12 @@ import {
   IfStmt,
   ReturnStmt,
   Stmt,
-  VariableStmt,
   WhileStmt,
 } from "./statement";
 import { isStepFunction } from "./step-function";
 import { isTable } from "./table";
-import { anyOf, evalToConstant } from "./util";
-import { visitEachChild } from "./visit";
+import { anyOf, DeterministicNameGenerator, evalToConstant } from "./util";
+import { visitBlock, visitEachChild } from "./visit";
 
 export function isASL(a: any): a is ASL {
   return (a as ASL | undefined)?.kind === ASL.ContextName;
@@ -364,7 +366,7 @@ export class ASL {
    */
   private readonly stateNames = new Map<Stmt, string>();
   private readonly stateNamesCount = new Map<string, number>();
-  private readonly generatedNames = new Map<FunctionlessNode, string>();
+  private readonly generatedNames = new DeterministicNameGenerator();
 
   constructor(
     readonly scope: Construct,
@@ -377,7 +379,7 @@ export class ASL {
       | FunctionlessNode[] {
       if (
         isBlockStmt(node) &&
-        (isFunctionExpr(node.parent) || isFunctionDecl(node.parent))
+        (isFunctionDecl(node.parent) || isFunctionExpr(node.parent))
       ) {
         // re-write the AST to include explicit `ReturnStmt(NullLiteral())` statements
         // this simplifies the interpreter code by always having a node to chain onto, even when
@@ -387,65 +389,36 @@ export class ASL {
           return new BlockStmt([new ReturnStmt(new NullLiteralExpr())]);
         } else if (!node.lastStmt.isTerminal()) {
           return new BlockStmt([
-            ...node.statements.map((stmt) =>
-              visitEachChild(stmt, normalizeAST)
-            ),
+            // for each block statement
+            ...visitBlock(
+              node,
+              function normalizeBlock(stmt, hoist) {
+                // if the statement contains an expression
+                if (
+                  isExprStmt(stmt) ||
+                  isVariableStmt(stmt) ||
+                  isReturnStmt(stmt)
+                ) {
+                  // check to see if we need to hoist anything
+                  return visitEachChild(stmt, function extract(childNode) {
+                    if (isIntegrationCall(childNode)) {
+                      // when we find an integration call, hoist it up (create variable, add above, replace expr with variable)
+                      return hoist(childNode);
+                    } else if (isFunctionDecl(childNode)) {
+                      // dive into nested blocks inside nested function declarations
+                      return visitEachChild(childNode, normalizeAST);
+                    }
+                    return childNode;
+                  });
+                }
+
+                // other statements may contain blocks.
+                return visitEachChild(stmt, normalizeAST);
+              },
+              self.generatedNames
+            ).statements,
             new ReturnStmt(new NullLiteralExpr()),
           ]);
-        }
-      } else if (
-        isExprStmt(node) ||
-        isVariableStmt(node) ||
-        isReturnStmt(node)
-      ) {
-        const expr = node.expr;
-        if (isCallExpr(expr)) {
-          // reduce nested Tasks to individual Statements
-          const nestedTasks = expr.children.flatMap(function findTasks(
-            node: FunctionlessNode
-          ): CallExpr[] {
-            if (isTask(node)) {
-              return [node, ...node.collectChildren(findTasks)];
-            } else if (isFunctionExpr(node)) {
-              // do not recurse into FunctionExpr - they do not need to be hoisted
-              return [];
-            } else {
-              return node.collectChildren(findTasks);
-            }
-          });
-
-          function isTask(node: FunctionlessNode): node is CallExpr {
-            return isCallExpr(node) && findIntegration(node) !== undefined;
-          }
-
-          if (nestedTasks.length > 0) {
-            const nestedTaskSet = new Set<FunctionlessNode>(nestedTasks);
-
-            // walks through the tree and replaces nodes with an Identifier referencing the
-            // result of their pre-computed value - this normalizes the whole AST into
-            // a linear sequence of `variable = constant or computation` operations.
-            const replaced = (function replaceTasks(
-              node: FunctionlessNode
-            ): FunctionlessNode | FunctionlessNode[] {
-              if (nestedTaskSet.has(node)) {
-                return new Identifier(self.getDeterministicGeneratedName(node));
-              } else {
-                return visitEachChild(node, replaceTasks);
-              }
-            })(node);
-
-            return [
-              // hoist all nested calls to individual VariableStmt(CallExpr())
-              ...nestedTasks.map(
-                (task) =>
-                  new VariableStmt(
-                    self.getDeterministicGeneratedName(task),
-                    task.clone()
-                  )
-              ),
-              ...(Array.isArray(replaced) ? replaced : [replaced]),
-            ];
-          }
         }
       }
       return visitEachChild(node, normalizeAST);
@@ -462,21 +435,6 @@ export class ASL {
       StartAt: start,
       States: states,
     };
-  }
-
-  /**
-   * Generate a deterministic and unique variable name for a node.
-   *
-   * The value is cached so that the same node reference always has the same name.
-   *
-   * @param node the node to generate a name for
-   * @returns a unique variable name that can be used in JSON Path
-   */
-  private getDeterministicGeneratedName(node: FunctionlessNode): string {
-    if (!this.generatedNames.has(node)) {
-      this.generatedNames.set(node, `${this.generatedNames.size}_tmp`);
-    }
-    return this.generatedNames.get(node)!;
   }
 
   /**
@@ -792,7 +750,7 @@ export class ASL {
                         Choices: [
                           {
                             // errors thrown from the catch block will be directed to this special variable for the `finally` block
-                            Variable: `$.${this.getDeterministicGeneratedName(
+                            Variable: `$.${this.generatedNames.generateOrGet(
                               stmt.finallyBlock
                             )}`,
                             IsPresent: true,
@@ -868,38 +826,32 @@ export class ASL {
       props.End = true;
     }
     if (isCallExpr(expr)) {
-      const serviceCall = findIntegration(expr);
-      if (serviceCall) {
-        if (
-          isPropAccessExpr(expr.expr) &&
-          (expr.expr.name === "waitFor" || expr.expr.name === "waitUntil")
-        ) {
-          delete (props as any).ResultPath;
-          return <State>{
+      if (isReferenceExpr(expr.expr)) {
+        const ref = expr.expr.ref();
+        if (isIntegration<Integration>(ref)) {
+          const serviceCall = new IntegrationImpl(ref);
+          const taskState = <State>{
             ...serviceCall.asl(expr, this),
             ...props,
           };
-        }
 
-        const taskState = <State>{
-          ...serviceCall.asl(expr, this),
-          ...props,
-        };
-
-        const throwOrPass = this.throw(expr);
-        if (throwOrPass?.Next) {
-          return <State>{
-            ...taskState,
-            Catch: [
-              {
-                ErrorEquals: ["States.ALL"],
-                Next: throwOrPass.Next,
-                ResultPath: throwOrPass.ResultPath,
-              },
-            ],
-          };
+          const throwOrPass = this.throw(expr);
+          if (throwOrPass?.Next) {
+            return <State>{
+              ...taskState,
+              Catch: [
+                {
+                  ErrorEquals: ["States.ALL"],
+                  Next: throwOrPass.Next,
+                  ResultPath: throwOrPass.ResultPath,
+                },
+              ],
+            };
+          } else {
+            return taskState;
+          }
         } else {
-          return taskState;
+          throw Error("");
         }
       } else if (isMapOrForEach(expr)) {
         const throwTransition = this.throw(expr);
@@ -990,7 +942,7 @@ export class ASL {
     } else if (
       isBinaryExpr(expr) &&
       expr.op === "=" &&
-      isVariableReference(expr.left)
+      (isVariableReference(expr.left) || isIdentifier(expr.left))
     ) {
       if (isNullLiteralExpr(expr.right)) {
         return {
@@ -1178,7 +1130,7 @@ export class ASL {
               // by terminal, we mean that every branch returns a value - meaning that the re-throw
               // behavior of a finally will never be triggered - the return within the finally intercepts it
               !catchOrFinally.isTerminal()
-            ? `$.${this.getDeterministicGeneratedName(catchOrFinally)}`
+            ? `$.${this.generatedNames.generateOrGet(catchOrFinally)}`
             : null,
       };
     } else {
@@ -1234,7 +1186,7 @@ function analyzeFlow(node: FunctionlessNode): FlowResult {
     .reduce(
       (a, b) => ({ ...a, ...b }),
       (isCallExpr(node) &&
-        (findIntegration(node) !== undefined || isMapOrForEach(node))) ||
+        (isReferenceExpr(node.expr) || isMapOrForEach(node))) ||
         isForInStmt(node) ||
         isForOfStmt(node)
         ? { hasTask: true }

--- a/src/compile.ts
+++ b/src/compile.ts
@@ -592,63 +592,69 @@ export function compile(
         } else if (ts.isExpressionStatement(node)) {
           return newExpr("ExprStmt", [toExpr(node.expression, scope)]);
         } else if (ts.isCallExpression(node) || ts.isNewExpression(node)) {
-          const exprType = checker.getTypeAtLocation(node.expression);
-          const functionBrand = exprType.getProperty("__functionBrand");
-          let signature: ts.Signature | undefined;
-          if (functionBrand !== undefined) {
-            const functionType = checker.getTypeOfSymbolAtLocation(
-              functionBrand,
-              node.expression
-            );
-            const signatures = checker.getSignaturesOfType(
-              functionType,
-              ts.SignatureKind.Call
-            );
-
-            if (signatures.length === 1) {
-              signature = signatures[0];
-            } else {
-              throw new Error(
-                "Lambda Functions with multiple signatures are not currently supported."
+          const getCall = () => {
+            const exprType = checker.getTypeAtLocation(node.expression);
+            const functionBrand = exprType.getProperty("__functionBrand");
+            let signature: ts.Signature | undefined;
+            if (functionBrand !== undefined) {
+              const functionType = checker.getTypeOfSymbolAtLocation(
+                functionBrand,
+                node.expression
               );
+              const signatures = checker.getSignaturesOfType(
+                functionType,
+                ts.SignatureKind.Call
+              );
+
+              if (signatures.length === 1) {
+                signature = signatures[0];
+              } else {
+                // If the function brand has multiple signatures, try the resolved signature.
+                signature = checker.getResolvedSignature(node);
+              }
+            } else {
+              signature = checker.getResolvedSignature(node);
             }
-          } else {
-            signature = checker.getResolvedSignature(node);
-          }
-          if (signature && signature.parameters.length > 0) {
-            return newExpr(ts.isCallExpression(node) ? "CallExpr" : "NewExpr", [
-              toExpr(node.expression, scope),
-              ts.factory.createArrayLiteralExpression(
-                signature.parameters.map((parameter, i) =>
-                  newExpr("Argument", [
-                    (parameter.declarations?.[0] as ts.ParameterDeclaration)
-                      ?.dotDotDotToken
-                      ? newExpr("ArrayLiteralExpr", [
-                          ts.factory.createArrayLiteralExpression(
-                            node.arguments
-                              ?.slice(i)
-                              .map((x) => toExpr(x, scope)) ?? []
-                          ),
-                        ])
-                      : toExpr(node.arguments?.[i], scope),
-                    ts.factory.createStringLiteral(parameter.name),
-                  ])
-                )
-              ),
-            ]);
-          } else {
-            return newExpr("CallExpr", [
-              toExpr(node.expression, scope),
-              ts.factory.createArrayLiteralExpression(
-                node.arguments?.map((arg) =>
-                  newExpr("Argument", [
-                    toExpr(arg, scope),
-                    ts.factory.createIdentifier("undefined"),
-                  ])
-                ) ?? []
-              ),
-            ]);
-          }
+            if (signature && signature.parameters.length > 0) {
+              return newExpr(
+                ts.isCallExpression(node) ? "CallExpr" : "NewExpr",
+                [
+                  toExpr(node.expression, scope),
+                  ts.factory.createArrayLiteralExpression(
+                    signature.parameters.map((parameter, i) =>
+                      newExpr("Argument", [
+                        (parameter.declarations?.[0] as ts.ParameterDeclaration)
+                          ?.dotDotDotToken
+                          ? newExpr("ArrayLiteralExpr", [
+                              ts.factory.createArrayLiteralExpression(
+                                node.arguments
+                                  ?.slice(i)
+                                  .map((x) => toExpr(x, scope)) ?? []
+                              ),
+                            ])
+                          : toExpr(node.arguments?.[i], scope),
+                        ts.factory.createStringLiteral(parameter.name),
+                      ])
+                    )
+                  ),
+                ]
+              );
+            } else {
+              return newExpr("CallExpr", [
+                toExpr(node.expression, scope),
+                ts.factory.createArrayLiteralExpression(
+                  node.arguments?.map((arg) =>
+                    newExpr("Argument", [
+                      toExpr(arg, scope),
+                      ts.factory.createIdentifier("undefined"),
+                    ])
+                  ) ?? []
+                ),
+              ]);
+            }
+          };
+
+          return getCall();
         } else if (ts.isBlock(node)) {
           return newExpr("BlockStmt", [
             ts.factory.createArrayLiteralExpression(

--- a/src/guards.ts
+++ b/src/guards.ts
@@ -91,6 +91,7 @@ export function isStmt(a: any): a is Stmt {
       isBlockStmt(a) ||
       isCatchClause(a) ||
       isContinueStmt(a) ||
+      isDoStmt(a) ||
       isExprStmt(a) ||
       isForInStmt(a) ||
       isForOfStmt(a) ||
@@ -98,7 +99,8 @@ export function isStmt(a: any): a is Stmt {
       isReturnStmt(a) ||
       isThrowStmt(a) ||
       isTryStmt(a) ||
-      isVariableStmt(a))
+      isVariableStmt(a) ||
+      isWhileStmt(a))
   );
 }
 export const isExprStmt = typeGuard("ExprStmt");

--- a/src/integration.ts
+++ b/src/integration.ts
@@ -21,6 +21,10 @@ export const isIntegration = <I extends IntegrationInput<string, AnyFunction>>(
   i: any
 ): i is I => typeof i === "object" && "kind" in i;
 
+export function isIntegrationCall(node: FunctionlessNode): node is CallExpr {
+  return isCallExpr(node) && isReferenceExpr(node.expr);
+}
+
 /**
  * Maintain a typesafe runtime map of integration type keys to use elsewhere.
  *

--- a/src/util.ts
+++ b/src/util.ts
@@ -273,3 +273,22 @@ export const evalToConstant = (expr: Expr): Constant | undefined => {
   }
   return undefined;
 };
+
+export class DeterministicNameGenerator {
+  private readonly generatedNames = new Map<FunctionlessNode, string>();
+
+  /**
+   * Generate a deterministic and unique variable name for a node.
+   *
+   * The value is cached so that the same node reference always has the same name.
+   *
+   * @param node the node to generate a name for
+   * @returns a unique variable name that can be used in JSON Path
+   */
+  public generateOrGet(node: FunctionlessNode): string {
+    if (!this.generatedNames.has(node)) {
+      this.generatedNames.set(node, `${this.generatedNames.size}_tmp`);
+    }
+    return this.generatedNames.get(node)!;
+  }
+}

--- a/src/visit.ts
+++ b/src/visit.ts
@@ -503,7 +503,7 @@ export function visitBlock(
 ): BlockStmt {
   return visitEachChild(block, (stmt) => {
     const nestedTasks: FunctionlessNode[] = [];
-    function hoist(expr: Expr): Expr {
+    function hoist(expr: Expr): Identifier {
       const id = new Identifier(nameGenerator.generateOrGet(expr));
       nestedTasks.push(new VariableStmt(id.name, expr));
       return id;

--- a/test/__snapshots__/appsync.test.ts.snap
+++ b/test/__snapshots__/appsync.test.ts.snap
@@ -1,5 +1,109 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`machine describe exec return 1`] = `
+Array [
+  "{}",
+  "#if($context.stash.return__flag)
+  #return($context.stash.return__val)
+#end
+#set($context.stash.exec = 'exec1')
+{
+  \\"version\\": \\"2018-05-29\\",
+  \\"method\\": \\"POST\\",
+  \\"resourcePath\\": \\"/\\",
+  \\"params\\": {
+    \\"headers\\": {
+      \\"content-type\\": \\"application/x-amz-json-1.0\\",
+      \\"x-amz-target\\": \\"AWSStepFunctions.DescribeExecution\\"
+    },
+    \\"body\\": {
+      \\"executionArn\\": $util.toJson($context.stash.exec)
+    }
+  }
+}",
+  "#if($context.result.statusCode == 200)
+    #set($sfn__result = $util.parseJson($context.result.body))
+    #else 
+    $util.error($context.result.body, \\"$context.result.statusCode\\")
+    #end
+#set( $context.stash.return__flag = true )
+#set( $context.stash.return__val = $sfn__result )
+{}",
+  "#if($context.stash.return__flag)
+  #return($context.stash.return__val)
+#end",
+]
+`;
+
+exports[`machine describe exec return 2`] = `
+Object {
+  "method": "POST",
+  "params": Object {
+    "body": Object {
+      "executionArn": "exec1",
+    },
+    "headers": Object {
+      "content-type": "application/x-amz-json-1.0",
+      "x-amz-target": "AWSStepFunctions.DescribeExecution",
+    },
+  },
+  "resourcePath": "/",
+  "version": "2018-05-29",
+}
+`;
+
+exports[`machine describe exec var 1`] = `
+Array [
+  "{}",
+  "#if($context.stash.return__flag)
+  #return($context.stash.return__val)
+#end
+#set($context.stash.exec = 'exec1')
+{
+  \\"version\\": \\"2018-05-29\\",
+  \\"method\\": \\"POST\\",
+  \\"resourcePath\\": \\"/\\",
+  \\"params\\": {
+    \\"headers\\": {
+      \\"content-type\\": \\"application/x-amz-json-1.0\\",
+      \\"x-amz-target\\": \\"AWSStepFunctions.DescribeExecution\\"
+    },
+    \\"body\\": {
+      \\"executionArn\\": $util.toJson($context.stash.exec)
+    }
+  }
+}",
+  "#if($context.result.statusCode == 200)
+    #set($sfn__result = $util.parseJson($context.result.body))
+    #else 
+    $util.error($context.result.body, \\"$context.result.statusCode\\")
+    #end
+#set( $context.stash.v = $sfn__result )
+{}",
+  "#if($context.stash.return__flag)
+  #return($context.stash.return__val)
+#end
+#return($context.stash.v)",
+]
+`;
+
+exports[`machine describe exec var 2`] = `
+Object {
+  "method": "POST",
+  "params": Object {
+    "body": Object {
+      "executionArn": "exec1",
+    },
+    "headers": Object {
+      "content-type": "application/x-amz-json-1.0",
+      "x-amz-target": "AWSStepFunctions.DescribeExecution",
+    },
+  },
+  "resourcePath": "/",
+  "version": "2018-05-29",
+}
+`;
+
 exports[`multiple isolated integrations 1`] = `
 Array [
   "{}",

--- a/test/__snapshots__/appsync.test.ts.snap
+++ b/test/__snapshots__/appsync.test.ts.snap
@@ -1,5 +1,51 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`integrations separated by in 1`] = `
+Array [
+  "{}",
+  "#if($context.stash.return__flag)
+  #return($context.stash.return__val)
+#end
+#set($v1 = {})
+#set($v2 = {\\"version\\": \\"2018-05-29\\", \\"operation\\": \\"Invoke\\", \\"payload\\": $v1})
+$util.toJson($v2)",
+  "#set( $context.stash.0_tmp = $context.result )
+{}",
+  "#if($context.stash.return__flag)
+  #return($context.stash.return__val)
+#end
+#set($v1 = {})
+#set($v2 = {\\"version\\": \\"2018-05-29\\", \\"operation\\": \\"Invoke\\", \\"payload\\": $v1})
+$util.toJson($v2)",
+  "#set( $context.stash.1_tmp = $context.result )
+{}",
+  "#if($context.stash.return__flag)
+  #return($context.stash.return__val)
+#end
+#set($v2 = $context.stash.1_tmp.class.name.startsWith('[L') || $context.stash.1_tmp.class.name.contains('ArrayList'))
+#if($v2)
+#set($v3 = $context.stash.1_tmp.length >= $context.stash.0_tmp)
+#set($v1 = $v3)
+#else
+#set($v1 = $context.stash.1_tmp.containsKey($context.stash.0_tmp))
+#end
+#if($v1)
+#set($context.stash.return__val = true)
+#set($context.stash.return__flag = true)
+#return($context.stash.return__val)
+#end
+#return(false)",
+]
+`;
+
+exports[`integrations separated by in 2`] = `
+Object {
+  "operation": "Invoke",
+  "payload": Object {},
+  "version": "2018-05-29",
+}
+`;
+
 exports[`machine describe exec return 1`] = `
 Array [
   "{}",
@@ -674,11 +720,9 @@ Array [
 #end
 #set($v1 = {})
 #set($v2 = {})
-#set($v3 = {})
-#set($v4 = {})
-$util.qr($v3.put('input', $util.toJson($v4)))
-$util.qr($v3.put('stateMachineArn', '__REPLACED_TOKEN'))
-$util.qr($v2.put('input', $util.toJson({
+$util.qr($v1.put('input', $util.toJson($v2)))
+$util.qr($v1.put('stateMachineArn', '__REPLACED_TOKEN'))
+{
   \\"version\\": \\"2018-05-29\\",
   \\"method\\": \\"POST\\",
   \\"resourcePath\\": \\"/\\",
@@ -687,11 +731,23 @@ $util.qr($v2.put('input', $util.toJson({
       \\"content-type\\": \\"application/x-amz-json-1.0\\",
       \\"x-amz-target\\": \\"AWSStepFunctions.StartExecution\\"
     },
-    \\"body\\": $util.toJson($v3)
+    \\"body\\": $util.toJson($v1)
   }
-})))
-$util.qr($v2.put('stateMachineArn', '__REPLACED_TOKEN'))
-$util.qr($v1.put('input', $util.toJson({
+}",
+  "#if($context.result.statusCode == 200)
+    #set($sfn__result = $util.parseJson($context.result.body))
+    #else 
+    $util.error($context.result.body, \\"$context.result.statusCode\\")
+    #end
+#set( $context.stash.0_tmp = $sfn__result )
+{}",
+  "#if($context.stash.return__flag)
+  #return($context.stash.return__val)
+#end
+#set($v1 = {})
+$util.qr($v1.put('input', $util.toJson($context.stash.0_tmp)))
+$util.qr($v1.put('stateMachineArn', '__REPLACED_TOKEN'))
+{
   \\"version\\": \\"2018-05-29\\",
   \\"method\\": \\"POST\\",
   \\"resourcePath\\": \\"/\\",
@@ -700,9 +756,21 @@ $util.qr($v1.put('input', $util.toJson({
       \\"content-type\\": \\"application/x-amz-json-1.0\\",
       \\"x-amz-target\\": \\"AWSStepFunctions.StartExecution\\"
     },
-    \\"body\\": $util.toJson($v2)
+    \\"body\\": $util.toJson($v1)
   }
-})))
+}",
+  "#if($context.result.statusCode == 200)
+    #set($sfn__result = $util.parseJson($context.result.body))
+    #else 
+    $util.error($context.result.body, \\"$context.result.statusCode\\")
+    #end
+#set( $context.stash.1_tmp = $sfn__result )
+{}",
+  "#if($context.stash.return__flag)
+  #return($context.stash.return__val)
+#end
+#set($v1 = {})
+$util.qr($v1.put('input', $util.toJson($context.stash.1_tmp)))
 $util.qr($v1.put('stateMachineArn', '__REPLACED_TOKEN'))
 {
   \\"version\\": \\"2018-05-29\\",
@@ -728,7 +796,7 @@ Object {
   "method": "POST",
   "params": Object {
     "body": Object {
-      "input": "{\\"version\\":\\"2018-05-29\\",\\"method\\":\\"POST\\",\\"resourcePath\\":\\"/\\",\\"params\\":{\\"headers\\":{\\"content-type\\":\\"application/x-amz-json-1.0\\",\\"x-amz-target\\":\\"AWSStepFunctions.StartExecution\\"},\\"body\\":\\"{\\\\\\"input\\\\\\":\\\\\\"{\\\\\\\\\\\\\\"version\\\\\\\\\\\\\\":\\\\\\\\\\\\\\"2018-05-29\\\\\\\\\\\\\\",\\\\\\\\\\\\\\"method\\\\\\\\\\\\\\":\\\\\\\\\\\\\\"POST\\\\\\\\\\\\\\",\\\\\\\\\\\\\\"resourcePath\\\\\\\\\\\\\\":\\\\\\\\\\\\\\"/\\\\\\\\\\\\\\",\\\\\\\\\\\\\\"params\\\\\\\\\\\\\\":{\\\\\\\\\\\\\\"headers\\\\\\\\\\\\\\":{\\\\\\\\\\\\\\"content-type\\\\\\\\\\\\\\":\\\\\\\\\\\\\\"application/x-amz-json-1.0\\\\\\\\\\\\\\",\\\\\\\\\\\\\\"x-amz-target\\\\\\\\\\\\\\":\\\\\\\\\\\\\\"AWSStepFunctions.StartExecution\\\\\\\\\\\\\\"},\\\\\\\\\\\\\\"body\\\\\\\\\\\\\\":\\\\\\\\\\\\\\"{\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\"input\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\":\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\"{}\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\",\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\"stateMachineArn\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\":\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\"__REPLACED_TOKEN\\\\\\\\\\\\\\\\\\\\\\\\\\\\\\"}\\\\\\\\\\\\\\"}}\\\\\\",\\\\\\"stateMachineArn\\\\\\":\\\\\\"__REPLACED_TOKEN\\\\\\"}\\"}}",
+      "input": "{}",
       "stateMachineArn": "__REPLACED_TOKEN",
     },
     "headers": Object {
@@ -757,33 +825,55 @@ Array [
       \\"x-amz-target\\": \\"AWSStepFunctions.DescribeExecution\\"
     },
     \\"body\\": {
-      \\"executionArn\\": $util.toJson({
-  \\"version\\": \\"2018-05-29\\",
-  \\"method\\": \\"POST\\",
-  \\"resourcePath\\": \\"/\\",
-  \\"params\\": {
-    \\"headers\\": {
-      \\"content-type\\": \\"application/x-amz-json-1.0\\",
-      \\"x-amz-target\\": \\"AWSStepFunctions.DescribeExecution\\"
-    },
-    \\"body\\": {
-      \\"executionArn\\": $util.toJson({
-  \\"version\\": \\"2018-05-29\\",
-  \\"method\\": \\"POST\\",
-  \\"resourcePath\\": \\"/\\",
-  \\"params\\": {
-    \\"headers\\": {
-      \\"content-type\\": \\"application/x-amz-json-1.0\\",
-      \\"x-amz-target\\": \\"AWSStepFunctions.DescribeExecution\\"
-    },
-    \\"body\\": {
       \\"executionArn\\": $util.toJson('exec1')
     }
   }
-}.executionArn)
+}",
+  "#if($context.result.statusCode == 200)
+    #set($sfn__result = $util.parseJson($context.result.body))
+    #else 
+    $util.error($context.result.body, \\"$context.result.statusCode\\")
+    #end
+#set( $context.stash.0_tmp = $sfn__result )
+{}",
+  "#if($context.stash.return__flag)
+  #return($context.stash.return__val)
+#end
+{
+  \\"version\\": \\"2018-05-29\\",
+  \\"method\\": \\"POST\\",
+  \\"resourcePath\\": \\"/\\",
+  \\"params\\": {
+    \\"headers\\": {
+      \\"content-type\\": \\"application/x-amz-json-1.0\\",
+      \\"x-amz-target\\": \\"AWSStepFunctions.DescribeExecution\\"
+    },
+    \\"body\\": {
+      \\"executionArn\\": $util.toJson($context.stash.0_tmp.executionArn)
     }
   }
-}.executionArn)
+}",
+  "#if($context.result.statusCode == 200)
+    #set($sfn__result = $util.parseJson($context.result.body))
+    #else 
+    $util.error($context.result.body, \\"$context.result.statusCode\\")
+    #end
+#set( $context.stash.1_tmp = $sfn__result )
+{}",
+  "#if($context.stash.return__flag)
+  #return($context.stash.return__val)
+#end
+{
+  \\"version\\": \\"2018-05-29\\",
+  \\"method\\": \\"POST\\",
+  \\"resourcePath\\": \\"/\\",
+  \\"params\\": {
+    \\"headers\\": {
+      \\"content-type\\": \\"application/x-amz-json-1.0\\",
+      \\"x-amz-target\\": \\"AWSStepFunctions.DescribeExecution\\"
+    },
+    \\"body\\": {
+      \\"executionArn\\": $util.toJson($context.stash.1_tmp.executionArn)
     }
   }
 }",
@@ -792,6 +882,23 @@ Array [
   #return($context.stash.return__val)
 #end",
 ]
+`;
+
+exports[`multiple nested integrations prop access 2`] = `
+Object {
+  "method": "POST",
+  "params": Object {
+    "body": Object {
+      "executionArn": "exec1",
+    },
+    "headers": Object {
+      "content-type": "application/x-amz-json-1.0",
+      "x-amz-target": "AWSStepFunctions.DescribeExecution",
+    },
+  },
+  "resourcePath": "/",
+  "version": "2018-05-29",
+}
 `;
 
 exports[`step function describe execution machine describe exec string 1`] = `

--- a/test/__snapshots__/step-function.test.ts.snap
+++ b/test/__snapshots__/step-function.test.ts.snap
@@ -863,7 +863,11 @@ Object {
       "Type": "Task",
     },
     "for(i of [0_tmp])": Object {
+<<<<<<< HEAD
       "ItemsPath": "__REPLACED_TOKEN",
+=======
+      "ItemsPath": "\${Token[States.Array....0_tmp...3356]}",
+>>>>>>> b784d750f5bbeadb47cf4d9a493130d70f9cf9e5
       "Iterator": Object {
         "StartAt": "1_tmp = task(i)",
         "States": Object {

--- a/test/__snapshots__/step-function.test.ts.snap
+++ b/test/__snapshots__/step-function.test.ts.snap
@@ -5005,6 +5005,7 @@ Object {
   "States": Object {
     "$SFN.waitFor(1)": Object {
       "Next": "return null",
+      "ResultPath": null,
       "Seconds": 1,
       "Type": "Wait",
     },
@@ -5026,6 +5027,7 @@ Object {
   "States": Object {
     "$SFN.waitUntil(\\"2022-08-01T00:00:00Z\\")": Object {
       "Next": "return null",
+      "ResultPath": null,
       "Timestamp": "2022-08-01T00:00:00Z",
       "Type": "Wait",
     },
@@ -5047,6 +5049,7 @@ Object {
   "States": Object {
     "$SFN.waitFor(input.seconds)": Object {
       "Next": "return null",
+      "ResultPath": null,
       "SecondsPath": "$.seconds",
       "Type": "Wait",
     },
@@ -5068,6 +5071,7 @@ Object {
   "States": Object {
     "$SFN.waitUntil(input.until)": Object {
       "Next": "return null",
+      "ResultPath": null,
       "TimestampPath": "$.until",
       "Type": "Wait",
     },
@@ -5179,6 +5183,7 @@ Object {
   "States": Object {
     "$SFN.waitFor(1)": Object {
       "Next": "while (true)",
+      "ResultPath": null,
       "Seconds": 1,
       "Type": "Wait",
     },

--- a/test/__snapshots__/step-function.test.ts.snap
+++ b/test/__snapshots__/step-function.test.ts.snap
@@ -798,7 +798,7 @@ Object {
       "Type": "Task",
     },
     "for(i in [0_tmp])": Object {
-      "ItemsPath": "\${Token[States.Array....0_tmp...3311]}",
+      "ItemsPath": "__REPLACED_TOKEN",
       "Iterator": Object {
         "StartAt": "1_tmp = task(i)",
         "States": Object {
@@ -863,7 +863,7 @@ Object {
       "Type": "Task",
     },
     "for(i of [0_tmp])": Object {
-      "ItemsPath": "\${Token[States.Array....0_tmp...3357]}",
+      "ItemsPath": "__REPLACED_TOKEN",
       "Iterator": Object {
         "StartAt": "1_tmp = task(i)",
         "States": Object {

--- a/test/__snapshots__/step-function.test.ts.snap
+++ b/test/__snapshots__/step-function.test.ts.snap
@@ -782,6 +782,135 @@ Object {
 }
 `;
 
+exports[`for (const i in [task(input)]) 1`] = `
+Object {
+  "StartAt": "0_tmp = task(input)",
+  "States": Object {
+    "0_tmp = task(input)": Object {
+      "Next": "for(i in [0_tmp])",
+      "Parameters": Object {
+        "FunctionName": "__REPLACED_TOKEN",
+        "Payload.$": "$",
+      },
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "ResultPath": "$.0_tmp",
+      "ResultSelector": "$.Payload",
+      "Type": "Task",
+    },
+    "for(i in [0_tmp])": Object {
+      "ItemsPath": "\${Token[States.Array....0_tmp...3311]}",
+      "Iterator": Object {
+        "StartAt": "1_tmp = task(i)",
+        "States": Object {
+          "1_tmp = task(i)": Object {
+            "Next": "task(1_tmp)",
+            "Parameters": Object {
+              "FunctionName": "__REPLACED_TOKEN",
+              "Payload.$": "$.i",
+            },
+            "Resource": "arn:aws:states:::lambda:invoke",
+            "ResultPath": "$.1_tmp",
+            "ResultSelector": "$.Payload",
+            "Type": "Task",
+          },
+          "task(1_tmp)": Object {
+            "End": true,
+            "Parameters": Object {
+              "FunctionName": "__REPLACED_TOKEN",
+              "Payload.$": "$.1_tmp",
+            },
+            "Resource": "arn:aws:states:::lambda:invoke",
+            "ResultPath": null,
+            "ResultSelector": "$.Payload",
+            "Type": "Task",
+          },
+        },
+      },
+      "MaxConcurrency": 1,
+      "Next": "return null",
+      "Parameters": Object {
+        "0_i.$": "$$.Map.Item.Value",
+        "i.$": "$$.Map.Item.Index",
+      },
+      "ResultPath": null,
+      "Type": "Map",
+    },
+    "return null": Object {
+      "End": true,
+      "OutputPath": "$.null",
+      "Parameters": Object {
+        "null": null,
+      },
+      "Type": "Pass",
+    },
+  },
+}
+`;
+
+exports[`for (const i of [task(input)]) 1`] = `
+Object {
+  "StartAt": "0_tmp = task(input)",
+  "States": Object {
+    "0_tmp = task(input)": Object {
+      "Next": "for(i of [0_tmp])",
+      "Parameters": Object {
+        "FunctionName": "__REPLACED_TOKEN",
+        "Payload.$": "$",
+      },
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "ResultPath": "$.0_tmp",
+      "ResultSelector": "$.Payload",
+      "Type": "Task",
+    },
+    "for(i of [0_tmp])": Object {
+      "ItemsPath": "\${Token[States.Array....0_tmp...3357]}",
+      "Iterator": Object {
+        "StartAt": "1_tmp = task(i)",
+        "States": Object {
+          "1_tmp = task(i)": Object {
+            "Next": "task(1_tmp)",
+            "Parameters": Object {
+              "FunctionName": "__REPLACED_TOKEN",
+              "Payload.$": "$.i",
+            },
+            "Resource": "arn:aws:states:::lambda:invoke",
+            "ResultPath": "$.1_tmp",
+            "ResultSelector": "$.Payload",
+            "Type": "Task",
+          },
+          "task(1_tmp)": Object {
+            "End": true,
+            "Parameters": Object {
+              "FunctionName": "__REPLACED_TOKEN",
+              "Payload.$": "$.1_tmp",
+            },
+            "Resource": "arn:aws:states:::lambda:invoke",
+            "ResultPath": null,
+            "ResultSelector": "$.Payload",
+            "Type": "Task",
+          },
+        },
+      },
+      "MaxConcurrency": 1,
+      "Next": "return null",
+      "Parameters": Object {
+        "i.$": "$$.Map.Item.Value",
+      },
+      "ResultPath": null,
+      "Type": "Map",
+    },
+    "return null": Object {
+      "End": true,
+      "OutputPath": "$.null",
+      "Parameters": Object {
+        "null": null,
+      },
+      "Type": "Pass",
+    },
+  },
+}
+`;
+
 exports[`for i in items, items[i] 1`] = `
 Object {
   "StartAt": "for(i in input.items)",
@@ -1629,6 +1758,68 @@ Object {
       ],
       "Default": "return null",
       "Type": "Choice",
+    },
+  },
+}
+`;
+
+exports[`list.filter(item => item.length > 2).map(item => item) 1`] = `
+Object {
+  "StartAt": "return input.list.filter(function(item)).map(function(item))",
+  "States": Object {
+    "return input.list.filter(function(item)).map(function(item))": Object {
+      "End": true,
+      "ItemsPath": "$.list[?(@.length>2)]",
+      "Iterator": Object {
+        "StartAt": "return item",
+        "States": Object {
+          "return item": Object {
+            "End": true,
+            "OutputPath": "$.item",
+            "Type": "Pass",
+          },
+        },
+      },
+      "MaxConcurrency": 1,
+      "Parameters": Object {
+        "item.$": "$$.Map.Item.Value",
+      },
+      "ResultPath": "$",
+      "Type": "Map",
+    },
+  },
+}
+`;
+
+exports[`list.filter(item => item.length > 2).map(item => task(item)) 1`] = `
+Object {
+  "StartAt": "return input.list.filter(function(item)).map(function(item))",
+  "States": Object {
+    "return input.list.filter(function(item)).map(function(item))": Object {
+      "End": true,
+      "ItemsPath": "$.list[?(@.length>2)]",
+      "Iterator": Object {
+        "StartAt": "return task(item)",
+        "States": Object {
+          "return task(item)": Object {
+            "End": true,
+            "Parameters": Object {
+              "FunctionName": "__REPLACED_TOKEN",
+              "Payload.$": "$.item",
+            },
+            "Resource": "arn:aws:states:::lambda:invoke",
+            "ResultPath": "$",
+            "ResultSelector": "$.Payload",
+            "Type": "Task",
+          },
+        },
+      },
+      "MaxConcurrency": 1,
+      "Parameters": Object {
+        "item.$": "$$.Map.Item.Value",
+      },
+      "ResultPath": "$",
+      "Type": "Map",
     },
   },
 }
@@ -3175,6 +3366,30 @@ Object {
     "throw new Error(\\"cause\\")": Object {
       "Cause": "{\\"message\\":\\"cause\\"}",
       "Error": "Error",
+      "Type": "Fail",
+    },
+  },
+}
+`;
+
+exports[`throw task(task()) 1`] = `
+Object {
+  "StartAt": "0_tmp = task(input)",
+  "States": Object {
+    "0_tmp = task(input)": Object {
+      "Next": "throw task(0_tmp)",
+      "Parameters": Object {
+        "FunctionName": "__REPLACED_TOKEN",
+        "Payload.$": "$",
+      },
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "ResultPath": "$.0_tmp",
+      "ResultSelector": "$.Payload",
+      "Type": "Task",
+    },
+    "throw task(0_tmp)": Object {
+      "Cause": "{\\"payload\\":\\"$.0_tmp\\"}",
+      "Error": "task",
       "Type": "Fail",
     },
   },

--- a/test/__snapshots__/step-function.test.ts.snap
+++ b/test/__snapshots__/step-function.test.ts.snap
@@ -863,11 +863,7 @@ Object {
       "Type": "Task",
     },
     "for(i of [0_tmp])": Object {
-<<<<<<< HEAD
       "ItemsPath": "__REPLACED_TOKEN",
-=======
-      "ItemsPath": "\${Token[States.Array....0_tmp...3356]}",
->>>>>>> b784d750f5bbeadb47cf4d9a493130d70f9cf9e5
       "Iterator": Object {
         "StartAt": "1_tmp = task(i)",
         "States": Object {

--- a/test/__snapshots__/table.test.ts.snap
+++ b/test/__snapshots__/table.test.ts.snap
@@ -608,12 +608,12 @@ $util.qr($v5.put('consistentRead', $v1.get('consistentRead')))
 $util.qr($v5.put('select', $v1.get('select')))
 #end
 $util.toJson($v5)",
-  "#set( $context.stash.return__flag = true )
-#set( $context.stash.return__val = $context.result.items )
+  "#set( $context.stash.0_tmp = $context.result )
 {}",
   "#if($context.stash.return__flag)
   #return($context.stash.return__val)
-#end",
+#end
+#return($context.stash.0_tmp.items)",
 ]
 `;
 
@@ -655,12 +655,12 @@ $util.qr($v5.put('consistentRead', $v1.get('consistentRead')))
 $util.qr($v5.put('select', $v1.get('select')))
 #end
 $util.toJson($v5)",
-  "#set( $context.stash.return__flag = true )
-#set( $context.stash.return__val = $context.result.items )
+  "#set( $context.stash.0_tmp = $context.result )
 {}",
   "#if($context.stash.return__flag)
   #return($context.stash.return__val)
-#end",
+#end
+#return($context.stash.0_tmp.items)",
 ]
 `;
 
@@ -702,12 +702,12 @@ $util.qr($v5.put('consistentRead', $v1.get('consistentRead')))
 $util.qr($v5.put('select', $v1.get('select')))
 #end
 $util.toJson($v5)",
-  "#set( $context.stash.return__flag = true )
-#set( $context.stash.return__val = $context.result.items )
+  "#set( $context.stash.0_tmp = $context.result )
 {}",
   "#if($context.stash.return__flag)
   #return($context.stash.return__val)
-#end",
+#end
+#return($context.stash.0_tmp.items)",
 ]
 `;
 
@@ -749,12 +749,12 @@ $util.qr($v5.put('consistentRead', $v1.get('consistentRead')))
 $util.qr($v5.put('select', $v1.get('select')))
 #end
 $util.toJson($v5)",
-  "#set( $context.stash.return__flag = true )
-#set( $context.stash.return__val = $context.result.items )
+  "#set( $context.stash.0_tmp = $context.result )
 {}",
   "#if($context.stash.return__flag)
   #return($context.stash.return__val)
-#end",
+#end
+#return($context.stash.0_tmp.items)",
 ]
 `;
 

--- a/test/appsync.test.ts
+++ b/test/appsync.test.ts
@@ -120,6 +120,33 @@ describe("step function integration", () => {
   });
 });
 
+test("machine describe exec return", () => {
+  const machine = new StepFunction(stack, "machine", () => {});
+
+  const templates = appsyncTestCase(
+    reflect(() => {
+      const exec = "exec1";
+      return machine.describeExecution(exec);
+    })
+  );
+
+  testAppsyncVelocity(templates[1]);
+});
+
+test("machine describe exec var", () => {
+  const machine = new StepFunction(stack, "machine", () => {});
+
+  const templates = appsyncTestCase(
+    reflect(() => {
+      const exec = "exec1";
+      const v = machine.describeExecution(exec);
+      return v;
+    })
+  );
+
+  testAppsyncVelocity(templates[1]);
+});
+
 describe("step function describe execution", () => {
   test("machine describe exec string", () => {
     const machine = new StepFunction(stack, "machine", () => {});

--- a/test/appsync.test.ts
+++ b/test/appsync.test.ts
@@ -1,5 +1,11 @@
 import { Stack } from "aws-cdk-lib";
-import { AppsyncContext, AppsyncResolver, reflect, StepFunction } from "../src";
+import {
+  AppsyncContext,
+  AppsyncResolver,
+  reflect,
+  StepFunction,
+  Function,
+} from "../src";
 import { appsyncTestCase, testAppsyncVelocity } from "./util";
 
 let stack: Stack;
@@ -251,7 +257,7 @@ test("multiple linked integrations with props", () => {
 });
 
 // https://github.com/functionless/functionless/issues/212
-test.skip("multiple nested integrations", () => {
+test("multiple nested integrations", () => {
   const machine = new StepFunction(stack, "machine", () => {});
 
   const templates = appsyncTestCase(
@@ -267,7 +273,7 @@ test.skip("multiple nested integrations", () => {
 });
 
 // https://github.com/functionless/functionless/issues/212
-test.skip("multiple nested integrations prop access", () => {
+test("multiple nested integrations prop access", () => {
   const machine = new StepFunction(stack, "machine", () => {});
 
   const templates = appsyncTestCase(
@@ -277,6 +283,29 @@ test.skip("multiple nested integrations prop access", () => {
           machine.describeExecution("exec1").executionArn
         ).executionArn
       );
+    }),
+    {
+      expectedTemplateCount: 8,
+    }
+  );
+
+  testAppsyncVelocity(templates[1]);
+});
+
+test("integrations separated by in", () => {
+  const func = new Function(stack, "func1", async () => {
+    return "key";
+  });
+  const func2 = new Function(stack, "func2", async () => {
+    return { key: "value" };
+  });
+
+  const templates = appsyncTestCase(
+    reflect(() => {
+      if (func({}) in func2({})) {
+        return true;
+      }
+      return false;
     }),
     {
       expectedTemplateCount: 8,

--- a/test/appsync.test.ts
+++ b/test/appsync.test.ts
@@ -308,7 +308,7 @@ test("integrations separated by in", () => {
       return false;
     }),
     {
-      expectedTemplateCount: 8,
+      expectedTemplateCount: 6,
     }
   );
 

--- a/test/step-function.test.ts
+++ b/test/step-function.test.ts
@@ -1272,6 +1272,85 @@ test("list.map(item => task(item))", () => {
   expect(normalizeDefinition(definition)).toMatchSnapshot();
 });
 
+test("list.filter(item => item.length > 2).map(item => task(item))", () => {
+  const { stack, task } = initStepFunctionApp();
+  const definition = new ExpressStepFunction<
+    { list: string[] },
+    (number | null)[]
+  >(stack, "fn", (input) => {
+    return input.list
+      .filter((item) => item.length > 2)
+      .map((item) => task(item));
+  }).definition;
+
+  expect(normalizeDefinition(definition)).toMatchSnapshot();
+});
+
+// https://github.com/functionless/functionless/issues/209
+test.skip("`template me ${input.value}`", () => {
+  const { stack } = initStepFunctionApp();
+  const definition = new ExpressStepFunction<{ value: string }, string>(
+    stack,
+    "fn",
+    (input) => {
+      return `template me ${input.value}`;
+    }
+  ).definition;
+
+  expect(normalizeDefinition(definition)).toMatchSnapshot();
+});
+
+// https://github.com/functionless/functionless/issues/209
+test.skip("`template me ${await task(input.value)}`", () => {
+  const { stack, task } = initStepFunctionApp();
+  const definition = new ExpressStepFunction<{ value: string }, string>(
+    stack,
+    "fn",
+    (input) => {
+      return `template me ${task(input.value)}`;
+    }
+  ).definition;
+
+  expect(normalizeDefinition(definition)).toMatchSnapshot();
+});
+
+test("list.filter(item => item.length > 2).map(item => item)", () => {
+  const { stack } = initStepFunctionApp();
+  const definition = new ExpressStepFunction<
+    { list: string[] },
+    (string | null)[]
+  >(stack, "fn", (input) => {
+    return input.list.filter((item) => item.length > 2).map((item) => item);
+  }).definition;
+
+  expect(normalizeDefinition(definition)).toMatchSnapshot();
+});
+
+// https://github.com/functionless/functionless/issues/210
+test.skip("input.list.map((item) => item).filter((item) => item.length > 2)", () => {
+  const { stack } = initStepFunctionApp();
+  const definition = new ExpressStepFunction<
+    { list: string[] },
+    (string | null)[]
+  >(stack, "fn", (input) => {
+    return input.list.map((item) => item).filter((item) => item.length > 2);
+  }).definition;
+
+  expect(normalizeDefinition(definition)).toMatchSnapshot();
+});
+
+test.skip("await Promise.all(input.list.map((item) => task(item)))).filter", () => {
+  const { stack, task } = initStepFunctionApp();
+  const definition = new ExpressStepFunction<
+    { list: string[] },
+    (number | null)[]
+  >(stack, "fn", (input) => {
+    return input.list.map((item) => task(item)).filter((item) => item !== null);
+  }).definition;
+
+  expect(normalizeDefinition(definition)).toMatchSnapshot();
+});
+
 test("list.map((item, i) => if (i == 0) task(item))", () => {
   const { stack, task } = initStepFunctionApp();
   const definition = new ExpressStepFunction<
@@ -1320,6 +1399,50 @@ test("try { list.map(item => task(item)) }", () => {
       return null;
     }
   }).definition;
+
+  expect(normalizeDefinition(definition)).toMatchSnapshot();
+});
+
+test("throw task(task())", () => {
+  const { stack, task } = initStepFunctionApp();
+  const definition = new ExpressStepFunction<
+    { list: string[] },
+    (null | number)[] | null
+  >(stack, "fn", (input) => {
+    throw task(task(input));
+  }).definition;
+
+  expect(normalizeDefinition(definition)).toMatchSnapshot();
+});
+
+test("for (const i in [task(input)])", () => {
+  const { stack, task } = initStepFunctionApp();
+  const definition = new ExpressStepFunction<{ str: string }, any | null>(
+    stack,
+    "fn",
+    (input) => {
+      for (const i in [task(input)]) {
+        task(task(i));
+      }
+      return null;
+    }
+  ).definition;
+
+  expect(normalizeDefinition(definition)).toMatchSnapshot();
+});
+
+test("for (const i of [task(input)])", () => {
+  const { stack, task } = initStepFunctionApp();
+  const definition = new ExpressStepFunction<{ list: string }, any | null>(
+    stack,
+    "fn",
+    (input) => {
+      for (const i of [task(input)]) {
+        task(task(i));
+      }
+      return null;
+    }
+  ).definition;
 
   expect(normalizeDefinition(definition)).toMatchSnapshot();
 });

--- a/test/step-function.test.ts
+++ b/test/step-function.test.ts
@@ -1415,6 +1415,19 @@ test("throw task(task())", () => {
   expect(normalizeDefinition(definition)).toMatchSnapshot();
 });
 
+test.skip("input.b ? task() : task(input)", () => {
+  const { stack, task } = initStepFunctionApp();
+  const definition = new ExpressStepFunction<{ b: boolean }, null | number>(
+    stack,
+    "fn",
+    (input) => {
+      return input.b ? task() : task(input);
+    }
+  ).definition;
+
+  expect(normalizeDefinition(definition)).toMatchSnapshot();
+});
+
 test("for (const i in [task(input)])", () => {
   const { stack, task } = initStepFunctionApp();
   const definition = new ExpressStepFunction<{ str: string }, any | null>(

--- a/test/util.ts
+++ b/test/util.ts
@@ -282,7 +282,7 @@ export function ebEventTargetTestCaseError<T extends Event>(
 export const normalizeCDKJson = (json: object) => {
   return JSON.parse(
     JSON.stringify(json).replace(
-      /\$\{Token\[[a-zA-Z0-9.]*\]\}/g,
+      /\$\{Token\[[a-zA-Z0-9.-_]*\]\}/g,
       "__REPLACED_TOKEN"
     )
   );


### PR DESCRIPTION
Closes #212

Refactor step functions and app sync interpreters to refactor nested tasks to a normal form. This change will make the #202 easier by providing a generic interface for re-writing the AST tree. Async introduces more complex statements that need to be hoisted to a-normal form which would have been previously difficult.