### PR TITLE
chore: no-debugger

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -114,7 +114,8 @@
     "quote-props": "off",
     "@typescript-eslint/indent": "off",
     "brace-style": "off",
-    "@typescript-eslint/explicit-member-accessibility": "off"
+    "@typescript-eslint/explicit-member-accessibility": "off",
+    "no-debugger": "error"
   },
   "overrides": [
     {

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -203,6 +203,7 @@ project.eslint.addRules({
   "@typescript-eslint/member-ordering": "off",
   "brace-style": "off",
   "@typescript-eslint/explicit-member-accessibility": "off",
+  "no-debugger": "error",
 });
 
 project.eslint.addOverride({

--- a/src/asl.ts
+++ b/src/asl.ts
@@ -874,7 +874,6 @@ export class ASL {
       if (isAwaitExpr(expr.parent) || isReturnStmt(expr.parent)) {
         return this.eval(expr.expr, props);
       }
-      debugger;
       throw new SynthError(
         ErrorCodes.Integration_must_be_immediately_awaited_or_returned
       );
@@ -887,7 +886,6 @@ export class ASL {
       ) {
         return this.eval(expr.expr, props);
       }
-      debugger;
       throw new SynthError(
         ErrorCodes.Arrays_of_Integration_must_be_immediately_wrapped_in_Promise_all
       );
@@ -989,7 +987,6 @@ export class ASL {
         if (values?.expr && isPromiseArrayExpr(values?.expr)) {
           return this.eval(values.expr, props);
         }
-        debugger;
         throw new SynthError(ErrorCodes.Unsupported_Use_of_Promises);
       }
       throw new Error(
@@ -1061,7 +1058,6 @@ export class ASL {
     } else if (isAwaitExpr(expr)) {
       return this.eval(expr.expr, props);
     }
-    debugger;
     throw new Error(`cannot eval expression kind '${expr.kind}'`);
   }
 
@@ -1384,7 +1380,6 @@ export namespace ASL {
         .filter((e) => !isLiteralExpr(e))
         .map((e) => toJsonPath(e))})`;
     }
-    debugger;
     throw new Error(`cannot evaluate ${expr.kind} to JSON`);
   }
 
@@ -1414,7 +1409,6 @@ export namespace ASL {
       return elementAccessExprToJsonPath(expr);
     }
 
-    debugger;
     throw new Error(
       `expression kind '${expr.kind}' cannot be evaluated to a JSON Path expression.`
     );
@@ -1917,8 +1911,6 @@ export namespace ASL {
         // return aws_stepfunctions.Condition.str
       }
     }
-    debugger;
-
     throw new Error(`cannot evaluate expression: '${expr.kind}`);
   }
 }

--- a/src/compile.ts
+++ b/src/compile.ts
@@ -1014,9 +1014,7 @@ export function compile(
                    */
                   return ts.factory.createIdentifier(symbol.name);
                 }
-                debugger;
               }
-              debugger;
             }
           }
         }

--- a/src/declaration.ts
+++ b/src/declaration.ts
@@ -75,7 +75,6 @@ export function validateFunctionlessNode<E extends FunctionlessNode>(
   } else if (isErr(a)) {
     throw a.error;
   } else {
-    debugger;
     throw new SynthError(
       ErrorCodes.FunctionDecl_not_compiled_by_Functionless,
       `Expected input function to ${functionLocation} to be compiled by Functionless. Make sure you have the Functionless compiler plugin configured correctly.`

--- a/src/util.ts
+++ b/src/util.ts
@@ -80,7 +80,6 @@ export function ensure<T>(
   message: string
 ): asserts a is T {
   if (!is(a)) {
-    debugger;
     throw new Error(message);
   }
 }

--- a/src/visit.ts
+++ b/src/visit.ts
@@ -170,7 +170,6 @@ export function visitEachChild<T extends FunctionlessNode>(
         } else if (isStmt(result)) {
           return [...stmts, result];
         } else {
-          debugger;
           throw new Error(
             "visitEachChild of a BlockStmt's child statements must return a Stmt"
           );

--- a/src/vtl.ts
+++ b/src/vtl.ts
@@ -402,7 +402,6 @@ export abstract class VTL {
           isIdentifier(node.expr.expr) &&
           node.expr.expr.name === "Promise"
         ) {
-          debugger;
           throw new SynthError(
             ErrorCodes.Unsupported_Use_of_Promises,
             "Appsync does not support concurrent integration invocation or methods on the `Promise` api."
@@ -553,12 +552,10 @@ export abstract class VTL {
       if (isAwaitExpr(node.parent) || isReturnStmt(node.parent)) {
         return this.eval(node.expr);
       }
-      debugger;
       throw new SynthError(
         ErrorCodes.Integration_must_be_immediately_awaited_or_returned
       );
     } else if (isPromiseArrayExpr(node)) {
-      debugger;
       throw new SynthError(
         ErrorCodes.Unsupported_Use_of_Promises,
         "Appsync does not support concurrent integration invocation."


### PR DESCRIPTION
Debugger statements will trigger for consumers as well. Enforce removing from code before push.