### PR TITLE
feat(aws-sdk): rename TableName and FunctionName to Table and Function

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ const validatePostWorkflow = new StepFunction(
     const validationResult = validatePost(post);
     if (validationResult.status === "Not Cool") {
       $AWS.DynamoDB.DeleteItem({
-        TableName: postTable,
+        Table: postTable,
         Key: {
           postId: {
             S: post.postId,

--- a/src/error-code.ts
+++ b/src/error-code.ts
@@ -285,7 +285,7 @@ export namespace ErrorCodes {
    * new Function(this, 'func', async () => {
    *    // valid use of a Table
    *    const $AWS.DynamoDB.GetItem({
-   *        TableName: table,
+   *        Table: table,
    *        ...
    *    })
    *    // invalid - .resource is not available
@@ -345,7 +345,7 @@ export namespace ErrorCodes {
    * ```ts
    * new AwsMethod({
    *   request: ($input) => $AWS.DynamoDB.GetItem({
-   *     TableName: table,
+   *     Table: table,
    *     // invalid, all property names must be literals
    *     [computedProperty]: prop
    *   })
@@ -400,7 +400,7 @@ export namespace ErrorCodes {
    *
    * ```ts
    * const input = {
-   *   TableName: table,
+   *   Table: table,
    *   Key: {
    *     // etc.
    *   }
@@ -413,7 +413,7 @@ export namespace ErrorCodes {
    *
    * ```ts
    * $AWS.DynamoDB.GetItem({
-   *   TableName: table,
+   *   Table: table,
    *   Key: {
    *     // etc.
    *   }
@@ -437,7 +437,7 @@ export namespace ErrorCodes {
    *   response: () => {
    *     // INVALID! - you cannot call an integration from within a response mapping template
    *     return $AWS.DynamoDB.GetItem({
-   *       TableName: table,
+   *       Table: table,
    *       ...
    *     });
    *   }

--- a/src/expression.ts
+++ b/src/expression.ts
@@ -372,6 +372,18 @@ export class PropAssignExpr extends BaseExpr<
     expr.setParent(this);
   }
 
+  /**
+   * @returns the name of this property if it is statically known (an Identifier or StringLiteralExpr).
+   */
+  public tryGetName(): string | undefined {
+    if (isIdentifier(this.name)) {
+      return this.name.name;
+    } else if (isStringLiteralExpr(this.name)) {
+      return this.name.value;
+    }
+    return undefined;
+  }
+
   public clone(): this {
     return new PropAssignExpr(this.name.clone(), this.expr.clone()) as this;
   }

--- a/src/step-function.ts
+++ b/src/step-function.ts
@@ -749,7 +749,7 @@ export interface StepFunctionProps
  *
  * const getItem = new ExpressStepFunction(this, "F", () => {
  *   return f.$AWS.DynamoDB.GetItem({
- *     TableName: table,
+ *     Table: table,
  *     Key: {
  *       ..
  *     }
@@ -851,7 +851,7 @@ interface BaseExpressStepFunction<
  *
  * const getItem = new ExpressStepFunction(this, "F", () => {
  *   return f.$AWS.DynamoDB.GetItem({
- *     TableName: table,
+ *     Table: table,
  *     Key: {
  *       ..
  *     }
@@ -1048,7 +1048,7 @@ export interface ExpressStepFunction<
  *
  * const getItem = new StepFunction(this, "F", () => {
  *   return f.$AWS.DynamoDB.GetItem({
- *     TableName: table,
+ *     Table: table,
  *     Key: {
  *       ..
  *     }
@@ -1227,7 +1227,7 @@ interface BaseStandardStepFunction<
  *
  * const getItem = new StepFunction(this, "F", () => {
  *   return f.$AWS.DynamoDB.GetItem({
- *     TableName: table,
+ *     Table: table,
  *     Key: {
  *       ..
  *     }

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,6 +1,11 @@
 import { Construct } from "constructs";
 import ts from "typescript";
-import { Expr } from "./expression";
+import {
+  Expr,
+  Identifier,
+  ObjectLiteralExpr,
+  PropAssignExpr,
+} from "./expression";
 import {
   isArrayLiteralExpr,
   isBinaryExpr,
@@ -24,6 +29,7 @@ import {
   isUndefinedLiteralExpr,
 } from "./guards";
 import { FunctionlessNode } from "./node";
+import { visitEachChild } from "./visit";
 
 export type AnyFunction = (...args: any[]) => any;
 
@@ -309,4 +315,30 @@ export class DeterministicNameGenerator {
     }
     return this.generatedNames.get(node)!;
   }
+}
+
+/**
+ * Rename all {@link PropAssignExpr} expressions within the {@link obj} where the
+ * name is statically known and matches a property in the {@link rename} map.
+ */
+export function renameObjectProperties(
+  obj: ObjectLiteralExpr,
+  rename: Record<string, string>
+) {
+  const newObj = visitEachChild(obj, (node) => {
+    if (isPropAssignExpr(node)) {
+      const propName = node.tryGetName();
+      if (propName !== undefined && propName in rename) {
+        const substituteName = rename[propName];
+
+        return new PropAssignExpr(
+          new Identifier(substituteName),
+          node.expr.clone()
+        );
+      }
+    }
+    return node;
+  });
+  newObj.parent = obj.parent;
+  return newObj;
 }

--- a/test-app/src/api-test.ts
+++ b/test-app/src/api-test.ts
@@ -129,7 +129,7 @@ new AwsMethod(
   },
   ($input) =>
     $AWS.DynamoDB.GetItem({
-      TableName: table,
+      Table: table,
       Key: {
         id: {
           S: `${$input.params("id")}`,

--- a/test-app/src/message-board.ts
+++ b/test-app/src/message-board.ts
@@ -174,7 +174,7 @@ export const commentValidationWorkflow = new StepFunction<
   const status = validateComment({ commentText: input.commentText });
   if (status === "bad") {
     $AWS.DynamoDB.DeleteItem({
-      TableName: database,
+      Table: database,
       Key: {
         pk: {
           S: `Post|${input.postId}`,
@@ -254,7 +254,7 @@ const deleteWorkflow = new StepFunction<{ postId: string }, void>(
     while (true) {
       try {
         const comments = $AWS.DynamoDB.Query({
-          TableName: database,
+          Table: database,
           KeyConditionExpression: `pk = :pk`,
           ExpressionAttributeValues: {
             ":pk": {
@@ -266,7 +266,7 @@ const deleteWorkflow = new StepFunction<{ postId: string }, void>(
         if (comments.Items?.[0] !== undefined) {
           $SFN.forEach(comments.Items, (comment) =>
             $AWS.DynamoDB.DeleteItem({
-              TableName: database,
+              Table: database,
               Key: {
                 pk: comment.pk,
                 sk: comment.sk,
@@ -275,7 +275,7 @@ const deleteWorkflow = new StepFunction<{ postId: string }, void>(
           );
         } else {
           $AWS.DynamoDB.DeleteItem({
-            TableName: database,
+            Table: database,
             Key: {
               pk: {
                 S: `Post|${input.postId}`,
@@ -483,7 +483,7 @@ new Function(
     });
     console.log(deleteWorkflow.describeExecution(exc.executionArn));
     $AWS.DynamoDB.PutItem({
-      TableName: database,
+      Table: database,
       Item: {
         pk: { S: "Post|1" },
         sk: { S: "Post" },
@@ -494,7 +494,7 @@ new Function(
       },
     });
     const item = $AWS.DynamoDB.GetItem({
-      TableName: database,
+      Table: database,
       ConsistentRead: true,
       Key: { pk: { S: "Post|1" }, sk: { S: "Post" } },
     });

--- a/test-app/src/people-db.ts
+++ b/test-app/src/people-db.ts
@@ -86,7 +86,7 @@ export class PeopleDatabase extends Construct {
       },
       (input) => {
         const person = $AWS.DynamoDB.GetItem({
-          TableName: this.personTable,
+          Table: this.personTable,
           Key: {
             id: {
               S: input.id,

--- a/test/__snapshots__/step-function.test.ts.snap
+++ b/test/__snapshots__/step-function.test.ts.snap
@@ -205,7 +205,7 @@ Object {
 
 exports[`call AWS.DynamoDB.GetItem, then Lambda and return LiteralExpr 1`] = `
 Object {
-  "StartAt": "person = $AWS.DynamoDB.GetItem({TableName: personTable, Key: {id: {S: input",
+  "StartAt": "person = $AWS.DynamoDB.GetItem({Table: personTable, Key: {id: {S: input.id}",
   "States": Object {
     "if(person.Item == undefined)": Object {
       "Choices": Array [
@@ -226,7 +226,7 @@ Object {
       "Default": "score = computeScore({id: person.Item.id.S, name: person.Item.name.S})",
       "Type": "Choice",
     },
-    "person = $AWS.DynamoDB.GetItem({TableName: personTable, Key: {id: {S: input": Object {
+    "person = $AWS.DynamoDB.GetItem({Table: personTable, Key: {id: {S: input.id}": Object {
       "Next": "if(person.Item == undefined)",
       "Parameters": Object {
         "Key": Object {
@@ -535,7 +535,7 @@ exports[`conditionally call DynamoDB and then void 1`] = `
 Object {
   "StartAt": "if(input.id == \\"hello\\")",
   "States": Object {
-    "$AWS.DynamoDB.GetItem({TableName: personTable, Key: {id: {S: input.id}}})": Object {
+    "$AWS.DynamoDB.GetItem({Table: personTable, Key: {id: {S: input.id}}})": Object {
       "Next": "return null",
       "Parameters": Object {
         "Key": Object {
@@ -552,7 +552,7 @@ Object {
     "if(input.id == \\"hello\\")": Object {
       "Choices": Array [
         Object {
-          "Next": "$AWS.DynamoDB.GetItem({TableName: personTable, Key: {id: {S: input.id}}})",
+          "Next": "$AWS.DynamoDB.GetItem({Table: personTable, Key: {id: {S: input.id}}})",
           "StringEquals": "hello",
           "Variable": "$.id",
         },
@@ -2634,7 +2634,7 @@ Object {
 
 exports[`return AWS.DynamoDB.GetItem 1`] = `
 Object {
-  "StartAt": "person = $AWS.DynamoDB.GetItem({TableName: personTable, Key: {id: {S: input",
+  "StartAt": "person = $AWS.DynamoDB.GetItem({Table: personTable, Key: {id: {S: input.id}",
   "States": Object {
     "if(person.Item == undefined)": Object {
       "Choices": Array [
@@ -2655,7 +2655,7 @@ Object {
       "Default": "return {id: person.Item.id.S, name: person.Item.name.S}",
       "Type": "Choice",
     },
-    "person = $AWS.DynamoDB.GetItem({TableName: personTable, Key: {id: {S: input": Object {
+    "person = $AWS.DynamoDB.GetItem({Table: personTable, Key: {id: {S: input.id}": Object {
       "Next": "if(person.Item == undefined)",
       "Parameters": Object {
         "Key": Object {

--- a/test/__snapshots__/validate.test.ts.snap
+++ b/test/__snapshots__/validate.test.ts.snap
@@ -13,12 +13,12 @@ https://functionless.org/docs/error-codes#awsmethod-request-must-have-exactly-on
 [7m  [0m [91m~~~~~~~~~~~~~~~~~~~~~~~[0m
 [7m64[0m   },
 [7m  [0m [91m~~~[0m
-[96mtest/test-files/api-gateway.ts[0m:[93m76[0m:[93m24[0m - [91merror[0m[90m Functionless(10011): [0mAPI Gateway does not support spread assignment expressions
+[96mtest/test-files/api-gateway.ts[0m:[93m76[0m:[93m20[0m - [91merror[0m[90m Functionless(10011): [0mAPI Gateway does not support spread assignment expressions
 
 https://functionless.org/docs/error-codes#api-gateway-does-not-support-spread-assignment-expressions
 
-[7m76[0m       TableName: table,
-[7m  [0m [91m                       [0m
+[7m76[0m       Table: table,
+[7m  [0m [91m                   [0m
 [7m77[0m       ...$input.data,
 [7m  [0m [91m~~~~~~~~~~~~~~~~~~~~[0m
 [96mtest/test-files/api-gateway.ts[0m:[93m77[0m:[93m22[0m - [91merror[0m[90m Functionless(10010): [0mAPI Gateway does not supported computed property names
@@ -35,8 +35,8 @@ https://functionless.org/docs/error-codes#api-gateway-response-mapping-template-
 
 [7m101[0m     return $AWS.DynamoDB.GetItem({
 [7m   [0m [91m          ~~~~~~~~~~~~~~~~~~~~~~~~[0m
-[7m102[0m       TableName: table,
-[7m   [0m [91m~~~~~~~~~~~~~~~~~~~~~~~[0m
+[7m102[0m       Table: table,
+[7m   [0m [91m~~~~~~~~~~~~~~~~~~~[0m
 [7m...[0m 
 [7m107[0m       },
 [7m   [0m [91m~~~~~~~~[0m

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -152,7 +152,7 @@ test("AWS integration with DynamoDB Table", () => {
       }>
     ) =>
       $AWS.DynamoDB.GetItem({
-        TableName: table,
+        Table: table,
         Key: {
           pk: {
             S: $input.data.id,
@@ -213,7 +213,7 @@ test("return $input.data", () => {
       }>
     ) =>
       $AWS.DynamoDB.GetItem({
-        TableName: table,
+        Table: table,
         Key: {
           pk: {
             S: $input.data.id,
@@ -250,7 +250,7 @@ test("return $input.data.list[0]", () => {
       }>
     ) =>
       $AWS.DynamoDB.GetItem({
-        TableName: table,
+        Table: table,
         Key: {
           pk: {
             S: $input.data.list[0],

--- a/test/eventbus.localstack.test.ts
+++ b/test/eventbus.localstack.test.ts
@@ -58,7 +58,7 @@ localstackTestSuite("eventBusStack", (testResource) => {
             Item: {
               id: { S: event.id },
             },
-            TableName: table,
+            Table: table,
           });
         }
       );

--- a/test/function.localstack.test.ts
+++ b/test/function.localstack.test.ts
@@ -731,7 +731,7 @@ localstackTestSuite("functionStack", (testResource, _stack, _app) => {
         localstackClientConfig,
         async () => {
           get({
-            TableName: flTable,
+            Table: flTable,
             Key: {
               key: { S: "hi" },
             },
@@ -888,14 +888,14 @@ localstackTestSuite("functionStack", (testResource, _stack, _app) => {
         localstackClientConfig,
         async () => {
           PutItem({
-            TableName: table,
+            Table: table,
             Item: {
               key: { S: "key" },
               value: { S: "wee" },
             },
           });
           const item = GetItem({
-            TableName: table,
+            Table: table,
             Key: {
               key: {
                 S: "key",
@@ -904,7 +904,7 @@ localstackTestSuite("functionStack", (testResource, _stack, _app) => {
             ConsistentRead: true,
           });
           UpdateItem({
-            TableName: table,
+            Table: table,
             Key: {
               key: { S: "key" },
             },
@@ -917,7 +917,7 @@ localstackTestSuite("functionStack", (testResource, _stack, _app) => {
             },
           });
           DeleteItem({
-            TableName: table,
+            Table: table,
             Key: {
               key: {
                 S: "key",
@@ -925,7 +925,7 @@ localstackTestSuite("functionStack", (testResource, _stack, _app) => {
             },
           });
           Query({
-            TableName: table,
+            Table: table,
             KeyConditionExpression: "#key = :key",
             ExpressionAttributeValues: {
               ":key": { S: "key" },
@@ -935,7 +935,7 @@ localstackTestSuite("functionStack", (testResource, _stack, _app) => {
             },
           });
           Scan({
-            TableName: table,
+            Table: table,
           });
           return item.Item?.key.S;
         }

--- a/test/step-function.test.ts
+++ b/test/step-function.test.ts
@@ -544,7 +544,7 @@ test("return AWS.DynamoDB.GetItem", () => {
     Person | undefined
   >(stack, "fn", (input) => {
     const person = $AWS.DynamoDB.GetItem({
-      TableName: personTable,
+      Table: personTable,
       Key: {
         id: {
           S: input.id,
@@ -572,7 +572,7 @@ test("call AWS.DynamoDB.GetItem, then Lambda and return LiteralExpr", () => {
     (Person & { score: number }) | undefined
   >(stack, "fn", (input) => {
     const person = $AWS.DynamoDB.GetItem({
-      TableName: personTable,
+      Table: personTable,
       Key: {
         id: {
           S: input.id,
@@ -626,7 +626,7 @@ test("conditionally call DynamoDB and then void", () => {
     (input): void => {
       if (input.id === "hello") {
         $AWS.DynamoDB.GetItem({
-          TableName: personTable,
+          Table: personTable,
           Key: {
             id: {
               S: input.id,

--- a/test/table.test.ts
+++ b/test/table.test.ts
@@ -113,12 +113,12 @@ export function typeCheck() {
 
   // Test1: type checking should work for Table
   $AWS.DynamoDB.GetItem({
-    TableName: newTable,
+    Table: newTable,
     // @ts-expect-error - missing id prop
     Key: {},
   });
   $AWS.DynamoDB.PutItem({
-    TableName: newTable,
+    Table: newTable,
     Item: {
       id: {
         S: "",
@@ -133,12 +133,12 @@ export function typeCheck() {
     },
   });
   $AWS.DynamoDB.DeleteItem({
-    TableName: newTable,
+    Table: newTable,
     // @ts-expect-error - missing id prop
     Key: {},
   });
   $AWS.DynamoDB.UpdateItem({
-    TableName: newTable,
+    Table: newTable,
     // @ts-expect-error - missing id prop
     Key: {},
     UpdateExpression: "",
@@ -146,12 +146,12 @@ export function typeCheck() {
 
   // Test2: type checking should work for ITable
   $AWS.DynamoDB.GetItem({
-    TableName: fromTable,
+    Table: fromTable,
     // @ts-expect-error - missing id prop
     Key: {},
   });
   $AWS.DynamoDB.PutItem({
-    TableName: fromTable,
+    Table: fromTable,
     Item: {
       id: {
         S: "",
@@ -166,12 +166,12 @@ export function typeCheck() {
     },
   });
   $AWS.DynamoDB.DeleteItem({
-    TableName: fromTable,
+    Table: fromTable,
     // @ts-expect-error - missing id prop
     Key: {},
   });
   $AWS.DynamoDB.UpdateItem({
-    TableName: fromTable,
+    Table: fromTable,
     // @ts-expect-error - missing id prop
     Key: {},
     UpdateExpression: "",
@@ -228,12 +228,12 @@ export function typeCheckSortKey() {
 
   // Test1: type checking should work for Table
   $AWS.DynamoDB.GetItem({
-    TableName: newTable,
+    Table: newTable,
     // @ts-expect-error - missing id prop
     Key: {},
   });
   $AWS.DynamoDB.PutItem({
-    TableName: newTable,
+    Table: newTable,
     Item: {
       id: {
         S: "",
@@ -248,12 +248,12 @@ export function typeCheckSortKey() {
     },
   });
   $AWS.DynamoDB.DeleteItem({
-    TableName: newTable,
+    Table: newTable,
     // @ts-expect-error - missing id prop
     Key: {},
   });
   $AWS.DynamoDB.UpdateItem({
-    TableName: newTable,
+    Table: newTable,
     // @ts-expect-error - missing id prop
     Key: {},
     UpdateExpression: "",
@@ -261,12 +261,12 @@ export function typeCheckSortKey() {
 
   // Test2: type checking should work for ITable
   $AWS.DynamoDB.GetItem({
-    TableName: fromTable,
+    Table: fromTable,
     // @ts-expect-error - missing id prop
     Key: {},
   });
   $AWS.DynamoDB.PutItem({
-    TableName: fromTable,
+    Table: fromTable,
     Item: {
       id: {
         S: "",
@@ -281,12 +281,12 @@ export function typeCheckSortKey() {
     },
   });
   $AWS.DynamoDB.DeleteItem({
-    TableName: fromTable,
+    Table: fromTable,
     // @ts-expect-error - missing id prop
     Key: {},
   });
   $AWS.DynamoDB.UpdateItem({
-    TableName: fromTable,
+    Table: fromTable,
     // @ts-expect-error - missing id prop
     Key: {},
     UpdateExpression: "",

--- a/test/test-files/api-gateway.ts
+++ b/test/test-files/api-gateway.ts
@@ -43,7 +43,7 @@ new AwsMethod(
   },
   ($input) =>
     $AWS.DynamoDB.GetItem({
-      TableName: table,
+      Table: table,
       Key: {
         id: {
           S: $input.params("id") as string,
@@ -73,7 +73,7 @@ new AwsMethod(
   },
   ($input) => {
     return $AWS.DynamoDB.GetItem({
-      TableName: table,
+      Table: table,
       ...$input.data,
       [$input.params("param")]: null,
     });
@@ -89,7 +89,7 @@ new AwsMethod(
   },
   ($input) =>
     $AWS.DynamoDB.GetItem({
-      TableName: table,
+      Table: table,
       Key: {
         id: {
           S: $input.params("id") as string,
@@ -99,7 +99,7 @@ new AwsMethod(
   ($input) => {
     // this is not allowed
     return $AWS.DynamoDB.GetItem({
-      TableName: table,
+      Table: table,
       Key: {
         id: {
           S: $input.params("id") as string,

--- a/website/docs/concepts/aws.md
+++ b/website/docs/concepts/aws.md
@@ -14,7 +14,7 @@ const table = Table.fromTable<Item, "pk">(..);
 new StepFunction(scope, "Func", (name: string) => {
   // call DynamoDB's DeleteItem API.
   $AWS.DynamoDB.DeleteItem({
-    TableName: table,
+    Table: table,
     Key: {
       name: {
         S: name

--- a/website/docs/concepts/function/index.md
+++ b/website/docs/concepts/function/index.md
@@ -153,7 +153,7 @@ const Table = Table.fromTable(scope, "Table");
 
 new Function(scope, "foo", async (id: string) => {
   return $AWS.DynamoDB.GetItem({
-    TableName: table,
+    Table: table,
     Key: {
       id: {
         S: id,
@@ -201,7 +201,7 @@ const table = new Table(this, 'table', { ... });
 new Function(this, 'func', async () => {
    // valid use of a Table
    const $AWS.DynamoDB.GetItem({
-       TableName: table,
+       Table: table,
        ...
    })
    // invalid - .resource is not available

--- a/website/docs/concepts/function/integrations.md
+++ b/website/docs/concepts/function/integrations.md
@@ -30,7 +30,7 @@ const Table = new Table(scope, "Table");
 
 new Function(scope, "foo", async (id: string) => {
   return $AWS.DynamoDB.GetItem({
-    TableName: table,
+    Table: table,
     Key: {
       id: {
         S: id,

--- a/website/docs/concepts/step-function/usage.md
+++ b/website/docs/concepts/step-function/usage.md
@@ -90,7 +90,7 @@ const table = Table.fromTable<Item, "pk">(new aws_dynamodb.Table(..));
 new StepFunction(stack, "Func", (name: string) => {
   // call DynamoDB's DeleteItem API.
   $AWS.DynamoDB.DeleteItem({
-    TableName: table,
+    Table: table,
     Key: {
       name: {
         S: name

--- a/website/docs/concepts/table.md
+++ b/website/docs/concepts/table.md
@@ -83,7 +83,7 @@ Use the [`$AWS`](./aws.md) SDK's DynamoDB APIs to access the Table from within a
 ```ts
 new StepFunction(scope, "Function", (itemId: string) => {
   return $AWS.DynamoDB.GetItem({
-    TableName: items,
+    Table: items,
     Key: {
       itemId: {
         S: itemId,

--- a/website/src/components/HomepageFeatures/index.tsx
+++ b/website/src/components/HomepageFeatures/index.tsx
@@ -162,7 +162,7 @@ const tasks = Table.fromTable<Task, "taskId">(this, "Tasks", {
     const status = validate({ commentText: input.commentText });
     if (status === "bad") {
       $AWS.DynamoDB.DeleteItem({
-        TableName: posts,
+        Table: posts,
         Key: {
           pk: {
             S: \`Post|\${input.postId}\`,


### PR DESCRIPTION
Fixes #241 

We received feedback that it was confusing how our `$AWS` Integrations exactly matched the AWS SDK's use of `TableName` and `FunctionName`. In Functionless, we pass the actual Table or Function Construct to these properties, not a string. As of this change, these fields are renamed to `Table` and `Function` so that they match the mental model of the developer - it isn't important to exactly match the AWS SDK's interface in this instance.

