### PR TITLE
feat(appsync, table): move appsync-specific methods on Table to a nested appsync property

### DIFF
--- a/src/table.ts
+++ b/src/table.ts
@@ -12,8 +12,13 @@ import {
 } from "typesafe-dynamodb/lib/expression-attributes";
 import { TableKey } from "typesafe-dynamodb/lib/key";
 import { Narrow } from "typesafe-dynamodb/lib/narrow";
-// @ts-expect-error - AppsyncResolver is imported for tsdoc
-import { AppsyncResolver, AppSyncVtlIntegration } from "./appsync";
+import {
+  // @ts-expect-error - AppsyncResolver is imported for tsdoc
+  AppsyncResolver,
+  // @ts-expect-error - AppsyncField is imported for tsdoc
+  AppsyncField,
+  AppSyncVtlIntegration,
+} from "./appsync";
 import { assertNodeKind } from "./assert";
 import { ObjectLiteralExpr } from "./expression";
 import {
@@ -82,7 +87,7 @@ export type AnyTable = ITable<Record<string, any>, string, string | undefined>;
  * const getPerson = new AppsyncResolver<
  *   (personId: string) => Person | undefined
  * >(($context, personId: string) => {
- *   const person = personTable.get({
+ *   const person = personTable.appsync.get({
  *     key: {
  *       id: $util.toDynamoDB(personId)
  *     }
@@ -132,115 +137,124 @@ export interface ITable<
   };
 
   /**
-   * @see https://docs.aws.amazon.com/appsync/latest/devguide/resolver-mapping-template-reference-dynamodb.html#aws-appsync-resolver-mapping-template-reference-dynamodb-getitem
+   * Contains Integration implementations specific to the AWS Appsync service.
+   *
+   * These integrations should only be called from within the {@link AppsyncResolver} and {@link AppsyncField} Integration Contexts.
+   *
+   * @see https://docs.aws.amazon.com/appsync/latest/devguide/resolver-mapping-template-reference-dynamodb.html
    */
-  getItem: DynamoIntegrationCall<
-    "getItem",
-    <
-      Key extends TableKey<
-        Item,
-        PartitionKey,
-        RangeKey,
-        JsonFormat.AttributeValue
-      >
-    >(input: {
-      key: Key;
-      consistentRead?: boolean;
-    }) => Narrow<Item, AttributeKeyToObject<Key>, JsonFormat.Document>
-  >;
-
-  /**
-   * @see https://docs.aws.amazon.com/appsync/latest/devguide/resolver-mapping-template-reference-dynamodb.html#aws-appsync-resolver-mapping-template-reference-dynamodb-putitem
-   */
-  putItem: DynamoIntegrationCall<
-    "putItem",
-    <
-      Key extends TableKey<
-        Item,
-        PartitionKey,
-        RangeKey,
-        JsonFormat.AttributeValue
-      >,
-      ConditionExpression extends string | undefined = undefined
-    >(input: {
-      key: Key;
-      attributeValues: ToAttributeMap<
-        Omit<
-          Narrow<Item, AttributeKeyToObject<Key>, JsonFormat.Document>,
-          Exclude<PartitionKey | RangeKey, undefined>
+  readonly appsync: {
+    /**
+     * @see https://docs.aws.amazon.com/appsync/latest/devguide/resolver-mapping-template-reference-dynamodb.html#aws-appsync-resolver-mapping-template-reference-dynamodb-getitem
+     */
+    getItem: DynamoIntegrationCall<
+      "getItem",
+      <
+        Key extends TableKey<
+          Item,
+          PartitionKey,
+          RangeKey,
+          JsonFormat.AttributeValue
         >
-      >;
-      condition?: DynamoExpression<ConditionExpression>;
-      _version?: number;
-    }) => Narrow<Item, AttributeKeyToObject<Key>, JsonFormat.Document>
-  >;
+      >(input: {
+        key: Key;
+        consistentRead?: boolean;
+      }) => Narrow<Item, AttributeKeyToObject<Key>, JsonFormat.Document>
+    >;
 
-  /**
-   * @see https://docs.aws.amazon.com/appsync/latest/devguide/resolver-mapping-template-reference-dynamodb.html#aws-appsync-resolver-mapping-template-reference-dynamodb-updateitem
-   *
-   * @returns the updated the item
-   */
-  updateItem: DynamoIntegrationCall<
-    "updateItem",
-    <
-      Key extends TableKey<
-        Item,
-        PartitionKey,
-        RangeKey,
-        JsonFormat.AttributeValue
-      >,
-      UpdateExpression extends string,
-      ConditionExpression extends string | undefined
-    >(input: {
-      key: Key;
-      update: DynamoExpression<UpdateExpression>;
-      condition?: DynamoExpression<ConditionExpression>;
-      _version?: number;
-    }) => Narrow<Item, AttributeKeyToObject<Key>, JsonFormat.Document>
-  >;
+    /**
+     * @see https://docs.aws.amazon.com/appsync/latest/devguide/resolver-mapping-template-reference-dynamodb.html#aws-appsync-resolver-mapping-template-reference-dynamodb-putitem
+     */
+    putItem: DynamoIntegrationCall<
+      "putItem",
+      <
+        Key extends TableKey<
+          Item,
+          PartitionKey,
+          RangeKey,
+          JsonFormat.AttributeValue
+        >,
+        ConditionExpression extends string | undefined = undefined
+      >(input: {
+        key: Key;
+        attributeValues: ToAttributeMap<
+          Omit<
+            Narrow<Item, AttributeKeyToObject<Key>, JsonFormat.Document>,
+            Exclude<PartitionKey | RangeKey, undefined>
+          >
+        >;
+        condition?: DynamoExpression<ConditionExpression>;
+        _version?: number;
+      }) => Narrow<Item, AttributeKeyToObject<Key>, JsonFormat.Document>
+    >;
 
-  /**
-   * @see https://docs.aws.amazon.com/appsync/latest/devguide/resolver-mapping-template-reference-dynamodb.html#aws-appsync-resolver-mapping-template-reference-dynamodb-deleteitem
-   *
-   * @returns the previous item.
-   */
-  deleteItem: DynamoIntegrationCall<
-    "deleteItem",
-    <
-      Key extends TableKey<
-        Item,
-        PartitionKey,
-        RangeKey,
-        JsonFormat.AttributeValue
-      >,
-      ConditionExpression extends string | undefined
-    >(input: {
-      key: Key;
-      condition?: DynamoExpression<ConditionExpression>;
-      _version?: number;
-    }) => Narrow<Item, AttributeKeyToObject<Key>, JsonFormat.Document>
-  >;
+    /**
+     * @see https://docs.aws.amazon.com/appsync/latest/devguide/resolver-mapping-template-reference-dynamodb.html#aws-appsync-resolver-mapping-template-reference-dynamodb-updateitem
+     *
+     * @returns the updated the item
+     */
+    updateItem: DynamoIntegrationCall<
+      "updateItem",
+      <
+        Key extends TableKey<
+          Item,
+          PartitionKey,
+          RangeKey,
+          JsonFormat.AttributeValue
+        >,
+        UpdateExpression extends string,
+        ConditionExpression extends string | undefined
+      >(input: {
+        key: Key;
+        update: DynamoExpression<UpdateExpression>;
+        condition?: DynamoExpression<ConditionExpression>;
+        _version?: number;
+      }) => Narrow<Item, AttributeKeyToObject<Key>, JsonFormat.Document>
+    >;
 
-  /**
-   * @see https://docs.aws.amazon.com/appsync/latest/devguide/resolver-mapping-template-reference-dynamodb.html#aws-appsync-resolver-mapping-template-reference-dynamodb-query
-   */
-  query: DynamoIntegrationCall<
-    "query",
-    <Query extends string, Filter extends string | undefined>(input: {
-      query: DynamoExpression<Query>;
-      filter?: DynamoExpression<Filter>;
-      index?: string;
-      nextToken?: string;
-      limit?: number;
-      scanIndexForward?: boolean;
-      consistentRead?: boolean;
-      select?: "ALL_ATTRIBUTES" | "ALL_PROJECTED_ATTRIBUTES";
-    }) => {
-      items: Item[];
-      nextToken: string;
-      scannedCount: number;
-    }
-  >;
+    /**
+     * @see https://docs.aws.amazon.com/appsync/latest/devguide/resolver-mapping-template-reference-dynamodb.html#aws-appsync-resolver-mapping-template-reference-dynamodb-deleteitem
+     *
+     * @returns the previous item.
+     */
+    deleteItem: DynamoIntegrationCall<
+      "deleteItem",
+      <
+        Key extends TableKey<
+          Item,
+          PartitionKey,
+          RangeKey,
+          JsonFormat.AttributeValue
+        >,
+        ConditionExpression extends string | undefined
+      >(input: {
+        key: Key;
+        condition?: DynamoExpression<ConditionExpression>;
+        _version?: number;
+      }) => Narrow<Item, AttributeKeyToObject<Key>, JsonFormat.Document>
+    >;
+
+    /**
+     * @see https://docs.aws.amazon.com/appsync/latest/devguide/resolver-mapping-template-reference-dynamodb.html#aws-appsync-resolver-mapping-template-reference-dynamodb-query
+     */
+    query: DynamoIntegrationCall<
+      "query",
+      <Query extends string, Filter extends string | undefined>(input: {
+        query: DynamoExpression<Query>;
+        filter?: DynamoExpression<Filter>;
+        index?: string;
+        nextToken?: string;
+        limit?: number;
+        scanIndexForward?: boolean;
+        consistentRead?: boolean;
+        select?: "ALL_ATTRIBUTES" | "ALL_PROJECTED_ATTRIBUTES";
+      }) => {
+        items: Item[];
+        nextToken: string;
+        scannedCount: number;
+      }
+    >;
+  };
 }
 
 class BaseTable<
@@ -261,145 +275,144 @@ class BaseTable<
     RangeKey: RangeKey;
   };
 
+  public readonly appsync;
+
   constructor(readonly resource: aws_dynamodb.ITable) {
     this.tableName = resource.tableName;
     this.tableArn = resource.tableArn;
+
+    this.appsync = {
+      getItem: this.makeTableIntegration("getItem", {
+        appSyncVtl: {
+          request(call, vtl) {
+            const input = vtl.eval(
+              assertNodeKind<ObjectLiteralExpr>(
+                call.getArgument("input")?.expr,
+                "ObjectLiteralExpr"
+              )
+            );
+            const request = vtl.var(
+              '{"operation": "GetItem", "version": "2018-05-29"}'
+            );
+            vtl.qr(`${request}.put('key', ${input}.get('key'))`);
+            addIfDefined(vtl, input, request, "consistentRead");
+
+            return vtl.json(request);
+          },
+        },
+      }),
+
+      putItem: this.makeTableIntegration("putItem", {
+        appSyncVtl: {
+          request: (call, vtl) => {
+            const input = vtl.eval(
+              assertNodeKind<ObjectLiteralExpr>(
+                call.getArgument("input")?.expr,
+                "ObjectLiteralExpr"
+              )
+            );
+            const request = vtl.var(
+              '{"operation": "PutItem", "version": "2018-05-29"}'
+            );
+            vtl.qr(`${request}.put('key', ${input}.get('key'))`);
+            vtl.qr(
+              `${request}.put('attributeValues', ${input}.get('attributeValues'))`
+            );
+            addIfDefined(vtl, input, request, "condition");
+            addIfDefined(vtl, input, request, "_version");
+
+            return vtl.json(request);
+          },
+        },
+      }),
+
+      updateItem: this.makeTableIntegration("updateItem", {
+        appSyncVtl: {
+          request: (call, vtl) => {
+            const input = vtl.eval(
+              assertNodeKind<ObjectLiteralExpr>(
+                call.getArgument("input")?.expr,
+                "ObjectLiteralExpr"
+              )
+            );
+            const request = vtl.var(
+              '{"operation": "UpdateItem", "version": "2018-05-29"}'
+            );
+            vtl.qr(`${request}.put('key', ${input}.get('key'))`);
+            vtl.qr(`${request}.put('update', ${input}.get('update'))`);
+            addIfDefined(vtl, input, request, "condition");
+            addIfDefined(vtl, input, request, "_version");
+
+            return vtl.json(request);
+          },
+        },
+      }),
+
+      deleteItem: this.makeTableIntegration("deleteItem", {
+        appSyncVtl: {
+          request: (call, vtl) => {
+            const input = vtl.eval(
+              assertNodeKind<ObjectLiteralExpr>(
+                call.getArgument("input")?.expr,
+                "ObjectLiteralExpr"
+              )
+            );
+            const request = vtl.var(
+              '{"operation": "DeleteItem", "version": "2018-05-29"}'
+            );
+            vtl.qr(`${request}.put('key', ${input}.get('key'))`);
+            addIfDefined(vtl, input, request, "condition");
+            addIfDefined(vtl, input, request, "_version");
+
+            return vtl.json(request);
+          },
+        },
+      }),
+
+      query: this.makeTableIntegration("query", {
+        appSyncVtl: {
+          request: (call, vtl) => {
+            const input = vtl.eval(
+              assertNodeKind<ObjectLiteralExpr>(
+                call.getArgument("input")?.expr,
+                "ObjectLiteralExpr"
+              )
+            );
+            const request = vtl.var(
+              '{"operation": "Query", "version": "2018-05-29"}'
+            );
+            vtl.qr(`${request}.put('query', ${input}.get('query'))`);
+            addIfDefined(vtl, input, request, "index");
+            addIfDefined(vtl, input, request, "nextToken");
+            addIfDefined(vtl, input, request, "limit");
+            addIfDefined(vtl, input, request, "scanIndexForward");
+            addIfDefined(vtl, input, request, "consistentRead");
+            addIfDefined(vtl, input, request, "select");
+
+            return vtl.json(request);
+          },
+        },
+      }),
+    } as const;
   }
 
-  public getItem = this.makeTableIntegration("getItem", {
-    appSyncVtl: {
-      request(call, vtl) {
-        const input = vtl.eval(
-          assertNodeKind<ObjectLiteralExpr>(
-            call.getArgument("input")?.expr,
-            "ObjectLiteralExpr"
-          )
-        );
-        const request = vtl.var(
-          '{"operation": "GetItem", "version": "2018-05-29"}'
-        );
-        vtl.qr(`${request}.put('key', ${input}.get('key'))`);
-        addIfDefined(vtl, input, request, "consistentRead");
-
-        return vtl.json(request);
-      },
-    },
-  });
-
-  public putItem = this.makeTableIntegration("putItem", {
-    appSyncVtl: {
-      request: (call, vtl) => {
-        const input = vtl.eval(
-          assertNodeKind<ObjectLiteralExpr>(
-            call.getArgument("input")?.expr,
-            "ObjectLiteralExpr"
-          )
-        );
-        const request = vtl.var(
-          '{"operation": "PutItem", "version": "2018-05-29"}'
-        );
-        vtl.qr(`${request}.put('key', ${input}.get('key'))`);
-        vtl.qr(
-          `${request}.put('attributeValues', ${input}.get('attributeValues'))`
-        );
-        addIfDefined(vtl, input, request, "condition");
-        addIfDefined(vtl, input, request, "_version");
-
-        return vtl.json(request);
-      },
-    },
-  });
-
-  public updateItem = this.makeTableIntegration("updateItem", {
-    appSyncVtl: {
-      request: (call, vtl) => {
-        const input = vtl.eval(
-          assertNodeKind<ObjectLiteralExpr>(
-            call.getArgument("input")?.expr,
-            "ObjectLiteralExpr"
-          )
-        );
-        const request = vtl.var(
-          '{"operation": "UpdateItem", "version": "2018-05-29"}'
-        );
-        vtl.qr(`${request}.put('key', ${input}.get('key'))`);
-        vtl.qr(`${request}.put('update', ${input}.get('update'))`);
-        addIfDefined(vtl, input, request, "condition");
-        addIfDefined(vtl, input, request, "_version");
-
-        return vtl.json(request);
-      },
-    },
-  });
-
-  public deleteItem = this.makeTableIntegration("deleteItem", {
-    appSyncVtl: {
-      request: (call, vtl) => {
-        const input = vtl.eval(
-          assertNodeKind<ObjectLiteralExpr>(
-            call.getArgument("input")?.expr,
-            "ObjectLiteralExpr"
-          )
-        );
-        const request = vtl.var(
-          '{"operation": "DeleteItem", "version": "2018-05-29"}'
-        );
-        vtl.qr(`${request}.put('key', ${input}.get('key'))`);
-        addIfDefined(vtl, input, request, "condition");
-        addIfDefined(vtl, input, request, "_version");
-
-        return vtl.json(request);
-      },
-    },
-  });
-
-  public query = this.makeTableIntegration("query", {
-    appSyncVtl: {
-      request: (call, vtl) => {
-        const input = vtl.eval(
-          assertNodeKind<ObjectLiteralExpr>(
-            call.getArgument("input")?.expr,
-            "ObjectLiteralExpr"
-          )
-        );
-        const request = vtl.var(
-          '{"operation": "Query", "version": "2018-05-29"}'
-        );
-        vtl.qr(`${request}.put('query', ${input}.get('query'))`);
-        addIfDefined(vtl, input, request, "index");
-        addIfDefined(vtl, input, request, "nextToken");
-        addIfDefined(vtl, input, request, "limit");
-        addIfDefined(vtl, input, request, "scanIndexForward");
-        addIfDefined(vtl, input, request, "consistentRead");
-        addIfDefined(vtl, input, request, "select");
-
-        return vtl.json(request);
-      },
-    },
-  });
-
   private makeTableIntegration<
-    K extends Exclude<
-      keyof ITable<Item, PartitionKey, RangeKey>,
-      | "kind"
-      | "resource"
-      | "_brand"
-      | "tableName"
-      | "tableArn"
-      | "functionlessKind"
-    >
+    K extends keyof ITable<Item, PartitionKey, RangeKey>["appsync"]
   >(
     methodName: K,
     integration: Omit<
-      IntegrationInput<K, ITable<Item, PartitionKey, RangeKey>[K]>,
+      IntegrationInput<K, ITable<Item, PartitionKey, RangeKey>["appsync"][K]>,
       "kind" | "appSyncVtl"
     > & {
       appSyncVtl: Omit<AppSyncVtlIntegration, "dataSource" | "dataSourceId">;
     }
-  ): DynamoIntegrationCall<K, ITable<Item, PartitionKey, RangeKey>[K]> {
+  ): DynamoIntegrationCall<
+    K,
+    ITable<Item, PartitionKey, RangeKey>["appsync"][K]
+  > {
     return makeIntegration<
       `Table.${K}`,
-      ITable<Item, PartitionKey, RangeKey>[K]
+      ITable<Item, PartitionKey, RangeKey>["appsync"][K]
     >({
       ...integration,
       kind: `Table.${methodName}`,

--- a/test-app/src/message-board.ts
+++ b/test-app/src/message-board.ts
@@ -70,7 +70,7 @@ new AppsyncResolver<{ postId: string }, Post | undefined>(
     fieldName: "getPost",
   },
   ($context) => {
-    return database.getItem({
+    return database.appsync.getItem({
       key: {
         pk: {
           S: `Post|${$context.arguments.postId}`,
@@ -96,7 +96,7 @@ new AppsyncResolver<
     fieldName: "comments",
   },
   ($context) => {
-    const response = database.query({
+    const response = database.appsync.query({
       query: {
         expression: `pk = :pk and begins_with(#sk,:sk)`,
         expressionValues: {
@@ -137,7 +137,7 @@ export const createPost = new AppsyncResolver<{ title: string }, Post>(
   },
   ($context) => {
     const postId = $util.autoUlid();
-    const post = database.putItem({
+    const post = database.appsync.putItem({
       key: {
         pk: {
           S: `Post|${postId}`,
@@ -200,7 +200,7 @@ export const addComment = new AppsyncResolver<
   },
   ($context) => {
     const commentId = $util.autoUlid();
-    const comment = database.putItem({
+    const comment = database.appsync.putItem({
       key: {
         pk: {
           S: `Post|${$context.arguments.postId}`,
@@ -318,7 +318,7 @@ export const deletePost = new AppsyncResolver<
     fieldName: "deletePost",
   },
   ($context) => {
-    const item = database.getItem({
+    const item = database.appsync.getItem({
       key: {
         pk: {
           S: `Post|${$context.arguments.postId}`,
@@ -596,7 +596,7 @@ post.addField({
         Omit<Post, "comments">
       >
     ): CommentPage => {
-      const response = database.query({
+      const response = database.appsync.query({
         query: {
           expression: `pk = :pk and begins_with(#sk,:sk)`,
           expressionValues: {
@@ -639,7 +639,7 @@ api2.addQuery(
       },
     },
     ($context) => {
-      return database.getItem({
+      return database.appsync.getItem({
         key: {
           pk: {
             S: `Post|${$context.arguments.postId}`,

--- a/test-app/src/people-db.ts
+++ b/test-app/src/people-db.ts
@@ -149,7 +149,7 @@ export class PeopleDatabase extends Construct {
         fieldName: "addPerson",
       },
       ($context) => {
-        const person = this.personTable.putItem({
+        const person = this.personTable.appsync.putItem({
           key: {
             id: {
               S: $util.autoId(),
@@ -176,7 +176,7 @@ export class PeopleDatabase extends Construct {
         fieldName: "updateName",
       },
       ($context: AppsyncContext<MutationResolvers["updateName"]["args"]>) =>
-        this.personTable.updateItem({
+        this.personTable.appsync.updateItem({
           key: {
             id: $util.dynamodb.toDynamoDB($context.arguments.id),
           },
@@ -205,7 +205,7 @@ export class PeopleDatabase extends Construct {
         fieldName: "deletePerson",
       },
       ($context) =>
-        this.personTable.deleteItem({
+        this.personTable.appsync.deleteItem({
           key: {
             id: $util.dynamodb.toDynamoDB($context.arguments.id),
           },

--- a/test/table.test.ts
+++ b/test/table.test.ts
@@ -296,7 +296,7 @@ export function typeCheckSortKey() {
 test.each([fromTable, newTable])("get item", (table) => {
   appsyncTestCase(
     reflect((context: AppsyncContext<{ id: string }>): Item | undefined => {
-      return table.getItem({
+      return table.appsync.getItem({
         key: {
           id: {
             S: context.arguments.id,
@@ -310,7 +310,7 @@ test.each([fromTable, newTable])("get item", (table) => {
 test.each([fromTableSortKey, newTableSortKey])("get item", (table) => {
   appsyncTestCase(
     reflect((context: AppsyncContext<{ id: string }>): Item | undefined => {
-      return table.getItem({
+      return table.appsync.getItem({
         key: {
           id: {
             S: context.arguments.id,
@@ -329,7 +329,7 @@ test.each([fromTable, newTable])(
   (table) => {
     appsyncTestCase(
       reflect((context: AppsyncContext<{ id: string }>): Item | undefined => {
-        return table.getItem({
+        return table.appsync.getItem({
           key: {
             id: {
               S: context.arguments.id,
@@ -347,7 +347,7 @@ test.each([fromTableSortKey, newTableSortKey])(
   (table) => {
     appsyncTestCase(
       reflect((context: AppsyncContext<{ id: string }>): Item | undefined => {
-        return table.getItem({
+        return table.appsync.getItem({
           key: {
             id: {
               S: context.arguments.id,
@@ -369,7 +369,7 @@ test.each([fromTable, newTable])("put item", (table) => {
       (
         context: AppsyncContext<{ id: string; name: number }>
       ): Item | undefined => {
-        return table.putItem({
+        return table.appsync.putItem({
           key: {
             id: {
               S: context.arguments.id,
@@ -403,7 +403,7 @@ test.each([fromTableSortKey, newTableSortKey])("put item", (table) => {
       (
         context: AppsyncContext<{ id: string; name: number }>
       ): Item | undefined => {
-        return table.putItem({
+        return table.appsync.putItem({
           key: {
             id: {
               S: context.arguments.id,
@@ -433,7 +433,7 @@ test.each([fromTableSortKey, newTableSortKey])("put item", (table) => {
 test.each([fromTable, newTable])("update item", (table) => {
   appsyncTestCase(
     reflect((context: AppsyncContext<{ id: string }>): Item | undefined => {
-      return table.updateItem({
+      return table.appsync.updateItem({
         key: {
           id: {
             S: context.arguments.id,
@@ -453,7 +453,7 @@ test.each([fromTable, newTable])("update item", (table) => {
 test.each([fromTableSortKey, newTableSortKey])("update item", (table) => {
   appsyncTestCase(
     reflect((context: AppsyncContext<{ id: string }>): Item | undefined => {
-      return table.updateItem({
+      return table.appsync.updateItem({
         key: {
           id: {
             S: context.arguments.id,
@@ -476,7 +476,7 @@ test.each([fromTableSortKey, newTableSortKey])("update item", (table) => {
 test.each([fromTable, newTable])("delete item", (table) => {
   appsyncTestCase(
     reflect((context: AppsyncContext<{ id: string }>): Item | undefined => {
-      return table.deleteItem({
+      return table.appsync.deleteItem({
         key: {
           id: {
             S: context.arguments.id,
@@ -496,7 +496,7 @@ test.each([fromTable, newTable])("delete item", (table) => {
 test.each([fromTableSortKey, newTableSortKey])("delete item", (table) => {
   appsyncTestCase(
     reflect((context: AppsyncContext<{ id: string }>): Item | undefined => {
-      return table.deleteItem({
+      return table.appsync.deleteItem({
         key: {
           id: {
             S: context.arguments.id,
@@ -519,7 +519,7 @@ test.each([fromTableSortKey, newTableSortKey])("delete item", (table) => {
 test.each([fromTable, newTable])("query", (table) => {
   appsyncTestCase(
     reflect((context: AppsyncContext<{ id: string; sort: number }>): Item[] => {
-      return table.query({
+      return table.appsync.query({
         query: {
           expression: "id = :id and #name = :val",
           expressionNames: {
@@ -538,7 +538,7 @@ test.each([fromTable, newTable])("query", (table) => {
 test.each([fromTableSortKey, newTableSortKey])("query", (table) => {
   appsyncTestCase(
     reflect((context: AppsyncContext<{ id: string; sort: number }>): Item[] => {
-      return table.query({
+      return table.appsync.query({
         query: {
           expression: "id = :id and #name = :val",
           expressionNames: {

--- a/website/docs/concepts/appsync/code-generation.md
+++ b/website/docs/concepts/appsync/code-generation.md
@@ -65,14 +65,12 @@ export class PeopleDatabase extends Construct {
   constructor(scope: Construct, id: string) {
     super(scope, id);
     // Person type can be used to define your typesafe dynamodb table
-    this.personTable = Table.fromTable<Person, "id", undefined>(
-      new aws_dynamodb.Table(this, "table", {
-        partitionKey: {
-          name: "id",
-          type: aws_dynamodb.AttributeType.STRING,
-        },
-      })
-    );
+    this.personTable = Table.fromTable<Person, "id", undefined>(this, "table", {
+      partitionKey: {
+        name: "id",
+        type: aws_dynamodb.AttributeType.STRING,
+      },
+    });
     // QueryResolvers type can be used to get parameters for AppsyncResolver
     this.getPerson = new AppsyncResolver<
       QueryResolvers["addPerson"]["args"],
@@ -85,7 +83,7 @@ export class PeopleDatabase extends Construct {
         fieldName: "addPerson",
       },
       ($context) => {
-        const person = this.personTable.putItem({
+        const person = this.personTable.appsync.putItem({
           key: {
             id: {
               S: $util.autoId(),

--- a/website/docs/concepts/appsync/index.md
+++ b/website/docs/concepts/appsync/index.md
@@ -32,7 +32,7 @@ Functionless enables you to automatically generate the Resolver configurations (
 ```ts
 const getItem = new AppsyncResolver(
   ($context: AppsyncContext<{ key: string }>, key) => {
-    const item = myTable.get({
+    const item = myTable.appsync.get({
       key: {
         S: key,
       },

--- a/website/docs/concepts/appsync/supported-integrations.md
+++ b/website/docs/concepts/appsync/supported-integrations.md
@@ -149,13 +149,13 @@ This is useful so that you don't have to do work to convert the AttributeValue f
 
 ### getItem
 
-`getItem` gets a value from the database by its key and returns `undefined` if it does not exist.
+`appsync.getItem` gets a value from the database by its key and returns `undefined` if it does not exist.
 
 It invokes `DynamoDB:GetItem` API using the [GetItem Appsync Resolver](https://docs.aws.amazon.com/appsync/latest/devguide/resolver-mapping-template-reference-dynamodb.html#aws-appsync-resolver-mapping-template-reference-dynamodb-getitem).
 
 ```ts
 new AppsyncResolver(($context: AppsyncContext<{ id: string }>) => {
-  return table.getItem({
+  return table.appsync.getItem({
     key: {
       id: $util.dynamodb.toJson($context.arguments.id),
     },
@@ -174,14 +174,14 @@ table.deleteItem({
 
 ### putItem
 
-`putItem` writes a value into the database and overwrites the existing value if one already exists.
+`appsync.putItem` writes a value into the database and overwrites the existing value if one already exists.
 
 It invokes `DynamoDB:PutItem` API using the [PutItem Appsync Resolver](https://docs.aws.amazon.com/appsync/latest/devguide/resolver-mapping-template-reference-dynamodb.html#aws-appsync-resolver-mapping-template-reference-dynamodb-putItem).
 
 ```ts
 new AppsyncResolver(
   ($context: AppsyncContext<{ id: string; text: string }>) => {
-    return table.putItem({
+    return table.appsync.putItem({
       key: {
         id: $util.dynamodb.toJson($context.arguments.id),
       },
@@ -196,7 +196,7 @@ new AppsyncResolver(
 The `condition` property enables you to write [DynamoDB ConditionExpressions](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.ConditionExpressions.html) so that the item is only update if some condition is true.
 
 ```ts
-table.putItem({
+table.appsync.putItem({
   key: {
     id: $util.dynamodb.toJson($context.arguments.id),
   },
@@ -214,13 +214,13 @@ table.putItem({
 
 ### updateItem
 
-`updateItem` updates a value in the database using an UpdateExpression. If no value already exists, then the expression runs against the empty value and may result in unexpected behavior or an error.
+`appsync.updateItem` updates a value in the database using an UpdateExpression. If no value already exists, then the expression runs against the empty value and may result in unexpected behavior or an error.
 
 It invokes `DynamoDB:UpdateItem` API using the [UpdateItem Appsync Resolver](https://docs.aws.amazon.com/appsync/latest/devguide/resolver-mapping-template-reference-dynamodb.html#aws-appsync-resolver-mapping-template-reference-dynamodb-updateitem).
 
 ```ts
 new AppsyncResolver(($context: AppsyncContext<{ id: string }>) => {
-  return table.updateItem({
+  return table.appsync.updateItem({
     key: {
       id: $util.dynamodb.toJson($context.arguments.id),
     },
@@ -243,7 +243,7 @@ It invokes `DynamoDB:DeleteItem` API using the [DeleteItem Appsync Resolver](htt
 
 ```ts
 new AppsyncResolver(($context: AppsyncContext<{ id: string }>) => {
-  return table.deleteItem({
+  return table.appsync.deleteItem({
     key: {
       id: $util.dynamodb.toJson($context.arguments.id),
     },
@@ -254,7 +254,7 @@ new AppsyncResolver(($context: AppsyncContext<{ id: string }>) => {
 The `condition` property enables you to write [DynamoDB ConditionExpressions](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Expressions.ConditionExpressions.html) so that the item is only deleted if some condition is true.
 
 ```ts
-table.deleteItem({
+table.appsync.deleteItem({
   key: {
     id: $util.dynamodb.toJson($context.arguments.id),
   },
@@ -279,7 +279,7 @@ The `query` property contains a KeyConditionExpression that will apply a conditi
 
 ```ts
 new AppsyncResolver(($context: AppsyncContext<{ id: string }>) => {
-  return table.query({
+  return table.appsync.query({
     query: {
       expression: "ownerId = :ownerId",
       expressionValues: {
@@ -295,7 +295,7 @@ new AppsyncResolver(($context: AppsyncContext<{ id: string }>) => {
 The KeyConditionExpression is limited to only operating on the Partition and Range Key properties. To further filter the returned items from your query, use a FilterExpression.
 
 ```ts
-table.query({
+table.appsync.query({
   filter: {
     expression: "Price > :p",
     expressionValues: {
@@ -312,7 +312,7 @@ table.query({
 To paginate through results, use the `nextToken` field.
 
 ```ts
-table.query({
+table.appsync.query({
   nextToken: paginationToken,
 });
 ```
@@ -320,7 +320,7 @@ table.query({
 This token is made available in the query's response payload.
 
 ```ts
-const response = table.query(..);
+const response = table.appsync.query(..);
 response.nextToken;
 ```
 

--- a/website/docs/concepts/appsync/usage.md
+++ b/website/docs/concepts/appsync/usage.md
@@ -201,7 +201,7 @@ const getPerson = new AppsyncField({
     argName: appsync.Field.string()
   }
 }, ($context) => {
-  return table.getItem({
+  return table.appsync.getItem({
     key: {
       id: {
         S: $context.arguments.id
@@ -256,17 +256,17 @@ myTable.get();
 
 ```ts
 // you cannot in-line a call as the if condition, store it as a variable first
-if (myTable.get()) {
+if (myTable.appsync.getItem(..)) {
 }
 
 if (condition) {
   // it is not currently possible to conditionally call a service, but this will be supported at a later time
-  myTable.get();
+  myTable.appsync.getItem(..);
 }
 
 for (const item in list) {
   // resolvers cannot be contained within a loop
-  myTable.get();
+  myTable.appsync.getItem(..);
 }
 ```
 

--- a/website/docs/concepts/table.md
+++ b/website/docs/concepts/table.md
@@ -97,13 +97,11 @@ Remember: plumbing such as IAM Policies and Environment Variables are automatica
 
 ## Call from an Appsync Resolver
 
-AWS Appsync has a purpose-built integration for DynamoDB that takes care of un-marshalling the Attribute Value JSON format to standard JSON for GraphQL compatibility. These integration methods are exposed as methods directly on the Table Construct.
-
-**TODO**: This is subject to change, see [Issue XYZ](https://github.com/functionless/functionless/issues/33).
+AWS Appsync has a purpose-built integration for DynamoDB that takes care of un-marshalling the Attribute Value JSON format to standard JSON for GraphQL compatibility. These integration methods are exposed as methods on the `Table.appsync` property.
 
 ```ts
 new AppsyncResolver(($context) => {
-  return table.get({
+  return table.appsync.get({
     itemId: {
       S: $context.itemId,
     },


### PR DESCRIPTION
Fixes #132 

The `Table` Resource used to expose Integrations, `getItem`, `putItem`, etc. that were only relevant to AWS Appsync Resolvers. This caused confusion where they were expected to be useful everywhere.

These appsync-specific integrations are now moved to the `appsync` property to more obviously represent this constraint.

Old behavior:
```ts
new AppsyncResolver(scope, id, () => {
  return table.getItem(..);
});
```

New behavior:
```ts
new AppsyncResolver(scope, id, () => {
  return table.appsync.getItem(..);
});
```

BREAKING CHANGE: Integration methods, `getItem`, `putItem`, `updateItem`, `deleteItem` and `query` on `Table` moved to `Table.appsync`.