### PR TITLE
fix: remove .only on function test, pin localstack

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -133,11 +133,15 @@
         "*.cts",
         "*.tsx"
       ],
+      "plugins": [
+        "no-only-tests"
+      ],
       "parserOptions": {
         "project": [
           "./tsconfig.dev.json",
           "./test-app/tsconfig.json",
-          "./website/tsconfig.json"
+          "./website/tsconfig.json",
+          "./test/tsconfig.json"
         ]
       },
       "rules": {
@@ -152,6 +156,12 @@
               "properties": "off",
               "parameterProperties": "off"
             }
+          }
+        ],
+        "no-only-tests/no-only-tests": [
+          "error",
+          {
+            "fix": true
           }
         ]
       }

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -161,7 +161,10 @@
         "no-only-tests/no-only-tests": [
           "error",
           {
-            "fix": true
+            "fix": true,
+            "block": [
+              "test."
+            ]
           }
         ]
       }

--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -100,6 +100,10 @@
       "type": "build"
     },
     {
+      "name": "eslint-plugin-no-only-tests",
+      "type": "build"
+    },
+    {
       "name": "eslint-plugin-prettier",
       "type": "build"
     },

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -93,10 +93,10 @@ const project = new CustomTypescriptProject({
     "@types/uuid",
     "amplify-appsync-simulator",
     "axios",
+    "eslint-plugin-no-only-tests",
     "graphql-request",
     "ts-node",
     "ts-patch",
-
     /**
      * For CDK Local Stack tests
      */
@@ -207,11 +207,13 @@ project.eslint.addRules({
 
 project.eslint.addOverride({
   files: ["*.ts", "*.mts", "*.cts", "*.tsx"],
+  plugins: ["no-only-tests"],
   parserOptions: {
     project: [
       "./tsconfig.dev.json",
       "./test-app/tsconfig.json",
       "./website/tsconfig.json",
+      "./test/tsconfig.json",
     ],
   },
   rules: {
@@ -228,6 +230,7 @@ project.eslint.addOverride({
         },
       },
     ],
+    "no-only-tests/no-only-tests": ["error", { fix: true }],
   },
 });
 

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -230,7 +230,7 @@ project.eslint.addOverride({
         },
       },
     ],
-    "no-only-tests/no-only-tests": ["error", { fix: true }],
+    "no-only-tests/no-only-tests": ["error", { fix: true, block: ["test."] }],
   },
 });
 

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "eslint-import-resolver-node": "^0.3.6",
     "eslint-import-resolver-typescript": "^2.7.1",
     "eslint-plugin-import": "^2.26.0",
+    "eslint-plugin-no-only-tests": "^2.6.0",
     "eslint-plugin-prettier": "^4.0.0",
     "graphql-request": "^4.3.0",
     "jest": "^27",

--- a/scripts/localstack
+++ b/scripts/localstack
@@ -3,7 +3,8 @@
 # Installs and runs localstack
 
 # install LocalStack cli and awslocal
-pip install localstack awscli-local[ver1]
+# TODO: remove pinned version - https://github.com/localstack/localstack/issues/6334
+pip install localstack==0.14.3.3 awscli-local[ver1]
 # install CDK Local
 npm install -g aws-cdk-local aws-cdk
 # Make sure to pull the latest version of the image

--- a/test/function.localstack.test.ts
+++ b/test/function.localstack.test.ts
@@ -128,6 +128,7 @@ localstackTestSuite("functionStack", (testResource, _stack, _app) => {
       async () => {}
     );
 
+  // eslint-disable-next-line no-only-tests/no-only-tests
   test.only = _testFunc(testResource.only);
 
   test(
@@ -845,7 +846,7 @@ localstackTestSuite("functionStack", (testResource, _stack, _app) => {
     `"hi"`
   );
 
-  test.only("import", (parent) => {
+  test("import", (parent) => {
     return new Function(
       parent,
       "function",

--- a/test/localstack.ts
+++ b/test/localstack.ts
@@ -157,6 +157,7 @@ export const localstackTestSuite = (
   testResource.skip = (name, resources, test) => {
     tests.push({ name, resources, test: test as any, skip: true, only: false });
   };
+  // eslint-disable-next-line no-only-tests/no-only-tests
   testResource.only = (name, resources, test) => {
     tests.push({ name, resources, test: test as any, skip: false, only: true });
   };
@@ -166,6 +167,7 @@ export const localstackTestSuite = (
 
   tests.forEach(({ name, test: testFunc, skip, only }, i) => {
     if (!skip) {
+      // eslint-disable-next-line no-only-tests/no-only-tests
       const t = only ? test.only : test;
       t(name, () => {
         const context = testContexts[i];

--- a/test/localstack.ts
+++ b/test/localstack.ts
@@ -157,7 +157,6 @@ export const localstackTestSuite = (
   testResource.skip = (name, resources, test) => {
     tests.push({ name, resources, test: test as any, skip: true, only: false });
   };
-  // eslint-disable-next-line no-only-tests/no-only-tests
   testResource.only = (name, resources, test) => {
     tests.push({ name, resources, test: test as any, skip: false, only: true });
   };

--- a/yarn.lock
+++ b/yarn.lock
@@ -3494,6 +3494,11 @@ eslint-plugin-import@^2.26.0:
     resolve "^1.22.0"
     tsconfig-paths "^3.14.1"
 
+eslint-plugin-no-only-tests@^2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-no-only-tests/-/eslint-plugin-no-only-tests-2.6.0.tgz#19f6c9620bda02b9b9221b436c5f070e42628d76"
+  integrity sha512-T9SmE/g6UV1uZo1oHAqOvL86XWl7Pl2EpRpnLI8g/bkJu+h7XBCB+1LnubRZ2CUQXj805vh4/CYZdnqtVaEo2Q==
+
 eslint-plugin-prettier@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/eslint-plugin-prettier/-/eslint-plugin-prettier-4.0.0.tgz#8b99d1e4b8b24a762472b4567992023619cb98e0"


### PR DESCRIPTION
* @thantos forgot to remove `.only` from a test. Do that now
* add eslint rule to remove `.only`
* pin localstack cli version https://github.com/localstack/localstack/issues/6334
* run localstack tests