### PR TITLE
chore(docs): remove h3s for the workaround docs

### DIFF
--- a/src/error-code.ts
+++ b/src/error-code.ts
@@ -293,7 +293,7 @@ export namespace ErrorCodes {
    * });
    * ```
    *
-   * ### Workaround - Functionless Resource Properties
+   * Workaround 1 - Functionless Resource Properties
    *
    * In many cases, common properties are available on the Functionless Resource, for example:
    *
@@ -304,7 +304,7 @@ export namespace ErrorCodes {
    * });
    * ```
    *
-   * ### Workaround - Dereference
+   * Workaround 2 - Dereference
    *
    * For some properties, referencing to a variable outside of the closure will work.
    *
@@ -316,7 +316,7 @@ export namespace ErrorCodes {
    * });
    * ```
    *
-   * ### Workaround - Environment Variable
+   * Workaround 3 - Environment Variable
    *
    * Finally, if none of the above work, the lambda environment variables can be used.
    *


### PR DESCRIPTION
Part of #285 

Remove the h3 from the error code documentation.