### PR TITLE
feat: simplify compile-phase by annotating all functions with their AST

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -4,7 +4,7 @@ import {
   APIGatewayProxyResult,
   APIGatewayEventRequestContext,
 } from "aws-lambda";
-import { FunctionDecl, validateFunctionDecl } from "./declaration";
+import { FunctionDecl, validateFunctionLike } from "./declaration";
 import { ErrorCodes, SynthError } from "./error-code";
 import { CallExpr, Expr, Identifier } from "./expression";
 import { Function } from "./function";
@@ -20,7 +20,6 @@ import {
   isArgument,
   isCallExpr,
   isParameterDecl,
-  isFunctionDecl,
   isElementAccessExpr,
   isObjectLiteralExpr,
   isPropAssignExpr,
@@ -29,6 +28,7 @@ import {
   isReferenceExpr,
   isAwaitExpr,
   isPromiseExpr,
+  isFunctionLike,
 } from "./guards";
 import { Integration, IntegrationImpl, isIntegration } from "./integration";
 import { Stmt } from "./statement";
@@ -260,11 +260,11 @@ export class MockMethod<
       ) => Promise<any> | any;
     }
   ) {
-    const requestDecl = validateFunctionDecl(request, "MockMethod Request");
+    const requestDecl = validateFunctionLike(request, "MockMethod Request");
     const responseDecls = Object.fromEntries(
       Object.entries(responses).map(([k, v]) => [
         k,
-        validateFunctionDecl(v, `MockMethod Response ${k}`),
+        validateFunctionLike(v, `MockMethod Response ${k}`),
       ])
     ) as { [K in 200]: FunctionDecl };
 
@@ -531,12 +531,12 @@ export class AwsMethod<
       ) => any;
     }
   ) {
-    const requestDecl = validateFunctionDecl(request, "AwsMethod Request");
-    const responseDecl = validateFunctionDecl(response, "AwsMethod Response");
+    const requestDecl = validateFunctionLike(request, "AwsMethod Request");
+    const responseDecl = validateFunctionLike(response, "AwsMethod Response");
     const errorDecls = Object.fromEntries(
       Object.entries(errors ?? {}).map(([k, v]) => [
         k,
-        validateFunctionDecl(v, `AwsMethod ${k}`),
+        validateFunctionLike(v, `AwsMethod ${k}`),
       ])
     );
     const role = getRole(props);
@@ -702,7 +702,7 @@ export class APIGatewayVTL extends VTL {
           const ref = expr.expr.expr.lookup();
           if (
             isParameterDecl(ref) &&
-            isFunctionDecl(ref.parent) &&
+            isFunctionLike(ref.parent) &&
             ref.parent.parent === undefined &&
             ref.parent.parameters.findIndex((param) => param === ref) === 0
           ) {
@@ -852,7 +852,11 @@ ${reference}
     const ref = id.lookup();
     if (isVariableStmt(ref)) {
       return `$${id.name}`;
-    } else if (isParameterDecl(ref) && isFunctionDecl(ref.parent)) {
+    } else if (
+      isParameterDecl(ref) &&
+      isFunctionLike(ref.parent) &&
+      ref.parent.parent === undefined
+    ) {
       const paramIndex = ref.parent.parameters.indexOf(ref);
       if (paramIndex === 0) {
         return `$input.path('$')`;
@@ -876,7 +880,7 @@ function isInputBody(expr: Expr): expr is Identifier {
     const ref = expr.lookup();
     return (
       isParameterDecl(ref) &&
-      isFunctionDecl(ref.parent) &&
+      isFunctionLike(ref.parent) &&
       ref.parent.parent === undefined
     );
   }

--- a/src/appsync.ts
+++ b/src/appsync.ts
@@ -6,7 +6,7 @@ import {
   ToAttributeMap,
   ToAttributeValue,
 } from "typesafe-dynamodb/lib/attribute-value";
-import { FunctionDecl, validateFunctionDecl } from "./declaration";
+import { validateFunctionLike } from "./declaration";
 import { ErrorCodes, SynthError } from "./error-code";
 import {
   Argument,
@@ -47,7 +47,7 @@ import {
   isIntegrationCallPattern,
 } from "./integration";
 import { Literal } from "./literal";
-import { FunctionlessNode } from "./node";
+import { FunctionlessNode, FunctionLike } from "./node";
 import { BlockStmt } from "./statement";
 import {
   AnyFunction,
@@ -196,7 +196,7 @@ export class AppsyncResolver<
   /**
    * The AST form of this resolver.
    */
-  public readonly decl: FunctionDecl<
+  public readonly decl: FunctionLike<
     ResolverFunction<Arguments, Result, Source>
   >;
 
@@ -245,7 +245,7 @@ export class AppsyncResolver<
         }),
     resolve: ResolverFunction<Arguments, Result, Source>
   ) {
-    this.decl = validateFunctionDecl(resolve, "AppsyncResolver");
+    this.decl = validateFunctionLike(resolve, "AppsyncResolver");
 
     const api = props.api ?? (scope as unknown as appsync.GraphqlApi);
 
@@ -353,7 +353,7 @@ export class AppsyncField<
   ) {
     const fields = synthResolvers(
       options.api,
-      validateFunctionDecl(resolve, "AppsyncField")
+      validateFunctionLike(resolve, "AppsyncField")
     );
     super({
       ...options,
@@ -365,7 +365,7 @@ export class AppsyncField<
   }
 }
 
-function synthResolvers(api: appsync.GraphqlApi, decl: FunctionDecl) {
+function synthResolvers(api: appsync.GraphqlApi, decl: FunctionLike) {
   const [pipelineConfig, responseMappingTemplate, innerTemplates] =
     synthesizeFunctions(api, decl);
 
@@ -413,7 +413,7 @@ function synthResolvers(api: appsync.GraphqlApi, decl: FunctionDecl) {
   }
 }
 
-function synthesizeFunctions(api: appsync.GraphqlApi, decl: FunctionDecl) {
+function synthesizeFunctions(api: appsync.GraphqlApi, decl: FunctionLike) {
   const generatedNames = new DeterministicNameGenerator();
   let resolverCount = 0;
   /**

--- a/src/checker.ts
+++ b/src/checker.ts
@@ -5,9 +5,10 @@ import { AppsyncField, AppsyncResolver } from "./appsync";
 import { EventBus, Rule } from "./event-bridge";
 import { EventTransform } from "./event-bridge/transform";
 import { Function } from "./function";
+import { anyOf } from "./guards";
 import { ExpressStepFunction, StepFunction } from "./step-function";
 import { Table } from "./table";
-import { anyOf, hasParent } from "./util";
+import { hasParent } from "./util";
 
 /**
  * Various types that could be in a call argument position of a function parameter.

--- a/src/compile.ts
+++ b/src/compile.ts
@@ -72,21 +72,11 @@ export function compile(
         ts.factory.createStringLiteral("functionless")
       );
 
-      if (
-        functionlessContext.requireFunctionless &&
-        // @ts-ignore
-        !updatedSourceFile.externalModuleIndicator &&
-        // @ts-ignore
-        updatedSourceFile.setExternalModuleIndicator
-      ) {
-        // @ts-ignore
-        updatedSourceFile.setExternalModuleIndicator(updatedSourceFile);
-      }
       const statements = sf.statements.map(
         (stmt) => visitor(stmt) as ts.Statement
       );
 
-      return ts.factory.updateSourceFile(
+      const updatedSourceFile = ts.factory.updateSourceFile(
         sf,
         [
           // only require functionless if it is used.
@@ -101,6 +91,19 @@ export function compile(
         sf.hasNoDefaultLib,
         sf.libReferenceDirectives
       );
+
+      if (
+        functionlessContext.requireFunctionless &&
+        // @ts-ignore
+        !updatedSourceFile.externalModuleIndicator &&
+        // @ts-ignore
+        updatedSourceFile.setExternalModuleIndicator
+      ) {
+        // @ts-ignore
+        updatedSourceFile.setExternalModuleIndicator(updatedSourceFile);
+      }
+
+      return updatedSourceFile;
 
       function visitor(node: ts.Node): ts.Node | ts.Node[] {
         if (ts.isArrowFunction(node) || ts.isFunctionExpression(node)) {

--- a/src/compile.ts
+++ b/src/compile.ts
@@ -61,25 +61,27 @@ export function compile(
         },
       };
 
-      const functionlessImport = ts.factory.createVariableStatement(
+      const functionlessImport = ts.factory.createImportDeclaration(
         undefined,
-        ts.factory.createVariableDeclarationList(
-          [
-            ts.factory.createVariableDeclaration(
-              functionless,
-              undefined,
-              undefined,
-              ts.factory.createCallExpression(
-                ts.factory.createIdentifier("require"),
-                undefined,
-                [ts.factory.createStringLiteral("functionless")]
-              )
-            ),
-          ],
-          ts.NodeFlags.Const
-        )
+        undefined,
+        ts.factory.createImportClause(
+          false,
+          undefined,
+          ts.factory.createNamespaceImport(functionless)
+        ),
+        ts.factory.createStringLiteral("functionless")
       );
 
+      if (
+        functionlessContext.requireFunctionless &&
+        // @ts-ignore
+        !updatedSourceFile.externalModuleIndicator &&
+        // @ts-ignore
+        updatedSourceFile.setExternalModuleIndicator
+      ) {
+        // @ts-ignore
+        updatedSourceFile.setExternalModuleIndicator(updatedSourceFile);
+      }
       const statements = sf.statements.map(
         (stmt) => visitor(stmt) as ts.Statement
       );

--- a/src/compile.ts
+++ b/src/compile.ts
@@ -62,15 +62,23 @@ export function compile(
         },
       };
 
-      const functionlessImport = ts.factory.createImportDeclaration(
+      const functionlessImport = ts.factory.createVariableStatement(
         undefined,
-        undefined,
-        ts.factory.createImportClause(
-          false,
-          undefined,
-          ts.factory.createNamespaceImport(functionless)
-        ),
-        ts.factory.createStringLiteral("functionless")
+        ts.factory.createVariableDeclarationList(
+          [
+            ts.factory.createVariableDeclaration(
+              functionless,
+              undefined,
+              undefined,
+              ts.factory.createCallExpression(
+                ts.factory.createIdentifier("require"),
+                undefined,
+                [ts.factory.createStringLiteral("functionless")]
+              )
+            ),
+          ],
+          ts.NodeFlags.Const
+        )
       );
 
       const statements = sf.statements.map(

--- a/src/event-bridge/event-pattern/synth.ts
+++ b/src/event-bridge/event-pattern/synth.ts
@@ -5,7 +5,6 @@ import {
   assertPrimitive,
   assertString,
 } from "../../assert";
-import { FunctionDecl } from "../../declaration";
 import { Err } from "../../error";
 import { ErrorCodes, SynthError } from "../../error-code";
 import {
@@ -23,13 +22,14 @@ import {
   isCallExpr,
   isElementAccessExpr,
   isErr,
-  isFunctionDecl,
+  isFunctionLike,
   isNullLiteralExpr,
   isPropAccessExpr,
   isUnaryExpr,
   isUndefinedLiteralExpr,
 } from "../../guards";
 import { isIntegrationCallPattern } from "../../integration";
+import { FunctionLike } from "../../node";
 import { evalToConstant, invertBinaryOperator } from "../../util";
 import * as functionless_event_bridge from "../types";
 import {
@@ -123,11 +123,11 @@ export const synthesizeEventPattern = (
  * https://github.com/functionless/functionless/issues/37#issuecomment-1066313146
  */
 export const synthesizePatternDocument = (
-  predicate: FunctionDecl | Err | unknown
+  predicate: FunctionLike | Err | undefined
 ): PatternDocument => {
   if (isErr(predicate)) {
     throw predicate.error;
-  } else if (!isFunctionDecl(predicate)) {
+  } else if (!isFunctionLike(predicate)) {
     throw Error(
       "Expected parameter to synthesizeEventPattern to be compiled by functionless."
     );

--- a/src/event-bridge/rule.ts
+++ b/src/event-bridge/rule.ts
@@ -1,5 +1,7 @@
 import { aws_events } from "aws-cdk-lib";
 import { Construct } from "constructs";
+import { validateFunctionLike } from "../declaration";
+import { reflect } from "../reflect";
 import {
   IEventBus,
   IEventBusFilterable,
@@ -264,7 +266,7 @@ export class PredicateRuleBase<
     predicate?: RulePredicateFunction<InEvent, NewEvnt>
   ): PredicateRuleBase<InEvent, NewEvnt> {
     if (predicate) {
-      const document = synthesizePatternDocument(predicate as any);
+      const document = synthesizePatternDocument(reflect(predicate));
 
       return new PredicateRuleBase<InEvent, NewEvnt>(
         scope as Construct,
@@ -274,7 +276,9 @@ export class PredicateRuleBase<
         document
       );
     } else {
-      const document = synthesizePatternDocument(id as any);
+      const document = synthesizePatternDocument(
+        reflect(id as RulePredicateFunction<InEvent, NewEvnt>)
+      );
 
       return new PredicateRuleBase<InEvent, NewEvnt>(
         this.bus.resource,
@@ -306,7 +310,9 @@ export class Rule<
     bus: IEventBus<Evnt>,
     predicate: RulePredicateFunction<Evnt, OutEvnt>
   ) {
-    const document = synthesizePatternDocument(predicate as any);
+    const document = synthesizePatternDocument(
+      validateFunctionLike(predicate, "Rule")
+    );
 
     super(scope, id, bus as IEventBus<Evnt>, document);
   }

--- a/src/event-bridge/target-input.ts
+++ b/src/event-bridge/target-input.ts
@@ -1,7 +1,7 @@
 import { aws_events } from "aws-cdk-lib";
 import { RuleTargetInput } from "aws-cdk-lib/aws-events";
 import { assertConstantValue, assertString } from "../assert";
-import { FunctionDecl, validateFunctionDecl } from "../declaration";
+import { FunctionDecl, validateFunctionLike } from "../declaration";
 import { Err } from "../error";
 import { ErrorCodes, SynthError } from "../error-code";
 import { ArrayLiteralExpr, Expr, ObjectLiteralExpr } from "../expression";
@@ -51,7 +51,7 @@ type PREDEFINED = typeof PREDEFINED_VALUES[number];
 export const synthesizeEventBridgeTargets = (
   maybeDecl: FunctionDecl | Err | unknown
 ): aws_events.RuleTargetInput => {
-  const decl = validateFunctionDecl(maybeDecl, "EventBridgeTarget");
+  const decl = validateFunctionLike(maybeDecl, "EventBridgeTarget");
 
   const [eventDecl = undefined, utilsDecl = undefined] = decl.parameters;
 

--- a/src/function.ts
+++ b/src/function.ts
@@ -949,7 +949,7 @@ export async function serialize(
               // input: associateAST(() => {}, new FunctionDecl([..]))
               // erase the associateAST call and replace with the closure,
               // output: () => {}
-              return node.arguments[0];
+              return visit(node.arguments[0]);
             }
             return ts.visitEachChild(node, visit, ctx);
           },

--- a/src/guards.ts
+++ b/src/guards.ts
@@ -1,4 +1,4 @@
-import { BindingPattern } from "./declaration";
+import type { BindingPattern } from "./declaration";
 import type { Expr, VariableReference } from "./expression";
 import type { FunctionlessNode } from "./node";
 import type { Stmt } from "./statement";
@@ -128,6 +128,8 @@ export const isWhileStmt = typeGuard("WhileStmt");
 export const isDoStmt = typeGuard("DoStmt");
 
 export const isFunctionDecl = typeGuard("FunctionDecl");
+
+export const isFunctionLike = anyOf(isFunctionDecl, isFunctionExpr);
 export const isParameterDecl = typeGuard("ParameterDecl");
 export const isBindingElem = typeGuard("BindingElem");
 
@@ -149,4 +151,16 @@ export function isVariableReference(expr: Expr): expr is VariableReference {
   return (
     isIdentifier(expr) || isPropAccessExpr(expr) || isElementAccessExpr(expr)
   );
+}
+
+export type EnsureOr<T extends ((a: any) => a is any)[]> = T[number] extends (
+  a: any
+) => a is infer T
+  ? T
+  : never;
+
+export function anyOf<T extends ((a: any) => a is any)[]>(
+  ...fns: T
+): (a: any) => a is EnsureOr<T> {
+  return (a: any): a is EnsureOr<T> => fns.some((f) => f(a));
 }

--- a/src/node.ts
+++ b/src/node.ts
@@ -1,11 +1,12 @@
-import {
+import type {
   BindingElem,
   BindingPattern,
   Decl,
+  FunctionDecl,
   ParameterDecl,
 } from "./declaration";
 import type { Err } from "./error";
-import { Expr } from "./expression";
+import type { Expr, FunctionExpr } from "./expression";
 import {
   isBlockStmt,
   isTryStmt,
@@ -24,9 +25,14 @@ import {
   isBindingElem,
   isIdentifier,
 } from "./guards";
-import { BlockStmt, CatchClause, Stmt, VariableStmt } from "./statement";
+import type { BlockStmt, CatchClause, Stmt, VariableStmt } from "./statement";
+import { AnyFunction } from "./util";
 
 export type FunctionlessNode = Decl | Expr | Stmt | Err | BindingPattern;
+
+export type FunctionLike<F extends AnyFunction = AnyFunction> =
+  | FunctionDecl<F>
+  | FunctionExpr<F>;
 
 export interface HasParent<Parent extends FunctionlessNode> {
   get parent(): Parent;

--- a/src/step-function.ts
+++ b/src/step-function.ts
@@ -12,7 +12,7 @@ import { ApiGatewayVtlIntegration } from "./api";
 import { AppSyncVtlIntegration } from "./appsync";
 import { ASL, ASLGraph, StateMachine, States } from "./asl";
 import { assertDefined } from "./assert";
-import { validateFunctionDecl, FunctionDecl } from "./declaration";
+import { validateFunctionLike } from "./declaration";
 import { ErrorCodes, SynthError } from "./error-code";
 import { EventBus, PredicateRuleBase, Rule } from "./event-bridge";
 import {
@@ -25,8 +25,6 @@ import { NativeIntegration } from "./function";
 import { PrewarmClients } from "./function-prewarm";
 import {
   isComputedPropertyNameExpr,
-  isErr,
-  isFunctionDecl,
   isFunctionExpr,
   isNumberLiteralExpr,
   isObjectLiteralExpr,
@@ -39,6 +37,7 @@ import {
   IntegrationInput,
   makeIntegration,
 } from "./integration";
+import { FunctionLike } from "./node";
 import { AnyFunction, ensureItemOf } from "./util";
 import { VTL } from "./vtl";
 
@@ -1391,10 +1390,9 @@ function getStepFunctionArgs<
     | [func: StepFunctionClosure<Payload, Out>]
 ) {
   const props =
-    isFunctionDecl(args[0]) || isErr(args[0])
-      ? {}
-      : (args[1] as StepFunctionProps);
-  const func = validateFunctionDecl(
+    typeof args[0] === "function" ? {} : (args[1] as StepFunctionProps);
+
+  const func = validateFunctionLike(
     args.length > 1 ? args[1] : args[0],
     "StepFunction"
   );
@@ -1405,7 +1403,7 @@ function getStepFunctionArgs<
 function synthesizeStateMachine(
   scope: Construct,
   id: string,
-  decl: FunctionDecl,
+  decl: FunctionLike,
   props: StepFunctionProps & {
     stateMachineType: aws_stepfunctions.StateMachineType;
   }

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,6 +1,7 @@
-import { Construct } from "constructs";
+import type { Construct } from "constructs";
 import ts from "typescript";
-import { BinaryOp, CallExpr, Expr, PropAccessExpr } from "./expression";
+
+import type { BinaryOp, CallExpr, Expr, PropAccessExpr } from "./expression";
 import {
   isArrayLiteralExpr,
   isBinaryExpr,
@@ -23,9 +24,9 @@ import {
   isUnaryExpr,
   isUndefinedLiteralExpr,
 } from "./guards";
-import { FunctionlessNode } from "./node";
+import type { FunctionlessNode } from "./node";
 
-export type AnyFunction = (...args: any[]) => any;
+export type AnyFunction = (...args: any[]) => any | Promise<any>;
 export type AnyAsyncFunction = (...args: any[]) => Promise<any>;
 
 /**
@@ -82,18 +83,6 @@ export function ensure<T>(
   if (!is(a)) {
     throw new Error(message);
   }
-}
-
-export type EnsureOr<T extends ((a: any) => a is any)[]> = T[number] extends (
-  a: any
-) => a is infer T
-  ? T
-  : never;
-
-export function anyOf<T extends ((a: any) => a is any)[]>(
-  ...fns: T
-): (a: any) => a is EnsureOr<T> {
-  return (a: any): a is EnsureOr<T> => fns.some((f) => f(a));
 }
 
 export type AnyDepthArray<T> = T | T[] | AnyDepthArray<T>[];

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -14,7 +14,7 @@ import {
   typeMatch,
 } from "./checker";
 import { ErrorCode, ErrorCodes, formatErrorMessage } from "./error-code";
-import { anyOf } from "./util";
+import { anyOf } from "./guards";
 
 /**
  * Validates a TypeScript SourceFile containing Functionless primitives does not

--- a/src/visit.ts
+++ b/src/visit.ts
@@ -40,6 +40,7 @@ import {
   PostfixUnaryExpr,
 } from "./expression";
 import {
+  anyOf,
   isArgument,
   isArrayLiteralExpr,
   isAwaitExpr,
@@ -113,7 +114,6 @@ import {
   WhileStmt,
 } from "./statement";
 import {
-  anyOf,
   DeterministicNameGenerator,
   ensure,
   ensureItemOf,

--- a/test/__snapshots__/serialize.test.ts.snap
+++ b/test/__snapshots__/serialize.test.ts.snap
@@ -8,9 +8,9 @@ function __f0() {
   return (function() {
     let axios_1 = __axios_1;
 
-    return async () => {
-            return axios_1.default.get(\\"https://functionless.org\\");
-        };
+    return (async () => {
+    return axios_1.default.get(\\"https://functionless.org\\");
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }"
 `;
@@ -12358,6 +12358,7 @@ function __f0() {
     return async () => {
       return axios_1.default.get(\\"https://functionless.org\\");
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 /*!
@@ -12418,242 +12419,246 @@ Object.defineProperty(__fnls_1, \\"$AWS\\", { enumerable: true, get: __f21 });
 var __bus = {eventBusName: process.env.env__functionless0};
 function __f3(__0, __1) {
   return (function() {
-    return (key, props) => { var _a; 
-        // eslint-disable-next-line @typescript-eslint/no-require-imports, import/no-extraneous-dependencies
-        return new (require(\\"aws-sdk\\").DynamoDB)((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key)); };
+    return ((key, props) => {
+    var _a;
+    // eslint-disable-next-line @typescript-eslint/no-require-imports, import/no-extraneous-dependencies
+    return new (require(\\"aws-sdk\\").DynamoDB)((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key));
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f4(__0, __1) {
   return (function() {
-    return (key, props) => { var _a; 
-        // eslint-disable-next-line @typescript-eslint/no-require-imports, import/no-extraneous-dependencies
-        return new (require(\\"aws-sdk\\").EventBridge)((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key)); };
+    return ((key, props) => {
+    var _a;
+    // eslint-disable-next-line @typescript-eslint/no-require-imports, import/no-extraneous-dependencies
+    return new (require(\\"aws-sdk\\").EventBridge)((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key));
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f2(__0, __1) {
   return (function() {
     let function_prewarm_1 = __function_prewarm_1;
 
-    return async (args, preWarmContext) => {
-                    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
-                    const [input] = args;
-                    const { Table: table, ...rest } = input;
-                    return dynamo
-                        .deleteItem({
-                        ...rest,
-                        TableName: input.Table.tableName,
-                    })
-                        .promise();
-                };
+    return (async (args, preWarmContext) => {
+    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
+    const [input] = args;
+    const { Table: table, ...rest } = input;
+    return dynamo
+        .deleteItem({
+        ...rest,
+        TableName: input.Table.tableName,
+    })
+        .promise();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f5(__0) {
   return (function() {
-    return function /*constructor*/(props) {
-        this.props = props;
-        this.cache = {};
-    };
+    return (function constructor(props) {
+    this.props = props;
+    this.cache = {};
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f6(__0) {
   return (function() {
-    return function /*get*/(key) {
-        return this.cache[key];
-    };
+    return (function (key) {
+    return this.cache[key];
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f7(__0) {
   return (function() {
-    return function /*getOrInit*/(client) {
-        if (!this.cache[client.key]) {
-            this.cache[client.key] = client.init(client.key, this.props);
-        }
-        return this.cache[client.key];
-    };
+    return (function getOrInit(client) {
+    if (!this.cache[client.key]) {
+        this.cache[client.key] = client.init(client.key, this.props);
+    }
+    return this.cache[client.key];
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f1() {
   return (function() {
     let c = __f2;
     let preWarmContext = __preWarmContext;
 
-    return function (...args) {
-                                return c(args, preWarmContext);
-                            };
+    return (function __computed(...args) {
+    return c(args, preWarmContext);
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f9(__0, __1) {
   return (function() {
     let function_prewarm_1 = __function_prewarm_1;
 
-    return async (args, preWarmContext) => {
-                    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
-                    const [input] = args;
-                    const { Table: table, AttributesToGet, ...rest } = input;
-                    const payload = {
-                        ...rest,
-                        AttributesToGet: AttributesToGet,
-                        TableName: table.tableName,
-                    };
-                    return dynamo.getItem(payload).promise();
-                };
+    return (async (args, preWarmContext) => {
+    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
+    const [input] = args;
+    const { Table: table, AttributesToGet, ...rest } = input;
+    const payload = {
+        ...rest,
+        AttributesToGet: AttributesToGet,
+        TableName: table.tableName,
+    };
+    return dynamo.getItem(payload).promise();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f8() {
   return (function() {
     let c = __f9;
     let preWarmContext = __preWarmContext;
 
-    return function (...args) {
-                                return c(args, preWarmContext);
-                            };
+    return (function __computed(...args) {
+    return c(args, preWarmContext);
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f11(__0, __1) {
   return (function() {
     let function_prewarm_1 = __function_prewarm_1;
 
-    return async (args, preWarmContext) => {
-                    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
-                    const [input] = args;
-                    const { Table: table, ...rest } = input;
-                    return dynamo
-                        .updateItem({
-                        ...rest,
-                        TableName: table.tableName,
-                    })
-                        .promise();
-                };
+    return (async (args, preWarmContext) => {
+    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
+    const [input] = args;
+    const { Table: table, ...rest } = input;
+    return dynamo
+        .updateItem({
+        ...rest,
+        TableName: table.tableName,
+    })
+        .promise();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f10() {
   return (function() {
     let c = __f11;
     let preWarmContext = __preWarmContext;
 
-    return function (...args) {
-                                return c(args, preWarmContext);
-                            };
+    return (function __computed(...args) {
+    return c(args, preWarmContext);
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f13(__0, __1) {
   return (function() {
     let function_prewarm_1 = __function_prewarm_1;
 
-    return async (args, preWarmContext) => {
-                    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
-                    const [input] = args;
-                    const { Table: table, Item, ...rest } = input;
-                    return dynamo
-                        .putItem({
-                        ...rest,
-                        Item: Item,
-                        TableName: table.tableName,
-                    })
-                        .promise();
-                };
+    return (async (args, preWarmContext) => {
+    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
+    const [input] = args;
+    const { Table: table, Item, ...rest } = input;
+    return dynamo
+        .putItem({
+        ...rest,
+        Item: Item,
+        TableName: table.tableName,
+    })
+        .promise();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f12() {
   return (function() {
     let c = __f13;
     let preWarmContext = __preWarmContext;
 
-    return function (...args) {
-                                return c(args, preWarmContext);
-                            };
+    return (function __computed(...args) {
+    return c(args, preWarmContext);
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f15(__0, __1) {
   return (function() {
     let function_prewarm_1 = __function_prewarm_1;
 
-    return async (args, preWarmContext) => {
-                    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
-                    const [input] = args;
-                    const { Table: table, AttributesToGet, ...rest } = input;
-                    return dynamo
-                        .query({
-                        ...rest,
-                        AttributesToGet: AttributesToGet,
-                        TableName: table.tableName,
-                    })
-                        .promise();
-                };
+    return (async (args, preWarmContext) => {
+    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
+    const [input] = args;
+    const { Table: table, AttributesToGet, ...rest } = input;
+    return dynamo
+        .query({
+        ...rest,
+        AttributesToGet: AttributesToGet,
+        TableName: table.tableName,
+    })
+        .promise();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f14() {
   return (function() {
     let c = __f15;
     let preWarmContext = __preWarmContext;
 
-    return function (...args) {
-                                return c(args, preWarmContext);
-                            };
+    return (function __computed(...args) {
+    return c(args, preWarmContext);
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f17(__0, __1) {
   return (function() {
     let function_prewarm_1 = __function_prewarm_1;
 
-    return async (args, preWarmContext) => {
-                    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
-                    const [input] = args;
-                    const { Table: table, AttributesToGet, ...rest } = input;
-                    return dynamo
-                        .scan({
-                        ...rest,
-                        AttributesToGet: AttributesToGet,
-                        TableName: table.tableName,
-                    })
-                        .promise();
-                };
+    return (async (args, preWarmContext) => {
+    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
+    const [input] = args;
+    const { Table: table, AttributesToGet, ...rest } = input;
+    return dynamo
+        .scan({
+        ...rest,
+        AttributesToGet: AttributesToGet,
+        TableName: table.tableName,
+    })
+        .promise();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f16() {
   return (function() {
     let c = __f17;
     let preWarmContext = __preWarmContext;
 
-    return function (...args) {
-                                return c(args, preWarmContext);
-                            };
+    return (function __computed(...args) {
+    return c(args, preWarmContext);
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f18() {
   return (function() {
-    return function () {
-                                    throw new Error();
-                                };
+    return (function __computed() {
+    throw new Error();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f20(__0, __1) {
   return (function() {
     let function_prewarm_1 = __function_prewarm_1;
 
-    return async ([request], preWarmContext) => {
-                    const eventBridge = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.EVENT_BRIDGE);
-                    return eventBridge
-                        .putEvents({
-                        Entries: request.Entries.map((e) => ({
-                            ...e,
-                        })),
-                    })
-                        .promise();
-                };
+    return (async ([request], preWarmContext) => {
+    const eventBridge = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.EVENT_BRIDGE);
+    return eventBridge
+        .putEvents({
+        Entries: request.Entries.map((e) => ({
+            ...e,
+        })),
+    })
+        .promise();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f19() {
   return (function() {
     let c = __f20;
     let preWarmContext = __preWarmContext;
 
-    return function (...args) {
-                                return c(args, preWarmContext);
-                            };
+    return (function __computed(...args) {
+    return c(args, preWarmContext);
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f21() {
   return (function() {
     let m = __m;
     let k = \\"$AWS\\";
 
-    return function () { return m[k]; };
+    return (function __computed() { return m[k]; });;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f0() {
   return (function() {
     let _fnls_1 = __fnls_1;
     let bus = __bus;
 
-    return () => {
-                return _fnls_1.$AWS.EventBridge.putEvents({
-                    Entries: [
-                        {
-                            EventBusName: bus.eventBusName,
-                        },
-                    ],
-                });
-            };
+    return (() => {
+    return _fnls_1.$AWS.EventBridge.putEvents({
+        Entries: [
+            {
+                EventBusName: bus.eventBusName,
+            },
+        ],
+    });
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }"
 `;
@@ -12705,6 +12710,7 @@ function __f3(__0, __1) {
       var _a;
       return new (require(\\"aws-sdk\\")).DynamoDB((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key));
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f4(__0, __1) {
@@ -12713,6 +12719,7 @@ function __f4(__0, __1) {
       var _a;
       return new (require(\\"aws-sdk\\")).EventBridge((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key));
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f2(__0, __1) {
@@ -12727,14 +12734,16 @@ function __f2(__0, __1) {
         TableName: input.Table.tableName
       }).promise();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f5(__0) {
   return function() {
-    return function(props) {
+    return function constructor(props) {
       this.props = props;
       this.cache = {};
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f6(__0) {
@@ -12742,25 +12751,28 @@ function __f6(__0) {
     return function(key) {
       return this.cache[key];
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f7(__0) {
   return function() {
-    return function(client) {
+    return function getOrInit(client) {
       if (!this.cache[client.key]) {
         this.cache[client.key] = client.init(client.key, this.props);
       }
       return this.cache[client.key];
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f1() {
   return function() {
     let c = __f2;
     let preWarmContext = __preWarmContext;
-    return function(...args) {
+    return function __computed(...args) {
       return c(args, preWarmContext);
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f9(__0, __1) {
@@ -12777,15 +12789,17 @@ function __f9(__0, __1) {
       };
       return dynamo.getItem(payload).promise();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f8() {
   return function() {
     let c = __f9;
     let preWarmContext = __preWarmContext;
-    return function(...args) {
+    return function __computed(...args) {
       return c(args, preWarmContext);
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f11(__0, __1) {
@@ -12800,15 +12814,17 @@ function __f11(__0, __1) {
         TableName: table.tableName
       }).promise();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f10() {
   return function() {
     let c = __f11;
     let preWarmContext = __preWarmContext;
-    return function(...args) {
+    return function __computed(...args) {
       return c(args, preWarmContext);
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f13(__0, __1) {
@@ -12824,15 +12840,17 @@ function __f13(__0, __1) {
         TableName: table.tableName
       }).promise();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f12() {
   return function() {
     let c = __f13;
     let preWarmContext = __preWarmContext;
-    return function(...args) {
+    return function __computed(...args) {
       return c(args, preWarmContext);
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f15(__0, __1) {
@@ -12848,15 +12866,17 @@ function __f15(__0, __1) {
         TableName: table.tableName
       }).promise();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f14() {
   return function() {
     let c = __f15;
     let preWarmContext = __preWarmContext;
-    return function(...args) {
+    return function __computed(...args) {
       return c(args, preWarmContext);
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f17(__0, __1) {
@@ -12872,22 +12892,25 @@ function __f17(__0, __1) {
         TableName: table.tableName
       }).promise();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f16() {
   return function() {
     let c = __f17;
     let preWarmContext = __preWarmContext;
-    return function(...args) {
+    return function __computed(...args) {
       return c(args, preWarmContext);
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f18() {
   return function() {
-    return function() {
+    return function __computed() {
       throw new Error();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f20(__0, __1) {
@@ -12901,24 +12924,27 @@ function __f20(__0, __1) {
         }))
       }).promise();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f19() {
   return function() {
     let c = __f20;
     let preWarmContext = __preWarmContext;
-    return function(...args) {
+    return function __computed(...args) {
       return c(args, preWarmContext);
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f21() {
   return function() {
     let m = __m;
     let k = \\"$AWS\\";
-    return function() {
+    return function __computed() {
       return m[k];
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f0() {
@@ -12934,6 +12960,7 @@ function __f0() {
         ]
       });
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 "
@@ -12982,242 +13009,246 @@ Object.defineProperty(__fnls_1, \\"$AWS\\", { enumerable: true, get: __f21 });
 var __bus = {eventBusName: process.env.env__functionless0};
 function __f3(__0, __1) {
   return (function() {
-    return (key, props) => { var _a; 
-        // eslint-disable-next-line @typescript-eslint/no-require-imports, import/no-extraneous-dependencies
-        return new (require(\\"aws-sdk\\").DynamoDB)((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key)); };
+    return ((key, props) => {
+    var _a;
+    // eslint-disable-next-line @typescript-eslint/no-require-imports, import/no-extraneous-dependencies
+    return new (require(\\"aws-sdk\\").DynamoDB)((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key));
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f4(__0, __1) {
   return (function() {
-    return (key, props) => { var _a; 
-        // eslint-disable-next-line @typescript-eslint/no-require-imports, import/no-extraneous-dependencies
-        return new (require(\\"aws-sdk\\").EventBridge)((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key)); };
+    return ((key, props) => {
+    var _a;
+    // eslint-disable-next-line @typescript-eslint/no-require-imports, import/no-extraneous-dependencies
+    return new (require(\\"aws-sdk\\").EventBridge)((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key));
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f2(__0, __1) {
   return (function() {
     let function_prewarm_1 = __function_prewarm_1;
 
-    return async (args, preWarmContext) => {
-                    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
-                    const [input] = args;
-                    const { Table: table, ...rest } = input;
-                    return dynamo
-                        .deleteItem({
-                        ...rest,
-                        TableName: input.Table.tableName,
-                    })
-                        .promise();
-                };
+    return (async (args, preWarmContext) => {
+    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
+    const [input] = args;
+    const { Table: table, ...rest } = input;
+    return dynamo
+        .deleteItem({
+        ...rest,
+        TableName: input.Table.tableName,
+    })
+        .promise();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f5(__0) {
   return (function() {
-    return function /*constructor*/(props) {
-        this.props = props;
-        this.cache = {};
-    };
+    return (function constructor(props) {
+    this.props = props;
+    this.cache = {};
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f6(__0) {
   return (function() {
-    return function /*get*/(key) {
-        return this.cache[key];
-    };
+    return (function (key) {
+    return this.cache[key];
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f7(__0) {
   return (function() {
-    return function /*getOrInit*/(client) {
-        if (!this.cache[client.key]) {
-            this.cache[client.key] = client.init(client.key, this.props);
-        }
-        return this.cache[client.key];
-    };
+    return (function getOrInit(client) {
+    if (!this.cache[client.key]) {
+        this.cache[client.key] = client.init(client.key, this.props);
+    }
+    return this.cache[client.key];
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f1() {
   return (function() {
     let c = __f2;
     let preWarmContext = __preWarmContext;
 
-    return function (...args) {
-                                return c(args, preWarmContext);
-                            };
+    return (function __computed(...args) {
+    return c(args, preWarmContext);
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f9(__0, __1) {
   return (function() {
     let function_prewarm_1 = __function_prewarm_1;
 
-    return async (args, preWarmContext) => {
-                    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
-                    const [input] = args;
-                    const { Table: table, AttributesToGet, ...rest } = input;
-                    const payload = {
-                        ...rest,
-                        AttributesToGet: AttributesToGet,
-                        TableName: table.tableName,
-                    };
-                    return dynamo.getItem(payload).promise();
-                };
+    return (async (args, preWarmContext) => {
+    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
+    const [input] = args;
+    const { Table: table, AttributesToGet, ...rest } = input;
+    const payload = {
+        ...rest,
+        AttributesToGet: AttributesToGet,
+        TableName: table.tableName,
+    };
+    return dynamo.getItem(payload).promise();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f8() {
   return (function() {
     let c = __f9;
     let preWarmContext = __preWarmContext;
 
-    return function (...args) {
-                                return c(args, preWarmContext);
-                            };
+    return (function __computed(...args) {
+    return c(args, preWarmContext);
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f11(__0, __1) {
   return (function() {
     let function_prewarm_1 = __function_prewarm_1;
 
-    return async (args, preWarmContext) => {
-                    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
-                    const [input] = args;
-                    const { Table: table, ...rest } = input;
-                    return dynamo
-                        .updateItem({
-                        ...rest,
-                        TableName: table.tableName,
-                    })
-                        .promise();
-                };
+    return (async (args, preWarmContext) => {
+    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
+    const [input] = args;
+    const { Table: table, ...rest } = input;
+    return dynamo
+        .updateItem({
+        ...rest,
+        TableName: table.tableName,
+    })
+        .promise();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f10() {
   return (function() {
     let c = __f11;
     let preWarmContext = __preWarmContext;
 
-    return function (...args) {
-                                return c(args, preWarmContext);
-                            };
+    return (function __computed(...args) {
+    return c(args, preWarmContext);
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f13(__0, __1) {
   return (function() {
     let function_prewarm_1 = __function_prewarm_1;
 
-    return async (args, preWarmContext) => {
-                    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
-                    const [input] = args;
-                    const { Table: table, Item, ...rest } = input;
-                    return dynamo
-                        .putItem({
-                        ...rest,
-                        Item: Item,
-                        TableName: table.tableName,
-                    })
-                        .promise();
-                };
+    return (async (args, preWarmContext) => {
+    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
+    const [input] = args;
+    const { Table: table, Item, ...rest } = input;
+    return dynamo
+        .putItem({
+        ...rest,
+        Item: Item,
+        TableName: table.tableName,
+    })
+        .promise();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f12() {
   return (function() {
     let c = __f13;
     let preWarmContext = __preWarmContext;
 
-    return function (...args) {
-                                return c(args, preWarmContext);
-                            };
+    return (function __computed(...args) {
+    return c(args, preWarmContext);
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f15(__0, __1) {
   return (function() {
     let function_prewarm_1 = __function_prewarm_1;
 
-    return async (args, preWarmContext) => {
-                    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
-                    const [input] = args;
-                    const { Table: table, AttributesToGet, ...rest } = input;
-                    return dynamo
-                        .query({
-                        ...rest,
-                        AttributesToGet: AttributesToGet,
-                        TableName: table.tableName,
-                    })
-                        .promise();
-                };
+    return (async (args, preWarmContext) => {
+    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
+    const [input] = args;
+    const { Table: table, AttributesToGet, ...rest } = input;
+    return dynamo
+        .query({
+        ...rest,
+        AttributesToGet: AttributesToGet,
+        TableName: table.tableName,
+    })
+        .promise();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f14() {
   return (function() {
     let c = __f15;
     let preWarmContext = __preWarmContext;
 
-    return function (...args) {
-                                return c(args, preWarmContext);
-                            };
+    return (function __computed(...args) {
+    return c(args, preWarmContext);
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f17(__0, __1) {
   return (function() {
     let function_prewarm_1 = __function_prewarm_1;
 
-    return async (args, preWarmContext) => {
-                    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
-                    const [input] = args;
-                    const { Table: table, AttributesToGet, ...rest } = input;
-                    return dynamo
-                        .scan({
-                        ...rest,
-                        AttributesToGet: AttributesToGet,
-                        TableName: table.tableName,
-                    })
-                        .promise();
-                };
+    return (async (args, preWarmContext) => {
+    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
+    const [input] = args;
+    const { Table: table, AttributesToGet, ...rest } = input;
+    return dynamo
+        .scan({
+        ...rest,
+        AttributesToGet: AttributesToGet,
+        TableName: table.tableName,
+    })
+        .promise();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f16() {
   return (function() {
     let c = __f17;
     let preWarmContext = __preWarmContext;
 
-    return function (...args) {
-                                return c(args, preWarmContext);
-                            };
+    return (function __computed(...args) {
+    return c(args, preWarmContext);
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f18() {
   return (function() {
-    return function () {
-                                    throw new Error();
-                                };
+    return (function __computed() {
+    throw new Error();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f20(__0, __1) {
   return (function() {
     let function_prewarm_1 = __function_prewarm_1;
 
-    return async ([request], preWarmContext) => {
-                    const eventBridge = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.EVENT_BRIDGE);
-                    return eventBridge
-                        .putEvents({
-                        Entries: request.Entries.map((e) => ({
-                            ...e,
-                        })),
-                    })
-                        .promise();
-                };
+    return (async ([request], preWarmContext) => {
+    const eventBridge = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.EVENT_BRIDGE);
+    return eventBridge
+        .putEvents({
+        Entries: request.Entries.map((e) => ({
+            ...e,
+        })),
+    })
+        .promise();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f19() {
   return (function() {
     let c = __f20;
     let preWarmContext = __preWarmContext;
 
-    return function (...args) {
-                                return c(args, preWarmContext);
-                            };
+    return (function __computed(...args) {
+    return c(args, preWarmContext);
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f21() {
   return (function() {
     let m = __m;
     let k = \\"$AWS\\";
 
-    return function () { return m[k]; };
+    return (function __computed() { return m[k]; });;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f0() {
   return (function() {
     let _fnls_1 = __fnls_1;
     let bus = __bus;
 
-    return () => {
-                return _fnls_1.$AWS.EventBridge.putEvents({
-                    Entries: [
-                        {
-                            EventBusName: bus.eventBusName,
-                        },
-                    ],
-                });
-            };
+    return (() => {
+    return _fnls_1.$AWS.EventBridge.putEvents({
+        Entries: [
+            {
+                EventBusName: bus.eventBusName,
+            },
+        ],
+    });
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }"
 `;
@@ -13269,6 +13300,7 @@ function __f3(__0, __1) {
       var _a;
       return new (require(\\"aws-sdk\\")).DynamoDB((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key));
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f4(__0, __1) {
@@ -13277,6 +13309,7 @@ function __f4(__0, __1) {
       var _a;
       return new (require(\\"aws-sdk\\")).EventBridge((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key));
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f2(__0, __1) {
@@ -13291,14 +13324,16 @@ function __f2(__0, __1) {
         TableName: input.Table.tableName
       }).promise();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f5(__0) {
   return function() {
-    return function(props) {
+    return function constructor(props) {
       this.props = props;
       this.cache = {};
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f6(__0) {
@@ -13306,25 +13341,28 @@ function __f6(__0) {
     return function(key) {
       return this.cache[key];
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f7(__0) {
   return function() {
-    return function(client) {
+    return function getOrInit(client) {
       if (!this.cache[client.key]) {
         this.cache[client.key] = client.init(client.key, this.props);
       }
       return this.cache[client.key];
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f1() {
   return function() {
     let c = __f2;
     let preWarmContext = __preWarmContext;
-    return function(...args) {
+    return function __computed(...args) {
       return c(args, preWarmContext);
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f9(__0, __1) {
@@ -13341,15 +13379,17 @@ function __f9(__0, __1) {
       };
       return dynamo.getItem(payload).promise();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f8() {
   return function() {
     let c = __f9;
     let preWarmContext = __preWarmContext;
-    return function(...args) {
+    return function __computed(...args) {
       return c(args, preWarmContext);
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f11(__0, __1) {
@@ -13364,15 +13404,17 @@ function __f11(__0, __1) {
         TableName: table.tableName
       }).promise();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f10() {
   return function() {
     let c = __f11;
     let preWarmContext = __preWarmContext;
-    return function(...args) {
+    return function __computed(...args) {
       return c(args, preWarmContext);
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f13(__0, __1) {
@@ -13388,15 +13430,17 @@ function __f13(__0, __1) {
         TableName: table.tableName
       }).promise();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f12() {
   return function() {
     let c = __f13;
     let preWarmContext = __preWarmContext;
-    return function(...args) {
+    return function __computed(...args) {
       return c(args, preWarmContext);
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f15(__0, __1) {
@@ -13412,15 +13456,17 @@ function __f15(__0, __1) {
         TableName: table.tableName
       }).promise();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f14() {
   return function() {
     let c = __f15;
     let preWarmContext = __preWarmContext;
-    return function(...args) {
+    return function __computed(...args) {
       return c(args, preWarmContext);
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f17(__0, __1) {
@@ -13436,22 +13482,25 @@ function __f17(__0, __1) {
         TableName: table.tableName
       }).promise();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f16() {
   return function() {
     let c = __f17;
     let preWarmContext = __preWarmContext;
-    return function(...args) {
+    return function __computed(...args) {
       return c(args, preWarmContext);
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f18() {
   return function() {
-    return function() {
+    return function __computed() {
       throw new Error();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f20(__0, __1) {
@@ -13465,24 +13514,27 @@ function __f20(__0, __1) {
         }))
       }).promise();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f19() {
   return function() {
     let c = __f20;
     let preWarmContext = __preWarmContext;
-    return function(...args) {
+    return function __computed(...args) {
       return c(args, preWarmContext);
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f21() {
   return function() {
     let m = __m;
     let k = \\"$AWS\\";
-    return function() {
+    return function __computed() {
       return m[k];
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f0() {
@@ -13498,6 +13550,7 @@ function __f0() {
         ]
       });
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 "
@@ -13524,75 +13577,77 @@ __f1.kind = \\"EventBus.putEvents\\";
 var __bus = {putEvents: __f1};
 function __f3(__0, __1) {
   return (function() {
-    return (key, props) => { var _a; 
-        // eslint-disable-next-line @typescript-eslint/no-require-imports, import/no-extraneous-dependencies
-        return new (require(\\"aws-sdk\\").EventBridge)((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key)); };
+    return ((key, props) => {
+    var _a;
+    // eslint-disable-next-line @typescript-eslint/no-require-imports, import/no-extraneous-dependencies
+    return new (require(\\"aws-sdk\\").EventBridge)((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key));
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f2(__0, __1) {
   return (function() {
     let function_prewarm_1 = __function_prewarm_1;
     let eventBusName = process.env.env__functionless0;
 
-    return async (args, preWarmContext) => {
-                    const eventBridge = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.EVENT_BRIDGE);
-                    await eventBridge
-                        .putEvents({
-                        Entries: args.map((event) => ({
-                            Detail: JSON.stringify(event.detail),
-                            EventBusName: eventBusName,
-                            DetailType: event[\\"detail-type\\"],
-                            Resources: event.resources,
-                            Source: event.source,
-                            Time: typeof event.time === \\"number\\"
-                                ? new Date(event.time)
-                                : undefined,
-                        })),
-                    })
-                        .promise();
-                };
+    return (async (args, preWarmContext) => {
+    const eventBridge = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.EVENT_BRIDGE);
+    await eventBridge
+        .putEvents({
+        Entries: args.map((event) => ({
+            Detail: JSON.stringify(event.detail),
+            EventBusName: eventBusName,
+            DetailType: event[\\"detail-type\\"],
+            Resources: event.resources,
+            Source: event.source,
+            Time: typeof event.time === \\"number\\"
+                ? new Date(event.time)
+                : undefined,
+        })),
+    })
+        .promise();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f4(__0) {
   return (function() {
-    return function /*constructor*/(props) {
-        this.props = props;
-        this.cache = {};
-    };
+    return (function constructor(props) {
+    this.props = props;
+    this.cache = {};
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f5(__0) {
   return (function() {
-    return function /*get*/(key) {
-        return this.cache[key];
-    };
+    return (function (key) {
+    return this.cache[key];
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f6(__0) {
   return (function() {
-    return function /*getOrInit*/(client) {
-        if (!this.cache[client.key]) {
-            this.cache[client.key] = client.init(client.key, this.props);
-        }
-        return this.cache[client.key];
-    };
+    return (function getOrInit(client) {
+    if (!this.cache[client.key]) {
+        this.cache[client.key] = client.init(client.key, this.props);
+    }
+    return this.cache[client.key];
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f1() {
   return (function() {
     let c = __f2;
     let preWarmContext = __preWarmContext;
 
-    return function (...args) {
-                                return c(args, preWarmContext);
-                            };
+    return (function __computed(...args) {
+    return c(args, preWarmContext);
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f0() {
   return (function() {
     let bus = __bus;
 
-    return () => {
-                return bus.putEvents({
-                    \\"detail-type\\": \\"test\\",
-                    detail: {},
-                    source: \\"\\",
-                });
-            };
+    return (() => {
+    return bus.putEvents({
+        \\"detail-type\\": \\"test\\",
+        detail: {},
+        source: \\"\\",
+    });
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }"
 `;
@@ -13622,6 +13677,7 @@ function __f3(__0, __1) {
       var _a;
       return new (require(\\"aws-sdk\\")).EventBridge((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key));
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f2(__0, __1) {
@@ -13641,14 +13697,16 @@ function __f2(__0, __1) {
         }))
       }).promise();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f4(__0) {
   return function() {
-    return function(props) {
+    return function constructor(props) {
       this.props = props;
       this.cache = {};
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f5(__0) {
@@ -13656,25 +13714,28 @@ function __f5(__0) {
     return function(key) {
       return this.cache[key];
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f6(__0) {
   return function() {
-    return function(client) {
+    return function getOrInit(client) {
       if (!this.cache[client.key]) {
         this.cache[client.key] = client.init(client.key, this.props);
       }
       return this.cache[client.key];
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f1() {
   return function() {
     let c = __f2;
     let preWarmContext = __preWarmContext;
-    return function(...args) {
+    return function __computed(...args) {
       return c(args, preWarmContext);
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f0() {
@@ -13687,6 +13748,7 @@ function __f0() {
         source: \\"\\"
       });
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 "
@@ -13713,75 +13775,77 @@ __f1.kind = \\"EventBus.putEvents\\";
 var __bus = {putEvents: __f1};
 function __f3(__0, __1) {
   return (function() {
-    return (key, props) => { var _a; 
-        // eslint-disable-next-line @typescript-eslint/no-require-imports, import/no-extraneous-dependencies
-        return new (require(\\"aws-sdk\\").EventBridge)((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key)); };
+    return ((key, props) => {
+    var _a;
+    // eslint-disable-next-line @typescript-eslint/no-require-imports, import/no-extraneous-dependencies
+    return new (require(\\"aws-sdk\\").EventBridge)((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key));
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f2(__0, __1) {
   return (function() {
     let function_prewarm_1 = __function_prewarm_1;
     let eventBusName = process.env.env__functionless0;
 
-    return async (args, preWarmContext) => {
-                    const eventBridge = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.EVENT_BRIDGE);
-                    await eventBridge
-                        .putEvents({
-                        Entries: args.map((event) => ({
-                            Detail: JSON.stringify(event.detail),
-                            EventBusName: eventBusName,
-                            DetailType: event[\\"detail-type\\"],
-                            Resources: event.resources,
-                            Source: event.source,
-                            Time: typeof event.time === \\"number\\"
-                                ? new Date(event.time)
-                                : undefined,
-                        })),
-                    })
-                        .promise();
-                };
+    return (async (args, preWarmContext) => {
+    const eventBridge = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.EVENT_BRIDGE);
+    await eventBridge
+        .putEvents({
+        Entries: args.map((event) => ({
+            Detail: JSON.stringify(event.detail),
+            EventBusName: eventBusName,
+            DetailType: event[\\"detail-type\\"],
+            Resources: event.resources,
+            Source: event.source,
+            Time: typeof event.time === \\"number\\"
+                ? new Date(event.time)
+                : undefined,
+        })),
+    })
+        .promise();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f4(__0) {
   return (function() {
-    return function /*constructor*/(props) {
-        this.props = props;
-        this.cache = {};
-    };
+    return (function constructor(props) {
+    this.props = props;
+    this.cache = {};
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f5(__0) {
   return (function() {
-    return function /*get*/(key) {
-        return this.cache[key];
-    };
+    return (function (key) {
+    return this.cache[key];
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f6(__0) {
   return (function() {
-    return function /*getOrInit*/(client) {
-        if (!this.cache[client.key]) {
-            this.cache[client.key] = client.init(client.key, this.props);
-        }
-        return this.cache[client.key];
-    };
+    return (function getOrInit(client) {
+    if (!this.cache[client.key]) {
+        this.cache[client.key] = client.init(client.key, this.props);
+    }
+    return this.cache[client.key];
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f1() {
   return (function() {
     let c = __f2;
     let preWarmContext = __preWarmContext;
 
-    return function (...args) {
-                                return c(args, preWarmContext);
-                            };
+    return (function __computed(...args) {
+    return c(args, preWarmContext);
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f0() {
   return (function() {
     let bus = __bus;
 
-    return () => {
-                return bus.putEvents({
-                    \\"detail-type\\": \\"test\\",
-                    detail: {},
-                    source: \\"\\",
-                });
-            };
+    return (() => {
+    return bus.putEvents({
+        \\"detail-type\\": \\"test\\",
+        detail: {},
+        source: \\"\\",
+    });
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }"
 `;
@@ -13811,6 +13875,7 @@ function __f3(__0, __1) {
       var _a;
       return new (require(\\"aws-sdk\\")).EventBridge((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key));
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f2(__0, __1) {
@@ -13830,14 +13895,16 @@ function __f2(__0, __1) {
         }))
       }).promise();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f4(__0) {
   return function() {
-    return function(props) {
+    return function constructor(props) {
       this.props = props;
       this.cache = {};
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f5(__0) {
@@ -13845,25 +13912,28 @@ function __f5(__0) {
     return function(key) {
       return this.cache[key];
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f6(__0) {
   return function() {
-    return function(client) {
+    return function getOrInit(client) {
       if (!this.cache[client.key]) {
         this.cache[client.key] = client.init(client.key, this.props);
       }
       return this.cache[client.key];
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f1() {
   return function() {
     let c = __f2;
     let preWarmContext = __preWarmContext;
-    return function(...args) {
+    return function __computed(...args) {
       return c(args, preWarmContext);
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f0() {
@@ -13876,6 +13946,7 @@ function __f0() {
         source: \\"\\"
       });
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 "
@@ -13902,66 +13973,68 @@ __f1.kind = \\"Function\\";
 __f1.functionlessKind = \\"Function\\";
 function __f3(__0, __1) {
   return (function() {
-    return (key, props) => { var _a; 
-        // eslint-disable-next-line @typescript-eslint/no-require-imports, import/no-extraneous-dependencies
-        return new (require(\\"aws-sdk\\").Lambda)((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key)); };
+    return ((key, props) => {
+    var _a;
+    // eslint-disable-next-line @typescript-eslint/no-require-imports, import/no-extraneous-dependencies
+    return new (require(\\"aws-sdk\\").Lambda)((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key));
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f2(__0, __1) {
   return (function() {
     let function_prewarm_1 = __function_prewarm_1;
     let functionName = process.env.env__functionless0;
 
-    return async (args, prewarmContext) => {
-                var _a;
-                const [payload] = args;
-                const lambdaClient = prewarmContext.getOrInit(function_prewarm_1.PrewarmClients.LAMBDA);
-                const response = (_a = (await lambdaClient
-                    .invoke({
-                    FunctionName: functionName,
-                    ...(payload ? { Payload: JSON.stringify(payload) } : undefined),
-                })
-                    .promise()).Payload) === null || _a === void 0 ? void 0 : _a.toString();
-                return (response ? JSON.parse(response) : undefined);
-            };
+    return (async (args, prewarmContext) => {
+    var _a;
+    const [payload] = args;
+    const lambdaClient = prewarmContext.getOrInit(function_prewarm_1.PrewarmClients.LAMBDA);
+    const response = (_a = (await lambdaClient
+        .invoke({
+        FunctionName: functionName,
+        ...(payload ? { Payload: JSON.stringify(payload) } : undefined),
+    })
+        .promise()).Payload) === null || _a === void 0 ? void 0 : _a.toString();
+    return (response ? JSON.parse(response) : undefined);
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f4(__0) {
   return (function() {
-    return function /*constructor*/(props) {
-        this.props = props;
-        this.cache = {};
-    };
+    return (function constructor(props) {
+    this.props = props;
+    this.cache = {};
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f5(__0) {
   return (function() {
-    return function /*get*/(key) {
-        return this.cache[key];
-    };
+    return (function (key) {
+    return this.cache[key];
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f6(__0) {
   return (function() {
-    return function /*getOrInit*/(client) {
-        if (!this.cache[client.key]) {
-            this.cache[client.key] = client.init(client.key, this.props);
-        }
-        return this.cache[client.key];
-    };
+    return (function getOrInit(client) {
+    if (!this.cache[client.key]) {
+        this.cache[client.key] = client.init(client.key, this.props);
+    }
+    return this.cache[client.key];
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f1() {
   return (function() {
     let c = __f2;
     let preWarmContext = __preWarmContext;
 
-    return function (...args) {
-                                return c(args, preWarmContext);
-                            };
+    return (function __computed(...args) {
+    return c(args, preWarmContext);
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f0() {
   return (function() {
     let func = __f1;
 
-    return () => {
-                return func();
-            };
+    return (() => {
+    return func();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }"
 `;
@@ -13991,6 +14064,7 @@ function __f3(__0, __1) {
       var _a;
       return new (require(\\"aws-sdk\\")).Lambda((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key));
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f2(__0, __1) {
@@ -14007,14 +14081,16 @@ function __f2(__0, __1) {
       }).promise()).Payload) === null || _a === void 0 ? void 0 : _a.toString();
       return response ? JSON.parse(response) : void 0;
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f4(__0) {
   return function() {
-    return function(props) {
+    return function constructor(props) {
       this.props = props;
       this.cache = {};
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f5(__0) {
@@ -14022,25 +14098,28 @@ function __f5(__0) {
     return function(key) {
       return this.cache[key];
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f6(__0) {
   return function() {
-    return function(client) {
+    return function getOrInit(client) {
       if (!this.cache[client.key]) {
         this.cache[client.key] = client.init(client.key, this.props);
       }
       return this.cache[client.key];
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f1() {
   return function() {
     let c = __f2;
     let preWarmContext = __preWarmContext;
-    return function(...args) {
+    return function __computed(...args) {
       return c(args, preWarmContext);
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f0() {
@@ -14049,6 +14128,7 @@ function __f0() {
     return () => {
       return func();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 "
@@ -14075,66 +14155,68 @@ __f1.kind = \\"Function\\";
 __f1.functionlessKind = \\"Function\\";
 function __f3(__0, __1) {
   return (function() {
-    return (key, props) => { var _a; 
-        // eslint-disable-next-line @typescript-eslint/no-require-imports, import/no-extraneous-dependencies
-        return new (require(\\"aws-sdk\\").Lambda)((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key)); };
+    return ((key, props) => {
+    var _a;
+    // eslint-disable-next-line @typescript-eslint/no-require-imports, import/no-extraneous-dependencies
+    return new (require(\\"aws-sdk\\").Lambda)((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key));
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f2(__0, __1) {
   return (function() {
     let function_prewarm_1 = __function_prewarm_1;
     let functionName = process.env.env__functionless0;
 
-    return async (args, prewarmContext) => {
-                var _a;
-                const [payload] = args;
-                const lambdaClient = prewarmContext.getOrInit(function_prewarm_1.PrewarmClients.LAMBDA);
-                const response = (_a = (await lambdaClient
-                    .invoke({
-                    FunctionName: functionName,
-                    ...(payload ? { Payload: JSON.stringify(payload) } : undefined),
-                })
-                    .promise()).Payload) === null || _a === void 0 ? void 0 : _a.toString();
-                return (response ? JSON.parse(response) : undefined);
-            };
+    return (async (args, prewarmContext) => {
+    var _a;
+    const [payload] = args;
+    const lambdaClient = prewarmContext.getOrInit(function_prewarm_1.PrewarmClients.LAMBDA);
+    const response = (_a = (await lambdaClient
+        .invoke({
+        FunctionName: functionName,
+        ...(payload ? { Payload: JSON.stringify(payload) } : undefined),
+    })
+        .promise()).Payload) === null || _a === void 0 ? void 0 : _a.toString();
+    return (response ? JSON.parse(response) : undefined);
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f4(__0) {
   return (function() {
-    return function /*constructor*/(props) {
-        this.props = props;
-        this.cache = {};
-    };
+    return (function constructor(props) {
+    this.props = props;
+    this.cache = {};
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f5(__0) {
   return (function() {
-    return function /*get*/(key) {
-        return this.cache[key];
-    };
+    return (function (key) {
+    return this.cache[key];
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f6(__0) {
   return (function() {
-    return function /*getOrInit*/(client) {
-        if (!this.cache[client.key]) {
-            this.cache[client.key] = client.init(client.key, this.props);
-        }
-        return this.cache[client.key];
-    };
+    return (function getOrInit(client) {
+    if (!this.cache[client.key]) {
+        this.cache[client.key] = client.init(client.key, this.props);
+    }
+    return this.cache[client.key];
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f1() {
   return (function() {
     let c = __f2;
     let preWarmContext = __preWarmContext;
 
-    return function (...args) {
-                                return c(args, preWarmContext);
-                            };
+    return (function __computed(...args) {
+    return c(args, preWarmContext);
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f0() {
   return (function() {
     let func = __f1;
 
-    return () => {
-                return func();
-            };
+    return (() => {
+    return func();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }"
 `;
@@ -14164,6 +14246,7 @@ function __f3(__0, __1) {
       var _a;
       return new (require(\\"aws-sdk\\")).Lambda((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key));
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f2(__0, __1) {
@@ -14180,14 +14263,16 @@ function __f2(__0, __1) {
       }).promise()).Payload) === null || _a === void 0 ? void 0 : _a.toString();
       return response ? JSON.parse(response) : void 0;
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f4(__0) {
   return function() {
-    return function(props) {
+    return function constructor(props) {
       this.props = props;
       this.cache = {};
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f5(__0) {
@@ -14195,25 +14280,28 @@ function __f5(__0) {
     return function(key) {
       return this.cache[key];
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f6(__0) {
   return function() {
-    return function(client) {
+    return function getOrInit(client) {
       if (!this.cache[client.key]) {
         this.cache[client.key] = client.init(client.key, this.props);
       }
       return this.cache[client.key];
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f1() {
   return function() {
     let c = __f2;
     let preWarmContext = __preWarmContext;
-    return function(...args) {
+    return function __computed(...args) {
       return c(args, preWarmContext);
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f0() {
@@ -14222,6 +14310,7 @@ function __f0() {
     return () => {
       return func();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 "
@@ -14273,272 +14362,278 @@ __f23.kind = \\"Function\\";
 __f23.functionlessKind = \\"Function\\";
 function __f3(__0, __1) {
   return (function() {
-    return (key, props) => { var _a; 
-        // eslint-disable-next-line @typescript-eslint/no-require-imports, import/no-extraneous-dependencies
-        return new (require(\\"aws-sdk\\").DynamoDB)((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key)); };
+    return ((key, props) => {
+    var _a;
+    // eslint-disable-next-line @typescript-eslint/no-require-imports, import/no-extraneous-dependencies
+    return new (require(\\"aws-sdk\\").DynamoDB)((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key));
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f4(__0, __1) {
   return (function() {
-    return (key, props) => { var _a; 
-        // eslint-disable-next-line @typescript-eslint/no-require-imports, import/no-extraneous-dependencies
-        return new (require(\\"aws-sdk\\").EventBridge)((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key)); };
+    return ((key, props) => {
+    var _a;
+    // eslint-disable-next-line @typescript-eslint/no-require-imports, import/no-extraneous-dependencies
+    return new (require(\\"aws-sdk\\").EventBridge)((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key));
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f5(__0, __1) {
   return (function() {
-    return (key, props) => { var _a; 
-        // eslint-disable-next-line @typescript-eslint/no-require-imports, import/no-extraneous-dependencies
-        return new (require(\\"aws-sdk\\").Lambda)((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key)); };
+    return ((key, props) => {
+    var _a;
+    // eslint-disable-next-line @typescript-eslint/no-require-imports, import/no-extraneous-dependencies
+    return new (require(\\"aws-sdk\\").Lambda)((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key));
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f2(__0, __1) {
   return (function() {
     let function_prewarm_1 = __function_prewarm_1;
 
-    return async (args, preWarmContext) => {
-                    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
-                    const [input] = args;
-                    const { Table: table, ...rest } = input;
-                    return dynamo
-                        .deleteItem({
-                        ...rest,
-                        TableName: input.Table.tableName,
-                    })
-                        .promise();
-                };
+    return (async (args, preWarmContext) => {
+    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
+    const [input] = args;
+    const { Table: table, ...rest } = input;
+    return dynamo
+        .deleteItem({
+        ...rest,
+        TableName: input.Table.tableName,
+    })
+        .promise();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f6(__0) {
   return (function() {
-    return function /*constructor*/(props) {
-        this.props = props;
-        this.cache = {};
-    };
+    return (function constructor(props) {
+    this.props = props;
+    this.cache = {};
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f7(__0) {
   return (function() {
-    return function /*get*/(key) {
-        return this.cache[key];
-    };
+    return (function (key) {
+    return this.cache[key];
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f8(__0) {
   return (function() {
-    return function /*getOrInit*/(client) {
-        if (!this.cache[client.key]) {
-            this.cache[client.key] = client.init(client.key, this.props);
-        }
-        return this.cache[client.key];
-    };
+    return (function getOrInit(client) {
+    if (!this.cache[client.key]) {
+        this.cache[client.key] = client.init(client.key, this.props);
+    }
+    return this.cache[client.key];
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f1() {
   return (function() {
     let c = __f2;
     let preWarmContext = __preWarmContext;
 
-    return function (...args) {
-                                return c(args, preWarmContext);
-                            };
+    return (function __computed(...args) {
+    return c(args, preWarmContext);
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f10(__0, __1) {
   return (function() {
     let function_prewarm_1 = __function_prewarm_1;
 
-    return async (args, preWarmContext) => {
-                    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
-                    const [input] = args;
-                    const { Table: table, AttributesToGet, ...rest } = input;
-                    const payload = {
-                        ...rest,
-                        AttributesToGet: AttributesToGet,
-                        TableName: table.tableName,
-                    };
-                    return dynamo.getItem(payload).promise();
-                };
+    return (async (args, preWarmContext) => {
+    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
+    const [input] = args;
+    const { Table: table, AttributesToGet, ...rest } = input;
+    const payload = {
+        ...rest,
+        AttributesToGet: AttributesToGet,
+        TableName: table.tableName,
+    };
+    return dynamo.getItem(payload).promise();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f9() {
   return (function() {
     let c = __f10;
     let preWarmContext = __preWarmContext;
 
-    return function (...args) {
-                                return c(args, preWarmContext);
-                            };
+    return (function __computed(...args) {
+    return c(args, preWarmContext);
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f12(__0, __1) {
   return (function() {
     let function_prewarm_1 = __function_prewarm_1;
 
-    return async (args, preWarmContext) => {
-                    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
-                    const [input] = args;
-                    const { Table: table, ...rest } = input;
-                    return dynamo
-                        .updateItem({
-                        ...rest,
-                        TableName: table.tableName,
-                    })
-                        .promise();
-                };
+    return (async (args, preWarmContext) => {
+    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
+    const [input] = args;
+    const { Table: table, ...rest } = input;
+    return dynamo
+        .updateItem({
+        ...rest,
+        TableName: table.tableName,
+    })
+        .promise();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f11() {
   return (function() {
     let c = __f12;
     let preWarmContext = __preWarmContext;
 
-    return function (...args) {
-                                return c(args, preWarmContext);
-                            };
+    return (function __computed(...args) {
+    return c(args, preWarmContext);
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f14(__0, __1) {
   return (function() {
     let function_prewarm_1 = __function_prewarm_1;
 
-    return async (args, preWarmContext) => {
-                    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
-                    const [input] = args;
-                    const { Table: table, Item, ...rest } = input;
-                    return dynamo
-                        .putItem({
-                        ...rest,
-                        Item: Item,
-                        TableName: table.tableName,
-                    })
-                        .promise();
-                };
+    return (async (args, preWarmContext) => {
+    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
+    const [input] = args;
+    const { Table: table, Item, ...rest } = input;
+    return dynamo
+        .putItem({
+        ...rest,
+        Item: Item,
+        TableName: table.tableName,
+    })
+        .promise();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f13() {
   return (function() {
     let c = __f14;
     let preWarmContext = __preWarmContext;
 
-    return function (...args) {
-                                return c(args, preWarmContext);
-                            };
+    return (function __computed(...args) {
+    return c(args, preWarmContext);
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f16(__0, __1) {
   return (function() {
     let function_prewarm_1 = __function_prewarm_1;
 
-    return async (args, preWarmContext) => {
-                    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
-                    const [input] = args;
-                    const { Table: table, AttributesToGet, ...rest } = input;
-                    return dynamo
-                        .query({
-                        ...rest,
-                        AttributesToGet: AttributesToGet,
-                        TableName: table.tableName,
-                    })
-                        .promise();
-                };
+    return (async (args, preWarmContext) => {
+    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
+    const [input] = args;
+    const { Table: table, AttributesToGet, ...rest } = input;
+    return dynamo
+        .query({
+        ...rest,
+        AttributesToGet: AttributesToGet,
+        TableName: table.tableName,
+    })
+        .promise();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f15() {
   return (function() {
     let c = __f16;
     let preWarmContext = __preWarmContext;
 
-    return function (...args) {
-                                return c(args, preWarmContext);
-                            };
+    return (function __computed(...args) {
+    return c(args, preWarmContext);
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f18(__0, __1) {
   return (function() {
     let function_prewarm_1 = __function_prewarm_1;
 
-    return async (args, preWarmContext) => {
-                    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
-                    const [input] = args;
-                    const { Table: table, AttributesToGet, ...rest } = input;
-                    return dynamo
-                        .scan({
-                        ...rest,
-                        AttributesToGet: AttributesToGet,
-                        TableName: table.tableName,
-                    })
-                        .promise();
-                };
+    return (async (args, preWarmContext) => {
+    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
+    const [input] = args;
+    const { Table: table, AttributesToGet, ...rest } = input;
+    return dynamo
+        .scan({
+        ...rest,
+        AttributesToGet: AttributesToGet,
+        TableName: table.tableName,
+    })
+        .promise();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f17() {
   return (function() {
     let c = __f18;
     let preWarmContext = __preWarmContext;
 
-    return function (...args) {
-                                return c(args, preWarmContext);
-                            };
+    return (function __computed(...args) {
+    return c(args, preWarmContext);
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f19() {
   return (function() {
-    return function () {
-                                    throw new Error();
-                                };
+    return (function __computed() {
+    throw new Error();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f21(__0, __1) {
   return (function() {
     let function_prewarm_1 = __function_prewarm_1;
 
-    return async ([request], preWarmContext) => {
-                    const eventBridge = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.EVENT_BRIDGE);
-                    return eventBridge
-                        .putEvents({
-                        Entries: request.Entries.map((e) => ({
-                            ...e,
-                        })),
-                    })
-                        .promise();
-                };
+    return (async ([request], preWarmContext) => {
+    const eventBridge = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.EVENT_BRIDGE);
+    return eventBridge
+        .putEvents({
+        Entries: request.Entries.map((e) => ({
+            ...e,
+        })),
+    })
+        .promise();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f20() {
   return (function() {
     let c = __f21;
     let preWarmContext = __preWarmContext;
 
-    return function (...args) {
-                                return c(args, preWarmContext);
-                            };
+    return (function __computed(...args) {
+    return c(args, preWarmContext);
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f22() {
   return (function() {
     let m = __m;
     let k = \\"$AWS\\";
 
-    return function () { return m[k]; };
+    return (function __computed() { return m[k]; });;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f24(__0, __1) {
   return (function() {
     let function_prewarm_1 = __function_prewarm_1;
     let functionName = process.env.env__functionless0;
 
-    return async (args, prewarmContext) => {
-                var _a;
-                const [payload] = args;
-                const lambdaClient = prewarmContext.getOrInit(function_prewarm_1.PrewarmClients.LAMBDA);
-                const response = (_a = (await lambdaClient
-                    .invoke({
-                    FunctionName: functionName,
-                    ...(payload ? { Payload: JSON.stringify(payload) } : undefined),
-                })
-                    .promise()).Payload) === null || _a === void 0 ? void 0 : _a.toString();
-                return (response ? JSON.parse(response) : undefined);
-            };
+    return (async (args, prewarmContext) => {
+    var _a;
+    const [payload] = args;
+    const lambdaClient = prewarmContext.getOrInit(function_prewarm_1.PrewarmClients.LAMBDA);
+    const response = (_a = (await lambdaClient
+        .invoke({
+        FunctionName: functionName,
+        ...(payload ? { Payload: JSON.stringify(payload) } : undefined),
+    })
+        .promise()).Payload) === null || _a === void 0 ? void 0 : _a.toString();
+    return (response ? JSON.parse(response) : undefined);
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f23() {
   return (function() {
     let c = __f24;
     let preWarmContext = __preWarmContext;
 
-    return function (...args) {
-                                return c(args, preWarmContext);
-                            };
+    return (function __computed(...args) {
+    return c(args, preWarmContext);
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f0() {
   return (function() {
     let _fnls_1 = __fnls_1;
     let func = __f23;
 
-    return () => {
-                return _fnls_1.$AWS.Lambda.Invoke({
-                    Function: func,
-                    Payload: undefined,
-                });
-            };
+    return (() => {
+    return _fnls_1.$AWS.Lambda.Invoke({
+        Function: func,
+        Payload: undefined,
+    });
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }"
 `;
@@ -14593,6 +14688,7 @@ function __f3(__0, __1) {
       var _a;
       return new (require(\\"aws-sdk\\")).DynamoDB((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key));
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f4(__0, __1) {
@@ -14601,6 +14697,7 @@ function __f4(__0, __1) {
       var _a;
       return new (require(\\"aws-sdk\\")).EventBridge((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key));
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f5(__0, __1) {
@@ -14609,6 +14706,7 @@ function __f5(__0, __1) {
       var _a;
       return new (require(\\"aws-sdk\\")).Lambda((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key));
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f2(__0, __1) {
@@ -14623,14 +14721,16 @@ function __f2(__0, __1) {
         TableName: input.Table.tableName
       }).promise();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f6(__0) {
   return function() {
-    return function(props) {
+    return function constructor(props) {
       this.props = props;
       this.cache = {};
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f7(__0) {
@@ -14638,25 +14738,28 @@ function __f7(__0) {
     return function(key) {
       return this.cache[key];
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f8(__0) {
   return function() {
-    return function(client) {
+    return function getOrInit(client) {
       if (!this.cache[client.key]) {
         this.cache[client.key] = client.init(client.key, this.props);
       }
       return this.cache[client.key];
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f1() {
   return function() {
     let c = __f2;
     let preWarmContext = __preWarmContext;
-    return function(...args) {
+    return function __computed(...args) {
       return c(args, preWarmContext);
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f10(__0, __1) {
@@ -14673,15 +14776,17 @@ function __f10(__0, __1) {
       };
       return dynamo.getItem(payload).promise();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f9() {
   return function() {
     let c = __f10;
     let preWarmContext = __preWarmContext;
-    return function(...args) {
+    return function __computed(...args) {
       return c(args, preWarmContext);
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f12(__0, __1) {
@@ -14696,15 +14801,17 @@ function __f12(__0, __1) {
         TableName: table.tableName
       }).promise();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f11() {
   return function() {
     let c = __f12;
     let preWarmContext = __preWarmContext;
-    return function(...args) {
+    return function __computed(...args) {
       return c(args, preWarmContext);
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f14(__0, __1) {
@@ -14720,15 +14827,17 @@ function __f14(__0, __1) {
         TableName: table.tableName
       }).promise();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f13() {
   return function() {
     let c = __f14;
     let preWarmContext = __preWarmContext;
-    return function(...args) {
+    return function __computed(...args) {
       return c(args, preWarmContext);
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f16(__0, __1) {
@@ -14744,15 +14853,17 @@ function __f16(__0, __1) {
         TableName: table.tableName
       }).promise();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f15() {
   return function() {
     let c = __f16;
     let preWarmContext = __preWarmContext;
-    return function(...args) {
+    return function __computed(...args) {
       return c(args, preWarmContext);
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f18(__0, __1) {
@@ -14768,22 +14879,25 @@ function __f18(__0, __1) {
         TableName: table.tableName
       }).promise();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f17() {
   return function() {
     let c = __f18;
     let preWarmContext = __preWarmContext;
-    return function(...args) {
+    return function __computed(...args) {
       return c(args, preWarmContext);
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f19() {
   return function() {
-    return function() {
+    return function __computed() {
       throw new Error();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f21(__0, __1) {
@@ -14797,24 +14911,27 @@ function __f21(__0, __1) {
         }))
       }).promise();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f20() {
   return function() {
     let c = __f21;
     let preWarmContext = __preWarmContext;
-    return function(...args) {
+    return function __computed(...args) {
       return c(args, preWarmContext);
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f22() {
   return function() {
     let m = __m;
     let k = \\"$AWS\\";
-    return function() {
+    return function __computed() {
       return m[k];
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f24(__0, __1) {
@@ -14831,15 +14948,17 @@ function __f24(__0, __1) {
       }).promise()).Payload) === null || _a === void 0 ? void 0 : _a.toString();
       return response ? JSON.parse(response) : void 0;
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f23() {
   return function() {
     let c = __f24;
     let preWarmContext = __preWarmContext;
-    return function(...args) {
+    return function __computed(...args) {
       return c(args, preWarmContext);
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f0() {
@@ -14852,6 +14971,7 @@ function __f0() {
         Payload: void 0
       });
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 "
@@ -14903,272 +15023,278 @@ __f23.kind = \\"Function\\";
 __f23.functionlessKind = \\"Function\\";
 function __f3(__0, __1) {
   return (function() {
-    return (key, props) => { var _a; 
-        // eslint-disable-next-line @typescript-eslint/no-require-imports, import/no-extraneous-dependencies
-        return new (require(\\"aws-sdk\\").DynamoDB)((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key)); };
+    return ((key, props) => {
+    var _a;
+    // eslint-disable-next-line @typescript-eslint/no-require-imports, import/no-extraneous-dependencies
+    return new (require(\\"aws-sdk\\").DynamoDB)((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key));
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f4(__0, __1) {
   return (function() {
-    return (key, props) => { var _a; 
-        // eslint-disable-next-line @typescript-eslint/no-require-imports, import/no-extraneous-dependencies
-        return new (require(\\"aws-sdk\\").EventBridge)((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key)); };
+    return ((key, props) => {
+    var _a;
+    // eslint-disable-next-line @typescript-eslint/no-require-imports, import/no-extraneous-dependencies
+    return new (require(\\"aws-sdk\\").EventBridge)((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key));
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f5(__0, __1) {
   return (function() {
-    return (key, props) => { var _a; 
-        // eslint-disable-next-line @typescript-eslint/no-require-imports, import/no-extraneous-dependencies
-        return new (require(\\"aws-sdk\\").Lambda)((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key)); };
+    return ((key, props) => {
+    var _a;
+    // eslint-disable-next-line @typescript-eslint/no-require-imports, import/no-extraneous-dependencies
+    return new (require(\\"aws-sdk\\").Lambda)((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key));
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f2(__0, __1) {
   return (function() {
     let function_prewarm_1 = __function_prewarm_1;
 
-    return async (args, preWarmContext) => {
-                    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
-                    const [input] = args;
-                    const { Table: table, ...rest } = input;
-                    return dynamo
-                        .deleteItem({
-                        ...rest,
-                        TableName: input.Table.tableName,
-                    })
-                        .promise();
-                };
+    return (async (args, preWarmContext) => {
+    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
+    const [input] = args;
+    const { Table: table, ...rest } = input;
+    return dynamo
+        .deleteItem({
+        ...rest,
+        TableName: input.Table.tableName,
+    })
+        .promise();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f6(__0) {
   return (function() {
-    return function /*constructor*/(props) {
-        this.props = props;
-        this.cache = {};
-    };
+    return (function constructor(props) {
+    this.props = props;
+    this.cache = {};
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f7(__0) {
   return (function() {
-    return function /*get*/(key) {
-        return this.cache[key];
-    };
+    return (function (key) {
+    return this.cache[key];
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f8(__0) {
   return (function() {
-    return function /*getOrInit*/(client) {
-        if (!this.cache[client.key]) {
-            this.cache[client.key] = client.init(client.key, this.props);
-        }
-        return this.cache[client.key];
-    };
+    return (function getOrInit(client) {
+    if (!this.cache[client.key]) {
+        this.cache[client.key] = client.init(client.key, this.props);
+    }
+    return this.cache[client.key];
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f1() {
   return (function() {
     let c = __f2;
     let preWarmContext = __preWarmContext;
 
-    return function (...args) {
-                                return c(args, preWarmContext);
-                            };
+    return (function __computed(...args) {
+    return c(args, preWarmContext);
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f10(__0, __1) {
   return (function() {
     let function_prewarm_1 = __function_prewarm_1;
 
-    return async (args, preWarmContext) => {
-                    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
-                    const [input] = args;
-                    const { Table: table, AttributesToGet, ...rest } = input;
-                    const payload = {
-                        ...rest,
-                        AttributesToGet: AttributesToGet,
-                        TableName: table.tableName,
-                    };
-                    return dynamo.getItem(payload).promise();
-                };
+    return (async (args, preWarmContext) => {
+    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
+    const [input] = args;
+    const { Table: table, AttributesToGet, ...rest } = input;
+    const payload = {
+        ...rest,
+        AttributesToGet: AttributesToGet,
+        TableName: table.tableName,
+    };
+    return dynamo.getItem(payload).promise();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f9() {
   return (function() {
     let c = __f10;
     let preWarmContext = __preWarmContext;
 
-    return function (...args) {
-                                return c(args, preWarmContext);
-                            };
+    return (function __computed(...args) {
+    return c(args, preWarmContext);
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f12(__0, __1) {
   return (function() {
     let function_prewarm_1 = __function_prewarm_1;
 
-    return async (args, preWarmContext) => {
-                    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
-                    const [input] = args;
-                    const { Table: table, ...rest } = input;
-                    return dynamo
-                        .updateItem({
-                        ...rest,
-                        TableName: table.tableName,
-                    })
-                        .promise();
-                };
+    return (async (args, preWarmContext) => {
+    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
+    const [input] = args;
+    const { Table: table, ...rest } = input;
+    return dynamo
+        .updateItem({
+        ...rest,
+        TableName: table.tableName,
+    })
+        .promise();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f11() {
   return (function() {
     let c = __f12;
     let preWarmContext = __preWarmContext;
 
-    return function (...args) {
-                                return c(args, preWarmContext);
-                            };
+    return (function __computed(...args) {
+    return c(args, preWarmContext);
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f14(__0, __1) {
   return (function() {
     let function_prewarm_1 = __function_prewarm_1;
 
-    return async (args, preWarmContext) => {
-                    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
-                    const [input] = args;
-                    const { Table: table, Item, ...rest } = input;
-                    return dynamo
-                        .putItem({
-                        ...rest,
-                        Item: Item,
-                        TableName: table.tableName,
-                    })
-                        .promise();
-                };
+    return (async (args, preWarmContext) => {
+    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
+    const [input] = args;
+    const { Table: table, Item, ...rest } = input;
+    return dynamo
+        .putItem({
+        ...rest,
+        Item: Item,
+        TableName: table.tableName,
+    })
+        .promise();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f13() {
   return (function() {
     let c = __f14;
     let preWarmContext = __preWarmContext;
 
-    return function (...args) {
-                                return c(args, preWarmContext);
-                            };
+    return (function __computed(...args) {
+    return c(args, preWarmContext);
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f16(__0, __1) {
   return (function() {
     let function_prewarm_1 = __function_prewarm_1;
 
-    return async (args, preWarmContext) => {
-                    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
-                    const [input] = args;
-                    const { Table: table, AttributesToGet, ...rest } = input;
-                    return dynamo
-                        .query({
-                        ...rest,
-                        AttributesToGet: AttributesToGet,
-                        TableName: table.tableName,
-                    })
-                        .promise();
-                };
+    return (async (args, preWarmContext) => {
+    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
+    const [input] = args;
+    const { Table: table, AttributesToGet, ...rest } = input;
+    return dynamo
+        .query({
+        ...rest,
+        AttributesToGet: AttributesToGet,
+        TableName: table.tableName,
+    })
+        .promise();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f15() {
   return (function() {
     let c = __f16;
     let preWarmContext = __preWarmContext;
 
-    return function (...args) {
-                                return c(args, preWarmContext);
-                            };
+    return (function __computed(...args) {
+    return c(args, preWarmContext);
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f18(__0, __1) {
   return (function() {
     let function_prewarm_1 = __function_prewarm_1;
 
-    return async (args, preWarmContext) => {
-                    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
-                    const [input] = args;
-                    const { Table: table, AttributesToGet, ...rest } = input;
-                    return dynamo
-                        .scan({
-                        ...rest,
-                        AttributesToGet: AttributesToGet,
-                        TableName: table.tableName,
-                    })
-                        .promise();
-                };
+    return (async (args, preWarmContext) => {
+    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
+    const [input] = args;
+    const { Table: table, AttributesToGet, ...rest } = input;
+    return dynamo
+        .scan({
+        ...rest,
+        AttributesToGet: AttributesToGet,
+        TableName: table.tableName,
+    })
+        .promise();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f17() {
   return (function() {
     let c = __f18;
     let preWarmContext = __preWarmContext;
 
-    return function (...args) {
-                                return c(args, preWarmContext);
-                            };
+    return (function __computed(...args) {
+    return c(args, preWarmContext);
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f19() {
   return (function() {
-    return function () {
-                                    throw new Error();
-                                };
+    return (function __computed() {
+    throw new Error();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f21(__0, __1) {
   return (function() {
     let function_prewarm_1 = __function_prewarm_1;
 
-    return async ([request], preWarmContext) => {
-                    const eventBridge = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.EVENT_BRIDGE);
-                    return eventBridge
-                        .putEvents({
-                        Entries: request.Entries.map((e) => ({
-                            ...e,
-                        })),
-                    })
-                        .promise();
-                };
+    return (async ([request], preWarmContext) => {
+    const eventBridge = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.EVENT_BRIDGE);
+    return eventBridge
+        .putEvents({
+        Entries: request.Entries.map((e) => ({
+            ...e,
+        })),
+    })
+        .promise();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f20() {
   return (function() {
     let c = __f21;
     let preWarmContext = __preWarmContext;
 
-    return function (...args) {
-                                return c(args, preWarmContext);
-                            };
+    return (function __computed(...args) {
+    return c(args, preWarmContext);
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f22() {
   return (function() {
     let m = __m;
     let k = \\"$AWS\\";
 
-    return function () { return m[k]; };
+    return (function __computed() { return m[k]; });;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f24(__0, __1) {
   return (function() {
     let function_prewarm_1 = __function_prewarm_1;
     let functionName = process.env.env__functionless0;
 
-    return async (args, prewarmContext) => {
-                var _a;
-                const [payload] = args;
-                const lambdaClient = prewarmContext.getOrInit(function_prewarm_1.PrewarmClients.LAMBDA);
-                const response = (_a = (await lambdaClient
-                    .invoke({
-                    FunctionName: functionName,
-                    ...(payload ? { Payload: JSON.stringify(payload) } : undefined),
-                })
-                    .promise()).Payload) === null || _a === void 0 ? void 0 : _a.toString();
-                return (response ? JSON.parse(response) : undefined);
-            };
+    return (async (args, prewarmContext) => {
+    var _a;
+    const [payload] = args;
+    const lambdaClient = prewarmContext.getOrInit(function_prewarm_1.PrewarmClients.LAMBDA);
+    const response = (_a = (await lambdaClient
+        .invoke({
+        FunctionName: functionName,
+        ...(payload ? { Payload: JSON.stringify(payload) } : undefined),
+    })
+        .promise()).Payload) === null || _a === void 0 ? void 0 : _a.toString();
+    return (response ? JSON.parse(response) : undefined);
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f23() {
   return (function() {
     let c = __f24;
     let preWarmContext = __preWarmContext;
 
-    return function (...args) {
-                                return c(args, preWarmContext);
-                            };
+    return (function __computed(...args) {
+    return c(args, preWarmContext);
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f0() {
   return (function() {
     let _fnls_1 = __fnls_1;
     let func = __f23;
 
-    return () => {
-                return _fnls_1.$AWS.Lambda.Invoke({
-                    Function: func,
-                    Payload: undefined,
-                });
-            };
+    return (() => {
+    return _fnls_1.$AWS.Lambda.Invoke({
+        Function: func,
+        Payload: undefined,
+    });
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }"
 `;
@@ -15223,6 +15349,7 @@ function __f3(__0, __1) {
       var _a;
       return new (require(\\"aws-sdk\\")).DynamoDB((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key));
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f4(__0, __1) {
@@ -15231,6 +15358,7 @@ function __f4(__0, __1) {
       var _a;
       return new (require(\\"aws-sdk\\")).EventBridge((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key));
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f5(__0, __1) {
@@ -15239,6 +15367,7 @@ function __f5(__0, __1) {
       var _a;
       return new (require(\\"aws-sdk\\")).Lambda((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key));
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f2(__0, __1) {
@@ -15253,14 +15382,16 @@ function __f2(__0, __1) {
         TableName: input.Table.tableName
       }).promise();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f6(__0) {
   return function() {
-    return function(props) {
+    return function constructor(props) {
       this.props = props;
       this.cache = {};
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f7(__0) {
@@ -15268,25 +15399,28 @@ function __f7(__0) {
     return function(key) {
       return this.cache[key];
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f8(__0) {
   return function() {
-    return function(client) {
+    return function getOrInit(client) {
       if (!this.cache[client.key]) {
         this.cache[client.key] = client.init(client.key, this.props);
       }
       return this.cache[client.key];
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f1() {
   return function() {
     let c = __f2;
     let preWarmContext = __preWarmContext;
-    return function(...args) {
+    return function __computed(...args) {
       return c(args, preWarmContext);
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f10(__0, __1) {
@@ -15303,15 +15437,17 @@ function __f10(__0, __1) {
       };
       return dynamo.getItem(payload).promise();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f9() {
   return function() {
     let c = __f10;
     let preWarmContext = __preWarmContext;
-    return function(...args) {
+    return function __computed(...args) {
       return c(args, preWarmContext);
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f12(__0, __1) {
@@ -15326,15 +15462,17 @@ function __f12(__0, __1) {
         TableName: table.tableName
       }).promise();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f11() {
   return function() {
     let c = __f12;
     let preWarmContext = __preWarmContext;
-    return function(...args) {
+    return function __computed(...args) {
       return c(args, preWarmContext);
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f14(__0, __1) {
@@ -15350,15 +15488,17 @@ function __f14(__0, __1) {
         TableName: table.tableName
       }).promise();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f13() {
   return function() {
     let c = __f14;
     let preWarmContext = __preWarmContext;
-    return function(...args) {
+    return function __computed(...args) {
       return c(args, preWarmContext);
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f16(__0, __1) {
@@ -15374,15 +15514,17 @@ function __f16(__0, __1) {
         TableName: table.tableName
       }).promise();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f15() {
   return function() {
     let c = __f16;
     let preWarmContext = __preWarmContext;
-    return function(...args) {
+    return function __computed(...args) {
       return c(args, preWarmContext);
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f18(__0, __1) {
@@ -15398,22 +15540,25 @@ function __f18(__0, __1) {
         TableName: table.tableName
       }).promise();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f17() {
   return function() {
     let c = __f18;
     let preWarmContext = __preWarmContext;
-    return function(...args) {
+    return function __computed(...args) {
       return c(args, preWarmContext);
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f19() {
   return function() {
-    return function() {
+    return function __computed() {
       throw new Error();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f21(__0, __1) {
@@ -15427,24 +15572,27 @@ function __f21(__0, __1) {
         }))
       }).promise();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f20() {
   return function() {
     let c = __f21;
     let preWarmContext = __preWarmContext;
-    return function(...args) {
+    return function __computed(...args) {
       return c(args, preWarmContext);
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f22() {
   return function() {
     let m = __m;
     let k = \\"$AWS\\";
-    return function() {
+    return function __computed() {
       return m[k];
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f24(__0, __1) {
@@ -15461,15 +15609,17 @@ function __f24(__0, __1) {
       }).promise()).Payload) === null || _a === void 0 ? void 0 : _a.toString();
       return response ? JSON.parse(response) : void 0;
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f23() {
   return function() {
     let c = __f24;
     let preWarmContext = __preWarmContext;
-    return function(...args) {
+    return function __computed(...args) {
       return c(args, preWarmContext);
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f0() {
@@ -15482,6 +15632,7 @@ function __f0() {
         Payload: void 0
       });
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 "
@@ -15533,100 +15684,100 @@ __f1_definition.States = __f1_definition_States;
 __f1.definition = __f1_definition;
 function __f3(__0, __1) {
   return (function() {
-    return (key, props) => {
-            var _a;
-            // eslint-disable-next-line @typescript-eslint/no-require-imports, import/no-extraneous-dependencies
-            return new (require(\\"aws-sdk\\").StepFunctions)((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key));
-        };
+    return ((key, props) => {
+    var _a;
+    // eslint-disable-next-line @typescript-eslint/no-require-imports, import/no-extraneous-dependencies
+    return new (require(\\"aws-sdk\\").StepFunctions)((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key));
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f2(__0, __1) {
   return (function() {
     let function_prewarm_1 = __function_prewarm_1;
     let stateMachineArn = process.env.env__functionless0;
 
-    return async (args, prewarmContext) => {
-                const stepFunctionsClient = prewarmContext.getOrInit(function_prewarm_1.PrewarmClients.STEP_FUNCTIONS);
-                const [payload] = args;
-                const result = await stepFunctionsClient
-                    .startExecution({
-                    ...payload,
-                    stateMachineArn: stateMachineArn,
-                    input: payload.input ? JSON.stringify(payload.input) : undefined,
-                })
-                    .promise();
-                return result;
-            };
+    return (async (args, prewarmContext) => {
+    const stepFunctionsClient = prewarmContext.getOrInit(function_prewarm_1.PrewarmClients.STEP_FUNCTIONS);
+    const [payload] = args;
+    const result = await stepFunctionsClient
+        .startExecution({
+        ...payload,
+        stateMachineArn: stateMachineArn,
+        input: payload.input ? JSON.stringify(payload.input) : undefined,
+    })
+        .promise();
+    return result;
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f4(__0) {
   return (function() {
-    return function /*constructor*/(props) {
-        this.props = props;
-        this.cache = {};
-    };
+    return (function constructor(props) {
+    this.props = props;
+    this.cache = {};
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f5(__0) {
   return (function() {
-    return function /*get*/(key) {
-        return this.cache[key];
-    };
+    return (function (key) {
+    return this.cache[key];
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f6(__0) {
   return (function() {
-    return function /*getOrInit*/(client) {
-        if (!this.cache[client.key]) {
-            this.cache[client.key] = client.init(client.key, this.props);
-        }
-        return this.cache[client.key];
-    };
+    return (function getOrInit(client) {
+    if (!this.cache[client.key]) {
+        this.cache[client.key] = client.init(client.key, this.props);
+    }
+    return this.cache[client.key];
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f1() {
   return (function() {
     let c = __f2;
     let preWarmContext = __preWarmContext;
 
-    return function (...args) {
-                                return c(args, preWarmContext);
-                            };
+    return (function __computed(...args) {
+    return c(args, preWarmContext);
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f8(__0, __1) {
   return (function() {
     let function_prewarm_1 = __function_prewarm_1;
 
-    return async (args, prewarmContext) => {
-                    const stepFunctionClient = prewarmContext.getOrInit(function_prewarm_1.PrewarmClients.STEP_FUNCTIONS);
-                    const [arn] = args;
-                    return stepFunctionClient
-                        .describeExecution({
-                        executionArn: arn,
-                    })
-                        .promise();
-                };
+    return (async (args, prewarmContext) => {
+    const stepFunctionClient = prewarmContext.getOrInit(function_prewarm_1.PrewarmClients.STEP_FUNCTIONS);
+    const [arn] = args;
+    return stepFunctionClient
+        .describeExecution({
+        executionArn: arn,
+    })
+        .promise();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f7() {
   return (function() {
     let c = __f8;
     let preWarmContext = __preWarmContext;
 
-    return function (...args) {
-                                return c(args, preWarmContext);
-                            };
+    return (function __computed(...args) {
+    return c(args, preWarmContext);
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f9(__0, __1) {
   return (function() {
     let asl_1 = __asl_1;
     let vtl_1 = __vtl_1;
 
-    return (kind, contextKind) => {
-                throw new Error(\`\${kind} is only available in the \${asl_1.ASL.ContextName} and \${vtl_1.VTL.ContextName} context, but was used in \${contextKind}.\`);
-            };
+    return ((kind, contextKind) => {
+    throw new Error(\`\${kind} is only available in the \${asl_1.ASL.ContextName} and \${vtl_1.VTL.ContextName} context, but was used in \${contextKind}.\`);
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f0() {
   return (function() {
     let sfn = __f1;
 
-    return async () => {
-                return sfn({ input: {} });
-            };
+    return (async () => {
+    return sfn({ input: {} });
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }"
 `;
@@ -15681,6 +15832,7 @@ function __f3(__0, __1) {
       var _a;
       return new (require(\\"aws-sdk\\")).StepFunctions((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key));
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f2(__0, __1) {
@@ -15697,14 +15849,16 @@ function __f2(__0, __1) {
       }).promise();
       return result;
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f4(__0) {
   return function() {
-    return function(props) {
+    return function constructor(props) {
       this.props = props;
       this.cache = {};
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f5(__0) {
@@ -15712,25 +15866,28 @@ function __f5(__0) {
     return function(key) {
       return this.cache[key];
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f6(__0) {
   return function() {
-    return function(client) {
+    return function getOrInit(client) {
       if (!this.cache[client.key]) {
         this.cache[client.key] = client.init(client.key, this.props);
       }
       return this.cache[client.key];
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f1() {
   return function() {
     let c = __f2;
     let preWarmContext = __preWarmContext;
-    return function(...args) {
+    return function __computed(...args) {
       return c(args, preWarmContext);
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f8(__0, __1) {
@@ -15743,15 +15900,17 @@ function __f8(__0, __1) {
         executionArn: arn
       }).promise();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f7() {
   return function() {
     let c = __f8;
     let preWarmContext = __preWarmContext;
-    return function(...args) {
+    return function __computed(...args) {
       return c(args, preWarmContext);
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f9(__0, __1) {
@@ -15761,6 +15920,7 @@ function __f9(__0, __1) {
     return (kind, contextKind) => {
       throw new Error(\`\${kind} is only available in the \${asl_1.ASL.ContextName} and \${vtl_1.VTL.ContextName} context, but was used in \${contextKind}.\`);
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f0() {
@@ -15769,6 +15929,7 @@ function __f0() {
     return async () => {
       return sfn({ input: {} });
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 "
@@ -15820,100 +15981,100 @@ __f1_definition.States = __f1_definition_States;
 __f1.definition = __f1_definition;
 function __f3(__0, __1) {
   return (function() {
-    return (key, props) => {
-            var _a;
-            // eslint-disable-next-line @typescript-eslint/no-require-imports, import/no-extraneous-dependencies
-            return new (require(\\"aws-sdk\\").StepFunctions)((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key));
-        };
+    return ((key, props) => {
+    var _a;
+    // eslint-disable-next-line @typescript-eslint/no-require-imports, import/no-extraneous-dependencies
+    return new (require(\\"aws-sdk\\").StepFunctions)((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key));
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f2(__0, __1) {
   return (function() {
     let function_prewarm_1 = __function_prewarm_1;
     let stateMachineArn = process.env.env__functionless0;
 
-    return async (args, prewarmContext) => {
-                const stepFunctionsClient = prewarmContext.getOrInit(function_prewarm_1.PrewarmClients.STEP_FUNCTIONS);
-                const [payload] = args;
-                const result = await stepFunctionsClient
-                    .startExecution({
-                    ...payload,
-                    stateMachineArn: stateMachineArn,
-                    input: payload.input ? JSON.stringify(payload.input) : undefined,
-                })
-                    .promise();
-                return result;
-            };
+    return (async (args, prewarmContext) => {
+    const stepFunctionsClient = prewarmContext.getOrInit(function_prewarm_1.PrewarmClients.STEP_FUNCTIONS);
+    const [payload] = args;
+    const result = await stepFunctionsClient
+        .startExecution({
+        ...payload,
+        stateMachineArn: stateMachineArn,
+        input: payload.input ? JSON.stringify(payload.input) : undefined,
+    })
+        .promise();
+    return result;
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f4(__0) {
   return (function() {
-    return function /*constructor*/(props) {
-        this.props = props;
-        this.cache = {};
-    };
+    return (function constructor(props) {
+    this.props = props;
+    this.cache = {};
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f5(__0) {
   return (function() {
-    return function /*get*/(key) {
-        return this.cache[key];
-    };
+    return (function (key) {
+    return this.cache[key];
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f6(__0) {
   return (function() {
-    return function /*getOrInit*/(client) {
-        if (!this.cache[client.key]) {
-            this.cache[client.key] = client.init(client.key, this.props);
-        }
-        return this.cache[client.key];
-    };
+    return (function getOrInit(client) {
+    if (!this.cache[client.key]) {
+        this.cache[client.key] = client.init(client.key, this.props);
+    }
+    return this.cache[client.key];
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f1() {
   return (function() {
     let c = __f2;
     let preWarmContext = __preWarmContext;
 
-    return function (...args) {
-                                return c(args, preWarmContext);
-                            };
+    return (function __computed(...args) {
+    return c(args, preWarmContext);
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f8(__0, __1) {
   return (function() {
     let function_prewarm_1 = __function_prewarm_1;
 
-    return async (args, prewarmContext) => {
-                    const stepFunctionClient = prewarmContext.getOrInit(function_prewarm_1.PrewarmClients.STEP_FUNCTIONS);
-                    const [arn] = args;
-                    return stepFunctionClient
-                        .describeExecution({
-                        executionArn: arn,
-                    })
-                        .promise();
-                };
+    return (async (args, prewarmContext) => {
+    const stepFunctionClient = prewarmContext.getOrInit(function_prewarm_1.PrewarmClients.STEP_FUNCTIONS);
+    const [arn] = args;
+    return stepFunctionClient
+        .describeExecution({
+        executionArn: arn,
+    })
+        .promise();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f7() {
   return (function() {
     let c = __f8;
     let preWarmContext = __preWarmContext;
 
-    return function (...args) {
-                                return c(args, preWarmContext);
-                            };
+    return (function __computed(...args) {
+    return c(args, preWarmContext);
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f9(__0, __1) {
   return (function() {
     let asl_1 = __asl_1;
     let vtl_1 = __vtl_1;
 
-    return (kind, contextKind) => {
-                throw new Error(\`\${kind} is only available in the \${asl_1.ASL.ContextName} and \${vtl_1.VTL.ContextName} context, but was used in \${contextKind}.\`);
-            };
+    return ((kind, contextKind) => {
+    throw new Error(\`\${kind} is only available in the \${asl_1.ASL.ContextName} and \${vtl_1.VTL.ContextName} context, but was used in \${contextKind}.\`);
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f0() {
   return (function() {
     let sfn = __f1;
 
-    return () => {
-                return sfn({ input: {} });
-            };
+    return (() => {
+    return sfn({ input: {} });
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }"
 `;
@@ -15968,6 +16129,7 @@ function __f3(__0, __1) {
       var _a;
       return new (require(\\"aws-sdk\\")).StepFunctions((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key));
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f2(__0, __1) {
@@ -15984,14 +16146,16 @@ function __f2(__0, __1) {
       }).promise();
       return result;
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f4(__0) {
   return function() {
-    return function(props) {
+    return function constructor(props) {
       this.props = props;
       this.cache = {};
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f5(__0) {
@@ -15999,25 +16163,28 @@ function __f5(__0) {
     return function(key) {
       return this.cache[key];
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f6(__0) {
   return function() {
-    return function(client) {
+    return function getOrInit(client) {
       if (!this.cache[client.key]) {
         this.cache[client.key] = client.init(client.key, this.props);
       }
       return this.cache[client.key];
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f1() {
   return function() {
     let c = __f2;
     let preWarmContext = __preWarmContext;
-    return function(...args) {
+    return function __computed(...args) {
       return c(args, preWarmContext);
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f8(__0, __1) {
@@ -16030,15 +16197,17 @@ function __f8(__0, __1) {
         executionArn: arn
       }).promise();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f7() {
   return function() {
     let c = __f8;
     let preWarmContext = __preWarmContext;
-    return function(...args) {
+    return function __computed(...args) {
       return c(args, preWarmContext);
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f9(__0, __1) {
@@ -16048,6 +16217,7 @@ function __f9(__0, __1) {
     return (kind, contextKind) => {
       throw new Error(\`\${kind} is only available in the \${asl_1.ASL.ContextName} and \${vtl_1.VTL.ContextName} context, but was used in \${contextKind}.\`);
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f0() {
@@ -16056,6 +16226,7 @@ function __f0() {
     return () => {
       return sfn({ input: {} });
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 "
@@ -16065,9 +16236,9 @@ exports[`serialize simple 1`] = `
 "exports.handler = __f0;
 function __f0() {
   return (function() {
-    return async () => {
-            return \\"hello\\";
-        };
+    return (async () => {
+    return \\"hello\\";
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }"
 `;
@@ -16080,6 +16251,7 @@ function __f0() {
     return async () => {
       return \\"hello\\";
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 "
@@ -16138,279 +16310,283 @@ var __f22_appsync = {getItem: __f23, putItem: __f24, updateItem: __f25, deleteIt
 __f22.appsync = __f22_appsync;
 function __f3(__0, __1) {
   return (function() {
-    return (key, props) => { var _a; 
-        // eslint-disable-next-line @typescript-eslint/no-require-imports, import/no-extraneous-dependencies
-        return new (require(\\"aws-sdk\\").DynamoDB)((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key)); };
+    return ((key, props) => {
+    var _a;
+    // eslint-disable-next-line @typescript-eslint/no-require-imports, import/no-extraneous-dependencies
+    return new (require(\\"aws-sdk\\").DynamoDB)((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key));
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f4(__0, __1) {
   return (function() {
-    return (key, props) => { var _a; 
-        // eslint-disable-next-line @typescript-eslint/no-require-imports, import/no-extraneous-dependencies
-        return new (require(\\"aws-sdk\\").EventBridge)((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key)); };
+    return ((key, props) => {
+    var _a;
+    // eslint-disable-next-line @typescript-eslint/no-require-imports, import/no-extraneous-dependencies
+    return new (require(\\"aws-sdk\\").EventBridge)((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key));
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f2(__0, __1) {
   return (function() {
     let function_prewarm_1 = __function_prewarm_1;
 
-    return async (args, preWarmContext) => {
-                    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
-                    const [input] = args;
-                    const { Table: table, ...rest } = input;
-                    return dynamo
-                        .deleteItem({
-                        ...rest,
-                        TableName: input.Table.tableName,
-                    })
-                        .promise();
-                };
+    return (async (args, preWarmContext) => {
+    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
+    const [input] = args;
+    const { Table: table, ...rest } = input;
+    return dynamo
+        .deleteItem({
+        ...rest,
+        TableName: input.Table.tableName,
+    })
+        .promise();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f5(__0) {
   return (function() {
-    return function /*constructor*/(props) {
-        this.props = props;
-        this.cache = {};
-    };
+    return (function constructor(props) {
+    this.props = props;
+    this.cache = {};
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f6(__0) {
   return (function() {
-    return function /*get*/(key) {
-        return this.cache[key];
-    };
+    return (function (key) {
+    return this.cache[key];
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f7(__0) {
   return (function() {
-    return function /*getOrInit*/(client) {
-        if (!this.cache[client.key]) {
-            this.cache[client.key] = client.init(client.key, this.props);
-        }
-        return this.cache[client.key];
-    };
+    return (function getOrInit(client) {
+    if (!this.cache[client.key]) {
+        this.cache[client.key] = client.init(client.key, this.props);
+    }
+    return this.cache[client.key];
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f1() {
   return (function() {
     let c = __f2;
     let preWarmContext = __preWarmContext;
 
-    return function (...args) {
-                                return c(args, preWarmContext);
-                            };
+    return (function __computed(...args) {
+    return c(args, preWarmContext);
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f9(__0, __1) {
   return (function() {
     let function_prewarm_1 = __function_prewarm_1;
 
-    return async (args, preWarmContext) => {
-                    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
-                    const [input] = args;
-                    const { Table: table, AttributesToGet, ...rest } = input;
-                    const payload = {
-                        ...rest,
-                        AttributesToGet: AttributesToGet,
-                        TableName: table.tableName,
-                    };
-                    return dynamo.getItem(payload).promise();
-                };
+    return (async (args, preWarmContext) => {
+    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
+    const [input] = args;
+    const { Table: table, AttributesToGet, ...rest } = input;
+    const payload = {
+        ...rest,
+        AttributesToGet: AttributesToGet,
+        TableName: table.tableName,
+    };
+    return dynamo.getItem(payload).promise();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f8() {
   return (function() {
     let c = __f9;
     let preWarmContext = __preWarmContext;
 
-    return function (...args) {
-                                return c(args, preWarmContext);
-                            };
+    return (function __computed(...args) {
+    return c(args, preWarmContext);
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f11(__0, __1) {
   return (function() {
     let function_prewarm_1 = __function_prewarm_1;
 
-    return async (args, preWarmContext) => {
-                    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
-                    const [input] = args;
-                    const { Table: table, ...rest } = input;
-                    return dynamo
-                        .updateItem({
-                        ...rest,
-                        TableName: table.tableName,
-                    })
-                        .promise();
-                };
+    return (async (args, preWarmContext) => {
+    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
+    const [input] = args;
+    const { Table: table, ...rest } = input;
+    return dynamo
+        .updateItem({
+        ...rest,
+        TableName: table.tableName,
+    })
+        .promise();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f10() {
   return (function() {
     let c = __f11;
     let preWarmContext = __preWarmContext;
 
-    return function (...args) {
-                                return c(args, preWarmContext);
-                            };
+    return (function __computed(...args) {
+    return c(args, preWarmContext);
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f13(__0, __1) {
   return (function() {
     let function_prewarm_1 = __function_prewarm_1;
 
-    return async (args, preWarmContext) => {
-                    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
-                    const [input] = args;
-                    const { Table: table, Item, ...rest } = input;
-                    return dynamo
-                        .putItem({
-                        ...rest,
-                        Item: Item,
-                        TableName: table.tableName,
-                    })
-                        .promise();
-                };
+    return (async (args, preWarmContext) => {
+    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
+    const [input] = args;
+    const { Table: table, Item, ...rest } = input;
+    return dynamo
+        .putItem({
+        ...rest,
+        Item: Item,
+        TableName: table.tableName,
+    })
+        .promise();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f12() {
   return (function() {
     let c = __f13;
     let preWarmContext = __preWarmContext;
 
-    return function (...args) {
-                                return c(args, preWarmContext);
-                            };
+    return (function __computed(...args) {
+    return c(args, preWarmContext);
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f15(__0, __1) {
   return (function() {
     let function_prewarm_1 = __function_prewarm_1;
 
-    return async (args, preWarmContext) => {
-                    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
-                    const [input] = args;
-                    const { Table: table, AttributesToGet, ...rest } = input;
-                    return dynamo
-                        .query({
-                        ...rest,
-                        AttributesToGet: AttributesToGet,
-                        TableName: table.tableName,
-                    })
-                        .promise();
-                };
+    return (async (args, preWarmContext) => {
+    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
+    const [input] = args;
+    const { Table: table, AttributesToGet, ...rest } = input;
+    return dynamo
+        .query({
+        ...rest,
+        AttributesToGet: AttributesToGet,
+        TableName: table.tableName,
+    })
+        .promise();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f14() {
   return (function() {
     let c = __f15;
     let preWarmContext = __preWarmContext;
 
-    return function (...args) {
-                                return c(args, preWarmContext);
-                            };
+    return (function __computed(...args) {
+    return c(args, preWarmContext);
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f17(__0, __1) {
   return (function() {
     let function_prewarm_1 = __function_prewarm_1;
 
-    return async (args, preWarmContext) => {
-                    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
-                    const [input] = args;
-                    const { Table: table, AttributesToGet, ...rest } = input;
-                    return dynamo
-                        .scan({
-                        ...rest,
-                        AttributesToGet: AttributesToGet,
-                        TableName: table.tableName,
-                    })
-                        .promise();
-                };
+    return (async (args, preWarmContext) => {
+    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
+    const [input] = args;
+    const { Table: table, AttributesToGet, ...rest } = input;
+    return dynamo
+        .scan({
+        ...rest,
+        AttributesToGet: AttributesToGet,
+        TableName: table.tableName,
+    })
+        .promise();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f16() {
   return (function() {
     let c = __f17;
     let preWarmContext = __preWarmContext;
 
-    return function (...args) {
-                                return c(args, preWarmContext);
-                            };
+    return (function __computed(...args) {
+    return c(args, preWarmContext);
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f18() {
   return (function() {
-    return function () {
-                                    throw new Error();
-                                };
+    return (function __computed() {
+    throw new Error();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f20(__0, __1) {
   return (function() {
     let function_prewarm_1 = __function_prewarm_1;
 
-    return async ([request], preWarmContext) => {
-                    const eventBridge = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.EVENT_BRIDGE);
-                    return eventBridge
-                        .putEvents({
-                        Entries: request.Entries.map((e) => ({
-                            ...e,
-                        })),
-                    })
-                        .promise();
-                };
+    return (async ([request], preWarmContext) => {
+    const eventBridge = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.EVENT_BRIDGE);
+    return eventBridge
+        .putEvents({
+        Entries: request.Entries.map((e) => ({
+            ...e,
+        })),
+    })
+        .promise();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f19() {
   return (function() {
     let c = __f20;
     let preWarmContext = __preWarmContext;
 
-    return function (...args) {
-                                return c(args, preWarmContext);
-                            };
+    return (function __computed(...args) {
+    return c(args, preWarmContext);
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f21() {
   return (function() {
     let m = __m;
     let k = \\"$AWS\\";
 
-    return function () { return m[k]; };
+    return (function __computed() { return m[k]; });;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f22() {
   return (function() {
-    return function () {
-                                    throw new Error();
-                                };
+    return (function __computed() {
+    throw new Error();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f23() {
   return (function() {
-    return function () {
-                                    throw new Error();
-                                };
+    return (function __computed() {
+    throw new Error();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f24() {
   return (function() {
-    return function () {
-                                    throw new Error();
-                                };
+    return (function __computed() {
+    throw new Error();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f25() {
   return (function() {
-    return function () {
-                                    throw new Error();
-                                };
+    return (function __computed() {
+    throw new Error();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f26() {
   return (function() {
-    return function () {
-                                    throw new Error();
-                                };
+    return (function __computed() {
+    throw new Error();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f27() {
   return (function() {
-    return function () {
-                                    throw new Error();
-                                };
+    return (function __computed() {
+    throw new Error();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f0() {
   return (function() {
     let _fnls_1 = __fnls_1;
     let table = __f22;
 
-    return async () => {
-                return _fnls_1.$AWS.DynamoDB.DeleteItem({
-                    Table: table,
-                    Key: {
-                        id: {
-                            S: \\"key\\",
-                        },
-                    },
-                });
-            };
+    return (async () => {
+    return _fnls_1.$AWS.DynamoDB.DeleteItem({
+        Table: table,
+        Key: {
+            id: {
+                S: \\"key\\",
+            },
+        },
+    });
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }"
 `;
@@ -16472,6 +16648,7 @@ function __f3(__0, __1) {
       var _a;
       return new (require(\\"aws-sdk\\")).DynamoDB((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key));
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f4(__0, __1) {
@@ -16480,6 +16657,7 @@ function __f4(__0, __1) {
       var _a;
       return new (require(\\"aws-sdk\\")).EventBridge((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key));
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f2(__0, __1) {
@@ -16494,14 +16672,16 @@ function __f2(__0, __1) {
         TableName: input.Table.tableName
       }).promise();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f5(__0) {
   return function() {
-    return function(props) {
+    return function constructor(props) {
       this.props = props;
       this.cache = {};
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f6(__0) {
@@ -16509,25 +16689,28 @@ function __f6(__0) {
     return function(key) {
       return this.cache[key];
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f7(__0) {
   return function() {
-    return function(client) {
+    return function getOrInit(client) {
       if (!this.cache[client.key]) {
         this.cache[client.key] = client.init(client.key, this.props);
       }
       return this.cache[client.key];
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f1() {
   return function() {
     let c = __f2;
     let preWarmContext = __preWarmContext;
-    return function(...args) {
+    return function __computed(...args) {
       return c(args, preWarmContext);
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f9(__0, __1) {
@@ -16544,15 +16727,17 @@ function __f9(__0, __1) {
       };
       return dynamo.getItem(payload).promise();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f8() {
   return function() {
     let c = __f9;
     let preWarmContext = __preWarmContext;
-    return function(...args) {
+    return function __computed(...args) {
       return c(args, preWarmContext);
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f11(__0, __1) {
@@ -16567,15 +16752,17 @@ function __f11(__0, __1) {
         TableName: table.tableName
       }).promise();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f10() {
   return function() {
     let c = __f11;
     let preWarmContext = __preWarmContext;
-    return function(...args) {
+    return function __computed(...args) {
       return c(args, preWarmContext);
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f13(__0, __1) {
@@ -16591,15 +16778,17 @@ function __f13(__0, __1) {
         TableName: table.tableName
       }).promise();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f12() {
   return function() {
     let c = __f13;
     let preWarmContext = __preWarmContext;
-    return function(...args) {
+    return function __computed(...args) {
       return c(args, preWarmContext);
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f15(__0, __1) {
@@ -16615,15 +16804,17 @@ function __f15(__0, __1) {
         TableName: table.tableName
       }).promise();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f14() {
   return function() {
     let c = __f15;
     let preWarmContext = __preWarmContext;
-    return function(...args) {
+    return function __computed(...args) {
       return c(args, preWarmContext);
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f17(__0, __1) {
@@ -16639,22 +16830,25 @@ function __f17(__0, __1) {
         TableName: table.tableName
       }).promise();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f16() {
   return function() {
     let c = __f17;
     let preWarmContext = __preWarmContext;
-    return function(...args) {
+    return function __computed(...args) {
       return c(args, preWarmContext);
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f18() {
   return function() {
-    return function() {
+    return function __computed() {
       throw new Error();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f20(__0, __1) {
@@ -16668,66 +16862,75 @@ function __f20(__0, __1) {
         }))
       }).promise();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f19() {
   return function() {
     let c = __f20;
     let preWarmContext = __preWarmContext;
-    return function(...args) {
+    return function __computed(...args) {
       return c(args, preWarmContext);
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f21() {
   return function() {
     let m = __m;
     let k = \\"$AWS\\";
-    return function() {
+    return function __computed() {
       return m[k];
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f22() {
   return function() {
-    return function() {
+    return function __computed() {
       throw new Error();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f23() {
   return function() {
-    return function() {
+    return function __computed() {
       throw new Error();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f24() {
   return function() {
-    return function() {
+    return function __computed() {
       throw new Error();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f25() {
   return function() {
-    return function() {
+    return function __computed() {
       throw new Error();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f26() {
   return function() {
-    return function() {
+    return function __computed() {
       throw new Error();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f27() {
   return function() {
-    return function() {
+    return function __computed() {
       throw new Error();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f0() {
@@ -16744,6 +16947,7 @@ function __f0() {
         }
       });
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 "
@@ -16802,277 +17006,281 @@ var __f22_appsync = {getItem: __f23, putItem: __f24, updateItem: __f25, deleteIt
 __f22.appsync = __f22_appsync;
 function __f3(__0, __1) {
   return (function() {
-    return (key, props) => { var _a; 
-        // eslint-disable-next-line @typescript-eslint/no-require-imports, import/no-extraneous-dependencies
-        return new (require(\\"aws-sdk\\").DynamoDB)((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key)); };
+    return ((key, props) => {
+    var _a;
+    // eslint-disable-next-line @typescript-eslint/no-require-imports, import/no-extraneous-dependencies
+    return new (require(\\"aws-sdk\\").DynamoDB)((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key));
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f4(__0, __1) {
   return (function() {
-    return (key, props) => { var _a; 
-        // eslint-disable-next-line @typescript-eslint/no-require-imports, import/no-extraneous-dependencies
-        return new (require(\\"aws-sdk\\").EventBridge)((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key)); };
+    return ((key, props) => {
+    var _a;
+    // eslint-disable-next-line @typescript-eslint/no-require-imports, import/no-extraneous-dependencies
+    return new (require(\\"aws-sdk\\").EventBridge)((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key));
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f2(__0, __1) {
   return (function() {
     let function_prewarm_1 = __function_prewarm_1;
 
-    return async (args, preWarmContext) => {
-                    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
-                    const [input] = args;
-                    const { Table: table, ...rest } = input;
-                    return dynamo
-                        .deleteItem({
-                        ...rest,
-                        TableName: input.Table.tableName,
-                    })
-                        .promise();
-                };
+    return (async (args, preWarmContext) => {
+    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
+    const [input] = args;
+    const { Table: table, ...rest } = input;
+    return dynamo
+        .deleteItem({
+        ...rest,
+        TableName: input.Table.tableName,
+    })
+        .promise();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f5(__0) {
   return (function() {
-    return function /*constructor*/(props) {
-        this.props = props;
-        this.cache = {};
-    };
+    return (function constructor(props) {
+    this.props = props;
+    this.cache = {};
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f6(__0) {
   return (function() {
-    return function /*get*/(key) {
-        return this.cache[key];
-    };
+    return (function (key) {
+    return this.cache[key];
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f7(__0) {
   return (function() {
-    return function /*getOrInit*/(client) {
-        if (!this.cache[client.key]) {
-            this.cache[client.key] = client.init(client.key, this.props);
-        }
-        return this.cache[client.key];
-    };
+    return (function getOrInit(client) {
+    if (!this.cache[client.key]) {
+        this.cache[client.key] = client.init(client.key, this.props);
+    }
+    return this.cache[client.key];
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f1() {
   return (function() {
     let c = __f2;
     let preWarmContext = __preWarmContext;
 
-    return function (...args) {
-                                return c(args, preWarmContext);
-                            };
+    return (function __computed(...args) {
+    return c(args, preWarmContext);
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f9(__0, __1) {
   return (function() {
     let function_prewarm_1 = __function_prewarm_1;
 
-    return async (args, preWarmContext) => {
-                    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
-                    const [input] = args;
-                    const { Table: table, AttributesToGet, ...rest } = input;
-                    const payload = {
-                        ...rest,
-                        AttributesToGet: AttributesToGet,
-                        TableName: table.tableName,
-                    };
-                    return dynamo.getItem(payload).promise();
-                };
+    return (async (args, preWarmContext) => {
+    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
+    const [input] = args;
+    const { Table: table, AttributesToGet, ...rest } = input;
+    const payload = {
+        ...rest,
+        AttributesToGet: AttributesToGet,
+        TableName: table.tableName,
+    };
+    return dynamo.getItem(payload).promise();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f8() {
   return (function() {
     let c = __f9;
     let preWarmContext = __preWarmContext;
 
-    return function (...args) {
-                                return c(args, preWarmContext);
-                            };
+    return (function __computed(...args) {
+    return c(args, preWarmContext);
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f11(__0, __1) {
   return (function() {
     let function_prewarm_1 = __function_prewarm_1;
 
-    return async (args, preWarmContext) => {
-                    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
-                    const [input] = args;
-                    const { Table: table, ...rest } = input;
-                    return dynamo
-                        .updateItem({
-                        ...rest,
-                        TableName: table.tableName,
-                    })
-                        .promise();
-                };
+    return (async (args, preWarmContext) => {
+    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
+    const [input] = args;
+    const { Table: table, ...rest } = input;
+    return dynamo
+        .updateItem({
+        ...rest,
+        TableName: table.tableName,
+    })
+        .promise();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f10() {
   return (function() {
     let c = __f11;
     let preWarmContext = __preWarmContext;
 
-    return function (...args) {
-                                return c(args, preWarmContext);
-                            };
+    return (function __computed(...args) {
+    return c(args, preWarmContext);
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f13(__0, __1) {
   return (function() {
     let function_prewarm_1 = __function_prewarm_1;
 
-    return async (args, preWarmContext) => {
-                    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
-                    const [input] = args;
-                    const { Table: table, Item, ...rest } = input;
-                    return dynamo
-                        .putItem({
-                        ...rest,
-                        Item: Item,
-                        TableName: table.tableName,
-                    })
-                        .promise();
-                };
+    return (async (args, preWarmContext) => {
+    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
+    const [input] = args;
+    const { Table: table, Item, ...rest } = input;
+    return dynamo
+        .putItem({
+        ...rest,
+        Item: Item,
+        TableName: table.tableName,
+    })
+        .promise();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f12() {
   return (function() {
     let c = __f13;
     let preWarmContext = __preWarmContext;
 
-    return function (...args) {
-                                return c(args, preWarmContext);
-                            };
+    return (function __computed(...args) {
+    return c(args, preWarmContext);
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f15(__0, __1) {
   return (function() {
     let function_prewarm_1 = __function_prewarm_1;
 
-    return async (args, preWarmContext) => {
-                    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
-                    const [input] = args;
-                    const { Table: table, AttributesToGet, ...rest } = input;
-                    return dynamo
-                        .query({
-                        ...rest,
-                        AttributesToGet: AttributesToGet,
-                        TableName: table.tableName,
-                    })
-                        .promise();
-                };
+    return (async (args, preWarmContext) => {
+    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
+    const [input] = args;
+    const { Table: table, AttributesToGet, ...rest } = input;
+    return dynamo
+        .query({
+        ...rest,
+        AttributesToGet: AttributesToGet,
+        TableName: table.tableName,
+    })
+        .promise();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f14() {
   return (function() {
     let c = __f15;
     let preWarmContext = __preWarmContext;
 
-    return function (...args) {
-                                return c(args, preWarmContext);
-                            };
+    return (function __computed(...args) {
+    return c(args, preWarmContext);
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f17(__0, __1) {
   return (function() {
     let function_prewarm_1 = __function_prewarm_1;
 
-    return async (args, preWarmContext) => {
-                    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
-                    const [input] = args;
-                    const { Table: table, AttributesToGet, ...rest } = input;
-                    return dynamo
-                        .scan({
-                        ...rest,
-                        AttributesToGet: AttributesToGet,
-                        TableName: table.tableName,
-                    })
-                        .promise();
-                };
+    return (async (args, preWarmContext) => {
+    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
+    const [input] = args;
+    const { Table: table, AttributesToGet, ...rest } = input;
+    return dynamo
+        .scan({
+        ...rest,
+        AttributesToGet: AttributesToGet,
+        TableName: table.tableName,
+    })
+        .promise();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f16() {
   return (function() {
     let c = __f17;
     let preWarmContext = __preWarmContext;
 
-    return function (...args) {
-                                return c(args, preWarmContext);
-                            };
+    return (function __computed(...args) {
+    return c(args, preWarmContext);
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f18() {
   return (function() {
-    return function () {
-                                    throw new Error();
-                                };
+    return (function __computed() {
+    throw new Error();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f20(__0, __1) {
   return (function() {
     let function_prewarm_1 = __function_prewarm_1;
 
-    return async ([request], preWarmContext) => {
-                    const eventBridge = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.EVENT_BRIDGE);
-                    return eventBridge
-                        .putEvents({
-                        Entries: request.Entries.map((e) => ({
-                            ...e,
-                        })),
-                    })
-                        .promise();
-                };
+    return (async ([request], preWarmContext) => {
+    const eventBridge = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.EVENT_BRIDGE);
+    return eventBridge
+        .putEvents({
+        Entries: request.Entries.map((e) => ({
+            ...e,
+        })),
+    })
+        .promise();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f19() {
   return (function() {
     let c = __f20;
     let preWarmContext = __preWarmContext;
 
-    return function (...args) {
-                                return c(args, preWarmContext);
-                            };
+    return (function __computed(...args) {
+    return c(args, preWarmContext);
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f21() {
   return (function() {
     let m = __m;
     let k = \\"$AWS\\";
 
-    return function () { return m[k]; };
+    return (function __computed() { return m[k]; });;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f22() {
   return (function() {
-    return function () {
-                                    throw new Error();
-                                };
+    return (function __computed() {
+    throw new Error();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f23() {
   return (function() {
-    return function () {
-                                    throw new Error();
-                                };
+    return (function __computed() {
+    throw new Error();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f24() {
   return (function() {
-    return function () {
-                                    throw new Error();
-                                };
+    return (function __computed() {
+    throw new Error();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f25() {
   return (function() {
-    return function () {
-                                    throw new Error();
-                                };
+    return (function __computed() {
+    throw new Error();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f26() {
   return (function() {
-    return function () {
-                                    throw new Error();
-                                };
+    return (function __computed() {
+    throw new Error();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f27() {
   return (function() {
-    return function () {
-                                    throw new Error();
-                                };
+    return (function __computed() {
+    throw new Error();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f0() {
   return (function() {
     let _fnls_1 = __fnls_1;
     let table = __f22;
 
-    return () => {
-                return _fnls_1.$AWS.DynamoDB.GetItem({
-                    Table: table,
-                    Key: {
-                        id: { S: \\"id\\" },
-                    },
-                });
-            };
+    return (() => {
+    return _fnls_1.$AWS.DynamoDB.GetItem({
+        Table: table,
+        Key: {
+            id: { S: \\"id\\" },
+        },
+    });
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }"
 `;
@@ -17134,6 +17342,7 @@ function __f3(__0, __1) {
       var _a;
       return new (require(\\"aws-sdk\\")).DynamoDB((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key));
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f4(__0, __1) {
@@ -17142,6 +17351,7 @@ function __f4(__0, __1) {
       var _a;
       return new (require(\\"aws-sdk\\")).EventBridge((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key));
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f2(__0, __1) {
@@ -17156,14 +17366,16 @@ function __f2(__0, __1) {
         TableName: input.Table.tableName
       }).promise();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f5(__0) {
   return function() {
-    return function(props) {
+    return function constructor(props) {
       this.props = props;
       this.cache = {};
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f6(__0) {
@@ -17171,25 +17383,28 @@ function __f6(__0) {
     return function(key) {
       return this.cache[key];
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f7(__0) {
   return function() {
-    return function(client) {
+    return function getOrInit(client) {
       if (!this.cache[client.key]) {
         this.cache[client.key] = client.init(client.key, this.props);
       }
       return this.cache[client.key];
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f1() {
   return function() {
     let c = __f2;
     let preWarmContext = __preWarmContext;
-    return function(...args) {
+    return function __computed(...args) {
       return c(args, preWarmContext);
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f9(__0, __1) {
@@ -17206,15 +17421,17 @@ function __f9(__0, __1) {
       };
       return dynamo.getItem(payload).promise();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f8() {
   return function() {
     let c = __f9;
     let preWarmContext = __preWarmContext;
-    return function(...args) {
+    return function __computed(...args) {
       return c(args, preWarmContext);
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f11(__0, __1) {
@@ -17229,15 +17446,17 @@ function __f11(__0, __1) {
         TableName: table.tableName
       }).promise();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f10() {
   return function() {
     let c = __f11;
     let preWarmContext = __preWarmContext;
-    return function(...args) {
+    return function __computed(...args) {
       return c(args, preWarmContext);
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f13(__0, __1) {
@@ -17253,15 +17472,17 @@ function __f13(__0, __1) {
         TableName: table.tableName
       }).promise();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f12() {
   return function() {
     let c = __f13;
     let preWarmContext = __preWarmContext;
-    return function(...args) {
+    return function __computed(...args) {
       return c(args, preWarmContext);
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f15(__0, __1) {
@@ -17277,15 +17498,17 @@ function __f15(__0, __1) {
         TableName: table.tableName
       }).promise();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f14() {
   return function() {
     let c = __f15;
     let preWarmContext = __preWarmContext;
-    return function(...args) {
+    return function __computed(...args) {
       return c(args, preWarmContext);
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f17(__0, __1) {
@@ -17301,22 +17524,25 @@ function __f17(__0, __1) {
         TableName: table.tableName
       }).promise();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f16() {
   return function() {
     let c = __f17;
     let preWarmContext = __preWarmContext;
-    return function(...args) {
+    return function __computed(...args) {
       return c(args, preWarmContext);
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f18() {
   return function() {
-    return function() {
+    return function __computed() {
       throw new Error();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f20(__0, __1) {
@@ -17330,66 +17556,75 @@ function __f20(__0, __1) {
         }))
       }).promise();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f19() {
   return function() {
     let c = __f20;
     let preWarmContext = __preWarmContext;
-    return function(...args) {
+    return function __computed(...args) {
       return c(args, preWarmContext);
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f21() {
   return function() {
     let m = __m;
     let k = \\"$AWS\\";
-    return function() {
+    return function __computed() {
       return m[k];
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f22() {
   return function() {
-    return function() {
+    return function __computed() {
       throw new Error();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f23() {
   return function() {
-    return function() {
+    return function __computed() {
       throw new Error();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f24() {
   return function() {
-    return function() {
+    return function __computed() {
       throw new Error();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f25() {
   return function() {
-    return function() {
+    return function __computed() {
       throw new Error();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f26() {
   return function() {
-    return function() {
+    return function __computed() {
       throw new Error();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f27() {
   return function() {
-    return function() {
+    return function __computed() {
       throw new Error();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f0() {
@@ -17404,6 +17639,7 @@ function __f0() {
         }
       });
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 "
@@ -17440,106 +17676,108 @@ var __f7_appsync = {getItem: __f8, putItem: __f9, updateItem: __f10, deleteItem:
 __f7.appsync = __f7_appsync;
 function __f3(__0, __1) {
   return (function() {
-    return (key, props) => { var _a; 
-        // eslint-disable-next-line @typescript-eslint/no-require-imports, import/no-extraneous-dependencies
-        return new (require(\\"aws-sdk\\").DynamoDB)((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key)); };
+    return ((key, props) => {
+    var _a;
+    // eslint-disable-next-line @typescript-eslint/no-require-imports, import/no-extraneous-dependencies
+    return new (require(\\"aws-sdk\\").DynamoDB)((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key));
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f2(__0, __1) {
   return (function() {
     let function_prewarm_1 = __function_prewarm_1;
 
-    return async (args, preWarmContext) => {
-                    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
-                    const [input] = args;
-                    const { Table: table, AttributesToGet, ...rest } = input;
-                    const payload = {
-                        ...rest,
-                        AttributesToGet: AttributesToGet,
-                        TableName: table.tableName,
-                    };
-                    return dynamo.getItem(payload).promise();
-                };
+    return (async (args, preWarmContext) => {
+    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
+    const [input] = args;
+    const { Table: table, AttributesToGet, ...rest } = input;
+    const payload = {
+        ...rest,
+        AttributesToGet: AttributesToGet,
+        TableName: table.tableName,
+    };
+    return dynamo.getItem(payload).promise();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f4(__0) {
   return (function() {
-    return function /*constructor*/(props) {
-        this.props = props;
-        this.cache = {};
-    };
+    return (function constructor(props) {
+    this.props = props;
+    this.cache = {};
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f5(__0) {
   return (function() {
-    return function /*get*/(key) {
-        return this.cache[key];
-    };
+    return (function (key) {
+    return this.cache[key];
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f6(__0) {
   return (function() {
-    return function /*getOrInit*/(client) {
-        if (!this.cache[client.key]) {
-            this.cache[client.key] = client.init(client.key, this.props);
-        }
-        return this.cache[client.key];
-    };
+    return (function getOrInit(client) {
+    if (!this.cache[client.key]) {
+        this.cache[client.key] = client.init(client.key, this.props);
+    }
+    return this.cache[client.key];
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f1() {
   return (function() {
     let c = __f2;
     let preWarmContext = __preWarmContext;
 
-    return function (...args) {
-                                return c(args, preWarmContext);
-                            };
+    return (function __computed(...args) {
+    return c(args, preWarmContext);
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f7() {
   return (function() {
-    return function () {
-                                    throw new Error();
-                                };
+    return (function __computed() {
+    throw new Error();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f8() {
   return (function() {
-    return function () {
-                                    throw new Error();
-                                };
+    return (function __computed() {
+    throw new Error();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f9() {
   return (function() {
-    return function () {
-                                    throw new Error();
-                                };
+    return (function __computed() {
+    throw new Error();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f10() {
   return (function() {
-    return function () {
-                                    throw new Error();
-                                };
+    return (function __computed() {
+    throw new Error();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f11() {
   return (function() {
-    return function () {
-                                    throw new Error();
-                                };
+    return (function __computed() {
+    throw new Error();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f12() {
   return (function() {
-    return function () {
-                                    throw new Error();
-                                };
+    return (function __computed() {
+    throw new Error();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f0() {
   return (function() {
     let GetItem = __f1;
     let table = __f7;
 
-    return async () => {
-                return GetItem({
-                    Table: table,
-                    Key: {
-                        id: { S: \\"id\\" },
-                    },
-                });
-            };
+    return (async () => {
+    return GetItem({
+        Table: table,
+        Key: {
+            id: { S: \\"id\\" },
+        },
+    });
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }"
 `;
@@ -17579,6 +17817,7 @@ function __f3(__0, __1) {
       var _a;
       return new (require(\\"aws-sdk\\")).DynamoDB((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key));
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f2(__0, __1) {
@@ -17595,14 +17834,16 @@ function __f2(__0, __1) {
       };
       return dynamo.getItem(payload).promise();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f4(__0) {
   return function() {
-    return function(props) {
+    return function constructor(props) {
       this.props = props;
       this.cache = {};
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f5(__0) {
@@ -17610,67 +17851,76 @@ function __f5(__0) {
     return function(key) {
       return this.cache[key];
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f6(__0) {
   return function() {
-    return function(client) {
+    return function getOrInit(client) {
       if (!this.cache[client.key]) {
         this.cache[client.key] = client.init(client.key, this.props);
       }
       return this.cache[client.key];
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f1() {
   return function() {
     let c = __f2;
     let preWarmContext = __preWarmContext;
-    return function(...args) {
+    return function __computed(...args) {
       return c(args, preWarmContext);
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f7() {
   return function() {
-    return function() {
+    return function __computed() {
       throw new Error();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f8() {
   return function() {
-    return function() {
+    return function __computed() {
       throw new Error();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f9() {
   return function() {
-    return function() {
+    return function __computed() {
       throw new Error();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f10() {
   return function() {
-    return function() {
+    return function __computed() {
       throw new Error();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f11() {
   return function() {
-    return function() {
+    return function __computed() {
       throw new Error();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f12() {
   return function() {
-    return function() {
+    return function __computed() {
       throw new Error();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f0() {
@@ -17685,6 +17935,7 @@ function __f0() {
         }
       });
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 "
@@ -17743,277 +17994,281 @@ var __f22_appsync = {getItem: __f23, putItem: __f24, updateItem: __f25, deleteIt
 __f22.appsync = __f22_appsync;
 function __f3(__0, __1) {
   return (function() {
-    return (key, props) => { var _a; 
-        // eslint-disable-next-line @typescript-eslint/no-require-imports, import/no-extraneous-dependencies
-        return new (require(\\"aws-sdk\\").DynamoDB)((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key)); };
+    return ((key, props) => {
+    var _a;
+    // eslint-disable-next-line @typescript-eslint/no-require-imports, import/no-extraneous-dependencies
+    return new (require(\\"aws-sdk\\").DynamoDB)((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key));
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f4(__0, __1) {
   return (function() {
-    return (key, props) => { var _a; 
-        // eslint-disable-next-line @typescript-eslint/no-require-imports, import/no-extraneous-dependencies
-        return new (require(\\"aws-sdk\\").EventBridge)((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key)); };
+    return ((key, props) => {
+    var _a;
+    // eslint-disable-next-line @typescript-eslint/no-require-imports, import/no-extraneous-dependencies
+    return new (require(\\"aws-sdk\\").EventBridge)((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key));
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f2(__0, __1) {
   return (function() {
     let function_prewarm_1 = __function_prewarm_1;
 
-    return async (args, preWarmContext) => {
-                    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
-                    const [input] = args;
-                    const { Table: table, ...rest } = input;
-                    return dynamo
-                        .deleteItem({
-                        ...rest,
-                        TableName: input.Table.tableName,
-                    })
-                        .promise();
-                };
+    return (async (args, preWarmContext) => {
+    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
+    const [input] = args;
+    const { Table: table, ...rest } = input;
+    return dynamo
+        .deleteItem({
+        ...rest,
+        TableName: input.Table.tableName,
+    })
+        .promise();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f5(__0) {
   return (function() {
-    return function /*constructor*/(props) {
-        this.props = props;
-        this.cache = {};
-    };
+    return (function constructor(props) {
+    this.props = props;
+    this.cache = {};
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f6(__0) {
   return (function() {
-    return function /*get*/(key) {
-        return this.cache[key];
-    };
+    return (function (key) {
+    return this.cache[key];
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f7(__0) {
   return (function() {
-    return function /*getOrInit*/(client) {
-        if (!this.cache[client.key]) {
-            this.cache[client.key] = client.init(client.key, this.props);
-        }
-        return this.cache[client.key];
-    };
+    return (function getOrInit(client) {
+    if (!this.cache[client.key]) {
+        this.cache[client.key] = client.init(client.key, this.props);
+    }
+    return this.cache[client.key];
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f1() {
   return (function() {
     let c = __f2;
     let preWarmContext = __preWarmContext;
 
-    return function (...args) {
-                                return c(args, preWarmContext);
-                            };
+    return (function __computed(...args) {
+    return c(args, preWarmContext);
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f9(__0, __1) {
   return (function() {
     let function_prewarm_1 = __function_prewarm_1;
 
-    return async (args, preWarmContext) => {
-                    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
-                    const [input] = args;
-                    const { Table: table, AttributesToGet, ...rest } = input;
-                    const payload = {
-                        ...rest,
-                        AttributesToGet: AttributesToGet,
-                        TableName: table.tableName,
-                    };
-                    return dynamo.getItem(payload).promise();
-                };
+    return (async (args, preWarmContext) => {
+    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
+    const [input] = args;
+    const { Table: table, AttributesToGet, ...rest } = input;
+    const payload = {
+        ...rest,
+        AttributesToGet: AttributesToGet,
+        TableName: table.tableName,
+    };
+    return dynamo.getItem(payload).promise();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f8() {
   return (function() {
     let c = __f9;
     let preWarmContext = __preWarmContext;
 
-    return function (...args) {
-                                return c(args, preWarmContext);
-                            };
+    return (function __computed(...args) {
+    return c(args, preWarmContext);
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f11(__0, __1) {
   return (function() {
     let function_prewarm_1 = __function_prewarm_1;
 
-    return async (args, preWarmContext) => {
-                    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
-                    const [input] = args;
-                    const { Table: table, ...rest } = input;
-                    return dynamo
-                        .updateItem({
-                        ...rest,
-                        TableName: table.tableName,
-                    })
-                        .promise();
-                };
+    return (async (args, preWarmContext) => {
+    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
+    const [input] = args;
+    const { Table: table, ...rest } = input;
+    return dynamo
+        .updateItem({
+        ...rest,
+        TableName: table.tableName,
+    })
+        .promise();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f10() {
   return (function() {
     let c = __f11;
     let preWarmContext = __preWarmContext;
 
-    return function (...args) {
-                                return c(args, preWarmContext);
-                            };
+    return (function __computed(...args) {
+    return c(args, preWarmContext);
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f13(__0, __1) {
   return (function() {
     let function_prewarm_1 = __function_prewarm_1;
 
-    return async (args, preWarmContext) => {
-                    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
-                    const [input] = args;
-                    const { Table: table, Item, ...rest } = input;
-                    return dynamo
-                        .putItem({
-                        ...rest,
-                        Item: Item,
-                        TableName: table.tableName,
-                    })
-                        .promise();
-                };
+    return (async (args, preWarmContext) => {
+    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
+    const [input] = args;
+    const { Table: table, Item, ...rest } = input;
+    return dynamo
+        .putItem({
+        ...rest,
+        Item: Item,
+        TableName: table.tableName,
+    })
+        .promise();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f12() {
   return (function() {
     let c = __f13;
     let preWarmContext = __preWarmContext;
 
-    return function (...args) {
-                                return c(args, preWarmContext);
-                            };
+    return (function __computed(...args) {
+    return c(args, preWarmContext);
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f15(__0, __1) {
   return (function() {
     let function_prewarm_1 = __function_prewarm_1;
 
-    return async (args, preWarmContext) => {
-                    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
-                    const [input] = args;
-                    const { Table: table, AttributesToGet, ...rest } = input;
-                    return dynamo
-                        .query({
-                        ...rest,
-                        AttributesToGet: AttributesToGet,
-                        TableName: table.tableName,
-                    })
-                        .promise();
-                };
+    return (async (args, preWarmContext) => {
+    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
+    const [input] = args;
+    const { Table: table, AttributesToGet, ...rest } = input;
+    return dynamo
+        .query({
+        ...rest,
+        AttributesToGet: AttributesToGet,
+        TableName: table.tableName,
+    })
+        .promise();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f14() {
   return (function() {
     let c = __f15;
     let preWarmContext = __preWarmContext;
 
-    return function (...args) {
-                                return c(args, preWarmContext);
-                            };
+    return (function __computed(...args) {
+    return c(args, preWarmContext);
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f17(__0, __1) {
   return (function() {
     let function_prewarm_1 = __function_prewarm_1;
 
-    return async (args, preWarmContext) => {
-                    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
-                    const [input] = args;
-                    const { Table: table, AttributesToGet, ...rest } = input;
-                    return dynamo
-                        .scan({
-                        ...rest,
-                        AttributesToGet: AttributesToGet,
-                        TableName: table.tableName,
-                    })
-                        .promise();
-                };
+    return (async (args, preWarmContext) => {
+    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
+    const [input] = args;
+    const { Table: table, AttributesToGet, ...rest } = input;
+    return dynamo
+        .scan({
+        ...rest,
+        AttributesToGet: AttributesToGet,
+        TableName: table.tableName,
+    })
+        .promise();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f16() {
   return (function() {
     let c = __f17;
     let preWarmContext = __preWarmContext;
 
-    return function (...args) {
-                                return c(args, preWarmContext);
-                            };
+    return (function __computed(...args) {
+    return c(args, preWarmContext);
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f18() {
   return (function() {
-    return function () {
-                                    throw new Error();
-                                };
+    return (function __computed() {
+    throw new Error();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f20(__0, __1) {
   return (function() {
     let function_prewarm_1 = __function_prewarm_1;
 
-    return async ([request], preWarmContext) => {
-                    const eventBridge = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.EVENT_BRIDGE);
-                    return eventBridge
-                        .putEvents({
-                        Entries: request.Entries.map((e) => ({
-                            ...e,
-                        })),
-                    })
-                        .promise();
-                };
+    return (async ([request], preWarmContext) => {
+    const eventBridge = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.EVENT_BRIDGE);
+    return eventBridge
+        .putEvents({
+        Entries: request.Entries.map((e) => ({
+            ...e,
+        })),
+    })
+        .promise();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f19() {
   return (function() {
     let c = __f20;
     let preWarmContext = __preWarmContext;
 
-    return function (...args) {
-                                return c(args, preWarmContext);
-                            };
+    return (function __computed(...args) {
+    return c(args, preWarmContext);
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f21() {
   return (function() {
     let m = __m;
     let k = \\"$AWS\\";
 
-    return function () { return m[k]; };
+    return (function __computed() { return m[k]; });;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f22() {
   return (function() {
-    return function () {
-                                    throw new Error();
-                                };
+    return (function __computed() {
+    throw new Error();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f23() {
   return (function() {
-    return function () {
-                                    throw new Error();
-                                };
+    return (function __computed() {
+    throw new Error();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f24() {
   return (function() {
-    return function () {
-                                    throw new Error();
-                                };
+    return (function __computed() {
+    throw new Error();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f25() {
   return (function() {
-    return function () {
-                                    throw new Error();
-                                };
+    return (function __computed() {
+    throw new Error();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f26() {
   return (function() {
-    return function () {
-                                    throw new Error();
-                                };
+    return (function __computed() {
+    throw new Error();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f27() {
   return (function() {
-    return function () {
-                                    throw new Error();
-                                };
+    return (function __computed() {
+    throw new Error();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f0() {
   return (function() {
     let _fnls_1 = __fnls_1;
     let table = __f22;
 
-    return async () => {
-                return _fnls_1.$AWS.DynamoDB.PutItem({
-                    Table: table,
-                    Item: {
-                        id: { S: \\"key\\" },
-                    },
-                });
-            };
+    return (async () => {
+    return _fnls_1.$AWS.DynamoDB.PutItem({
+        Table: table,
+        Item: {
+            id: { S: \\"key\\" },
+        },
+    });
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }"
 `;
@@ -18075,6 +18330,7 @@ function __f3(__0, __1) {
       var _a;
       return new (require(\\"aws-sdk\\")).DynamoDB((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key));
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f4(__0, __1) {
@@ -18083,6 +18339,7 @@ function __f4(__0, __1) {
       var _a;
       return new (require(\\"aws-sdk\\")).EventBridge((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key));
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f2(__0, __1) {
@@ -18097,14 +18354,16 @@ function __f2(__0, __1) {
         TableName: input.Table.tableName
       }).promise();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f5(__0) {
   return function() {
-    return function(props) {
+    return function constructor(props) {
       this.props = props;
       this.cache = {};
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f6(__0) {
@@ -18112,25 +18371,28 @@ function __f6(__0) {
     return function(key) {
       return this.cache[key];
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f7(__0) {
   return function() {
-    return function(client) {
+    return function getOrInit(client) {
       if (!this.cache[client.key]) {
         this.cache[client.key] = client.init(client.key, this.props);
       }
       return this.cache[client.key];
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f1() {
   return function() {
     let c = __f2;
     let preWarmContext = __preWarmContext;
-    return function(...args) {
+    return function __computed(...args) {
       return c(args, preWarmContext);
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f9(__0, __1) {
@@ -18147,15 +18409,17 @@ function __f9(__0, __1) {
       };
       return dynamo.getItem(payload).promise();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f8() {
   return function() {
     let c = __f9;
     let preWarmContext = __preWarmContext;
-    return function(...args) {
+    return function __computed(...args) {
       return c(args, preWarmContext);
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f11(__0, __1) {
@@ -18170,15 +18434,17 @@ function __f11(__0, __1) {
         TableName: table.tableName
       }).promise();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f10() {
   return function() {
     let c = __f11;
     let preWarmContext = __preWarmContext;
-    return function(...args) {
+    return function __computed(...args) {
       return c(args, preWarmContext);
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f13(__0, __1) {
@@ -18194,15 +18460,17 @@ function __f13(__0, __1) {
         TableName: table.tableName
       }).promise();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f12() {
   return function() {
     let c = __f13;
     let preWarmContext = __preWarmContext;
-    return function(...args) {
+    return function __computed(...args) {
       return c(args, preWarmContext);
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f15(__0, __1) {
@@ -18218,15 +18486,17 @@ function __f15(__0, __1) {
         TableName: table.tableName
       }).promise();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f14() {
   return function() {
     let c = __f15;
     let preWarmContext = __preWarmContext;
-    return function(...args) {
+    return function __computed(...args) {
       return c(args, preWarmContext);
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f17(__0, __1) {
@@ -18242,22 +18512,25 @@ function __f17(__0, __1) {
         TableName: table.tableName
       }).promise();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f16() {
   return function() {
     let c = __f17;
     let preWarmContext = __preWarmContext;
-    return function(...args) {
+    return function __computed(...args) {
       return c(args, preWarmContext);
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f18() {
   return function() {
-    return function() {
+    return function __computed() {
       throw new Error();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f20(__0, __1) {
@@ -18271,66 +18544,75 @@ function __f20(__0, __1) {
         }))
       }).promise();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f19() {
   return function() {
     let c = __f20;
     let preWarmContext = __preWarmContext;
-    return function(...args) {
+    return function __computed(...args) {
       return c(args, preWarmContext);
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f21() {
   return function() {
     let m = __m;
     let k = \\"$AWS\\";
-    return function() {
+    return function __computed() {
       return m[k];
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f22() {
   return function() {
-    return function() {
+    return function __computed() {
       throw new Error();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f23() {
   return function() {
-    return function() {
+    return function __computed() {
       throw new Error();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f24() {
   return function() {
-    return function() {
+    return function __computed() {
       throw new Error();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f25() {
   return function() {
-    return function() {
+    return function __computed() {
       throw new Error();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f26() {
   return function() {
-    return function() {
+    return function __computed() {
       throw new Error();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f27() {
   return function() {
-    return function() {
+    return function __computed() {
       throw new Error();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f0() {
@@ -18345,6 +18627,7 @@ function __f0() {
         }
       });
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 "
@@ -18403,284 +18686,288 @@ var __f22_appsync = {getItem: __f23, putItem: __f24, updateItem: __f25, deleteIt
 __f22.appsync = __f22_appsync;
 function __f3(__0, __1) {
   return (function() {
-    return (key, props) => { var _a; 
-        // eslint-disable-next-line @typescript-eslint/no-require-imports, import/no-extraneous-dependencies
-        return new (require(\\"aws-sdk\\").DynamoDB)((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key)); };
+    return ((key, props) => {
+    var _a;
+    // eslint-disable-next-line @typescript-eslint/no-require-imports, import/no-extraneous-dependencies
+    return new (require(\\"aws-sdk\\").DynamoDB)((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key));
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f4(__0, __1) {
   return (function() {
-    return (key, props) => { var _a; 
-        // eslint-disable-next-line @typescript-eslint/no-require-imports, import/no-extraneous-dependencies
-        return new (require(\\"aws-sdk\\").EventBridge)((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key)); };
+    return ((key, props) => {
+    var _a;
+    // eslint-disable-next-line @typescript-eslint/no-require-imports, import/no-extraneous-dependencies
+    return new (require(\\"aws-sdk\\").EventBridge)((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key));
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f2(__0, __1) {
   return (function() {
     let function_prewarm_1 = __function_prewarm_1;
 
-    return async (args, preWarmContext) => {
-                    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
-                    const [input] = args;
-                    const { Table: table, ...rest } = input;
-                    return dynamo
-                        .deleteItem({
-                        ...rest,
-                        TableName: input.Table.tableName,
-                    })
-                        .promise();
-                };
+    return (async (args, preWarmContext) => {
+    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
+    const [input] = args;
+    const { Table: table, ...rest } = input;
+    return dynamo
+        .deleteItem({
+        ...rest,
+        TableName: input.Table.tableName,
+    })
+        .promise();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f5(__0) {
   return (function() {
-    return function /*constructor*/(props) {
-        this.props = props;
-        this.cache = {};
-    };
+    return (function constructor(props) {
+    this.props = props;
+    this.cache = {};
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f6(__0) {
   return (function() {
-    return function /*get*/(key) {
-        return this.cache[key];
-    };
+    return (function (key) {
+    return this.cache[key];
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f7(__0) {
   return (function() {
-    return function /*getOrInit*/(client) {
-        if (!this.cache[client.key]) {
-            this.cache[client.key] = client.init(client.key, this.props);
-        }
-        return this.cache[client.key];
-    };
+    return (function getOrInit(client) {
+    if (!this.cache[client.key]) {
+        this.cache[client.key] = client.init(client.key, this.props);
+    }
+    return this.cache[client.key];
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f1() {
   return (function() {
     let c = __f2;
     let preWarmContext = __preWarmContext;
 
-    return function (...args) {
-                                return c(args, preWarmContext);
-                            };
+    return (function __computed(...args) {
+    return c(args, preWarmContext);
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f9(__0, __1) {
   return (function() {
     let function_prewarm_1 = __function_prewarm_1;
 
-    return async (args, preWarmContext) => {
-                    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
-                    const [input] = args;
-                    const { Table: table, AttributesToGet, ...rest } = input;
-                    const payload = {
-                        ...rest,
-                        AttributesToGet: AttributesToGet,
-                        TableName: table.tableName,
-                    };
-                    return dynamo.getItem(payload).promise();
-                };
+    return (async (args, preWarmContext) => {
+    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
+    const [input] = args;
+    const { Table: table, AttributesToGet, ...rest } = input;
+    const payload = {
+        ...rest,
+        AttributesToGet: AttributesToGet,
+        TableName: table.tableName,
+    };
+    return dynamo.getItem(payload).promise();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f8() {
   return (function() {
     let c = __f9;
     let preWarmContext = __preWarmContext;
 
-    return function (...args) {
-                                return c(args, preWarmContext);
-                            };
+    return (function __computed(...args) {
+    return c(args, preWarmContext);
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f11(__0, __1) {
   return (function() {
     let function_prewarm_1 = __function_prewarm_1;
 
-    return async (args, preWarmContext) => {
-                    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
-                    const [input] = args;
-                    const { Table: table, ...rest } = input;
-                    return dynamo
-                        .updateItem({
-                        ...rest,
-                        TableName: table.tableName,
-                    })
-                        .promise();
-                };
+    return (async (args, preWarmContext) => {
+    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
+    const [input] = args;
+    const { Table: table, ...rest } = input;
+    return dynamo
+        .updateItem({
+        ...rest,
+        TableName: table.tableName,
+    })
+        .promise();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f10() {
   return (function() {
     let c = __f11;
     let preWarmContext = __preWarmContext;
 
-    return function (...args) {
-                                return c(args, preWarmContext);
-                            };
+    return (function __computed(...args) {
+    return c(args, preWarmContext);
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f13(__0, __1) {
   return (function() {
     let function_prewarm_1 = __function_prewarm_1;
 
-    return async (args, preWarmContext) => {
-                    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
-                    const [input] = args;
-                    const { Table: table, Item, ...rest } = input;
-                    return dynamo
-                        .putItem({
-                        ...rest,
-                        Item: Item,
-                        TableName: table.tableName,
-                    })
-                        .promise();
-                };
+    return (async (args, preWarmContext) => {
+    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
+    const [input] = args;
+    const { Table: table, Item, ...rest } = input;
+    return dynamo
+        .putItem({
+        ...rest,
+        Item: Item,
+        TableName: table.tableName,
+    })
+        .promise();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f12() {
   return (function() {
     let c = __f13;
     let preWarmContext = __preWarmContext;
 
-    return function (...args) {
-                                return c(args, preWarmContext);
-                            };
+    return (function __computed(...args) {
+    return c(args, preWarmContext);
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f15(__0, __1) {
   return (function() {
     let function_prewarm_1 = __function_prewarm_1;
 
-    return async (args, preWarmContext) => {
-                    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
-                    const [input] = args;
-                    const { Table: table, AttributesToGet, ...rest } = input;
-                    return dynamo
-                        .query({
-                        ...rest,
-                        AttributesToGet: AttributesToGet,
-                        TableName: table.tableName,
-                    })
-                        .promise();
-                };
+    return (async (args, preWarmContext) => {
+    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
+    const [input] = args;
+    const { Table: table, AttributesToGet, ...rest } = input;
+    return dynamo
+        .query({
+        ...rest,
+        AttributesToGet: AttributesToGet,
+        TableName: table.tableName,
+    })
+        .promise();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f14() {
   return (function() {
     let c = __f15;
     let preWarmContext = __preWarmContext;
 
-    return function (...args) {
-                                return c(args, preWarmContext);
-                            };
+    return (function __computed(...args) {
+    return c(args, preWarmContext);
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f17(__0, __1) {
   return (function() {
     let function_prewarm_1 = __function_prewarm_1;
 
-    return async (args, preWarmContext) => {
-                    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
-                    const [input] = args;
-                    const { Table: table, AttributesToGet, ...rest } = input;
-                    return dynamo
-                        .scan({
-                        ...rest,
-                        AttributesToGet: AttributesToGet,
-                        TableName: table.tableName,
-                    })
-                        .promise();
-                };
+    return (async (args, preWarmContext) => {
+    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
+    const [input] = args;
+    const { Table: table, AttributesToGet, ...rest } = input;
+    return dynamo
+        .scan({
+        ...rest,
+        AttributesToGet: AttributesToGet,
+        TableName: table.tableName,
+    })
+        .promise();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f16() {
   return (function() {
     let c = __f17;
     let preWarmContext = __preWarmContext;
 
-    return function (...args) {
-                                return c(args, preWarmContext);
-                            };
+    return (function __computed(...args) {
+    return c(args, preWarmContext);
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f18() {
   return (function() {
-    return function () {
-                                    throw new Error();
-                                };
+    return (function __computed() {
+    throw new Error();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f20(__0, __1) {
   return (function() {
     let function_prewarm_1 = __function_prewarm_1;
 
-    return async ([request], preWarmContext) => {
-                    const eventBridge = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.EVENT_BRIDGE);
-                    return eventBridge
-                        .putEvents({
-                        Entries: request.Entries.map((e) => ({
-                            ...e,
-                        })),
-                    })
-                        .promise();
-                };
+    return (async ([request], preWarmContext) => {
+    const eventBridge = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.EVENT_BRIDGE);
+    return eventBridge
+        .putEvents({
+        Entries: request.Entries.map((e) => ({
+            ...e,
+        })),
+    })
+        .promise();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f19() {
   return (function() {
     let c = __f20;
     let preWarmContext = __preWarmContext;
 
-    return function (...args) {
-                                return c(args, preWarmContext);
-                            };
+    return (function __computed(...args) {
+    return c(args, preWarmContext);
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f21() {
   return (function() {
     let m = __m;
     let k = \\"$AWS\\";
 
-    return function () { return m[k]; };
+    return (function __computed() { return m[k]; });;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f22() {
   return (function() {
-    return function () {
-                                    throw new Error();
-                                };
+    return (function __computed() {
+    throw new Error();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f23() {
   return (function() {
-    return function () {
-                                    throw new Error();
-                                };
+    return (function __computed() {
+    throw new Error();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f24() {
   return (function() {
-    return function () {
-                                    throw new Error();
-                                };
+    return (function __computed() {
+    throw new Error();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f25() {
   return (function() {
-    return function () {
-                                    throw new Error();
-                                };
+    return (function __computed() {
+    throw new Error();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f26() {
   return (function() {
-    return function () {
-                                    throw new Error();
-                                };
+    return (function __computed() {
+    throw new Error();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f27() {
   return (function() {
-    return function () {
-                                    throw new Error();
-                                };
+    return (function __computed() {
+    throw new Error();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f0() {
   return (function() {
     let _fnls_1 = __fnls_1;
     let table = __f22;
 
-    return async () => {
-                return _fnls_1.$AWS.DynamoDB.UpdateItem({
-                    Table: table,
-                    Key: {
-                        id: { S: \\"key\\" },
-                    },
-                    UpdateExpression: \\"set #value = :value\\",
-                    ExpressionAttributeValues: {
-                        \\":value\\": { S: \\"value\\" },
-                    },
-                    ExpressionAttributeNames: {
-                        \\"#value\\": \\"value\\",
-                    },
-                });
-            };
+    return (async () => {
+    return _fnls_1.$AWS.DynamoDB.UpdateItem({
+        Table: table,
+        Key: {
+            id: { S: \\"key\\" },
+        },
+        UpdateExpression: \\"set #value = :value\\",
+        ExpressionAttributeValues: {
+            \\":value\\": { S: \\"value\\" },
+        },
+        ExpressionAttributeNames: {
+            \\"#value\\": \\"value\\",
+        },
+    });
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }"
 `;
@@ -18742,6 +19029,7 @@ function __f3(__0, __1) {
       var _a;
       return new (require(\\"aws-sdk\\")).DynamoDB((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key));
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f4(__0, __1) {
@@ -18750,6 +19038,7 @@ function __f4(__0, __1) {
       var _a;
       return new (require(\\"aws-sdk\\")).EventBridge((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key));
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f2(__0, __1) {
@@ -18764,14 +19053,16 @@ function __f2(__0, __1) {
         TableName: input.Table.tableName
       }).promise();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f5(__0) {
   return function() {
-    return function(props) {
+    return function constructor(props) {
       this.props = props;
       this.cache = {};
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f6(__0) {
@@ -18779,25 +19070,28 @@ function __f6(__0) {
     return function(key) {
       return this.cache[key];
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f7(__0) {
   return function() {
-    return function(client) {
+    return function getOrInit(client) {
       if (!this.cache[client.key]) {
         this.cache[client.key] = client.init(client.key, this.props);
       }
       return this.cache[client.key];
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f1() {
   return function() {
     let c = __f2;
     let preWarmContext = __preWarmContext;
-    return function(...args) {
+    return function __computed(...args) {
       return c(args, preWarmContext);
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f9(__0, __1) {
@@ -18814,15 +19108,17 @@ function __f9(__0, __1) {
       };
       return dynamo.getItem(payload).promise();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f8() {
   return function() {
     let c = __f9;
     let preWarmContext = __preWarmContext;
-    return function(...args) {
+    return function __computed(...args) {
       return c(args, preWarmContext);
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f11(__0, __1) {
@@ -18837,15 +19133,17 @@ function __f11(__0, __1) {
         TableName: table.tableName
       }).promise();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f10() {
   return function() {
     let c = __f11;
     let preWarmContext = __preWarmContext;
-    return function(...args) {
+    return function __computed(...args) {
       return c(args, preWarmContext);
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f13(__0, __1) {
@@ -18861,15 +19159,17 @@ function __f13(__0, __1) {
         TableName: table.tableName
       }).promise();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f12() {
   return function() {
     let c = __f13;
     let preWarmContext = __preWarmContext;
-    return function(...args) {
+    return function __computed(...args) {
       return c(args, preWarmContext);
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f15(__0, __1) {
@@ -18885,15 +19185,17 @@ function __f15(__0, __1) {
         TableName: table.tableName
       }).promise();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f14() {
   return function() {
     let c = __f15;
     let preWarmContext = __preWarmContext;
-    return function(...args) {
+    return function __computed(...args) {
       return c(args, preWarmContext);
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f17(__0, __1) {
@@ -18909,22 +19211,25 @@ function __f17(__0, __1) {
         TableName: table.tableName
       }).promise();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f16() {
   return function() {
     let c = __f17;
     let preWarmContext = __preWarmContext;
-    return function(...args) {
+    return function __computed(...args) {
       return c(args, preWarmContext);
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f18() {
   return function() {
-    return function() {
+    return function __computed() {
       throw new Error();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f20(__0, __1) {
@@ -18938,66 +19243,75 @@ function __f20(__0, __1) {
         }))
       }).promise();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f19() {
   return function() {
     let c = __f20;
     let preWarmContext = __preWarmContext;
-    return function(...args) {
+    return function __computed(...args) {
       return c(args, preWarmContext);
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f21() {
   return function() {
     let m = __m;
     let k = \\"$AWS\\";
-    return function() {
+    return function __computed() {
       return m[k];
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f22() {
   return function() {
-    return function() {
+    return function __computed() {
       throw new Error();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f23() {
   return function() {
-    return function() {
+    return function __computed() {
       throw new Error();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f24() {
   return function() {
-    return function() {
+    return function __computed() {
       throw new Error();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f25() {
   return function() {
-    return function() {
+    return function __computed() {
       throw new Error();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f26() {
   return function() {
-    return function() {
+    return function __computed() {
       throw new Error();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f27() {
   return function() {
-    return function() {
+    return function __computed() {
       throw new Error();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f0() {
@@ -19019,6 +19333,7 @@ function __f0() {
         }
       });
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 "
@@ -19077,281 +19392,285 @@ var __f22_appsync = {getItem: __f23, putItem: __f24, updateItem: __f25, deleteIt
 __f22.appsync = __f22_appsync;
 function __f3(__0, __1) {
   return (function() {
-    return (key, props) => { var _a; 
-        // eslint-disable-next-line @typescript-eslint/no-require-imports, import/no-extraneous-dependencies
-        return new (require(\\"aws-sdk\\").DynamoDB)((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key)); };
+    return ((key, props) => {
+    var _a;
+    // eslint-disable-next-line @typescript-eslint/no-require-imports, import/no-extraneous-dependencies
+    return new (require(\\"aws-sdk\\").DynamoDB)((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key));
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f4(__0, __1) {
   return (function() {
-    return (key, props) => { var _a; 
-        // eslint-disable-next-line @typescript-eslint/no-require-imports, import/no-extraneous-dependencies
-        return new (require(\\"aws-sdk\\").EventBridge)((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key)); };
+    return ((key, props) => {
+    var _a;
+    // eslint-disable-next-line @typescript-eslint/no-require-imports, import/no-extraneous-dependencies
+    return new (require(\\"aws-sdk\\").EventBridge)((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key));
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f2(__0, __1) {
   return (function() {
     let function_prewarm_1 = __function_prewarm_1;
 
-    return async (args, preWarmContext) => {
-                    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
-                    const [input] = args;
-                    const { Table: table, ...rest } = input;
-                    return dynamo
-                        .deleteItem({
-                        ...rest,
-                        TableName: input.Table.tableName,
-                    })
-                        .promise();
-                };
+    return (async (args, preWarmContext) => {
+    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
+    const [input] = args;
+    const { Table: table, ...rest } = input;
+    return dynamo
+        .deleteItem({
+        ...rest,
+        TableName: input.Table.tableName,
+    })
+        .promise();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f5(__0) {
   return (function() {
-    return function /*constructor*/(props) {
-        this.props = props;
-        this.cache = {};
-    };
+    return (function constructor(props) {
+    this.props = props;
+    this.cache = {};
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f6(__0) {
   return (function() {
-    return function /*get*/(key) {
-        return this.cache[key];
-    };
+    return (function (key) {
+    return this.cache[key];
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f7(__0) {
   return (function() {
-    return function /*getOrInit*/(client) {
-        if (!this.cache[client.key]) {
-            this.cache[client.key] = client.init(client.key, this.props);
-        }
-        return this.cache[client.key];
-    };
+    return (function getOrInit(client) {
+    if (!this.cache[client.key]) {
+        this.cache[client.key] = client.init(client.key, this.props);
+    }
+    return this.cache[client.key];
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f1() {
   return (function() {
     let c = __f2;
     let preWarmContext = __preWarmContext;
 
-    return function (...args) {
-                                return c(args, preWarmContext);
-                            };
+    return (function __computed(...args) {
+    return c(args, preWarmContext);
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f9(__0, __1) {
   return (function() {
     let function_prewarm_1 = __function_prewarm_1;
 
-    return async (args, preWarmContext) => {
-                    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
-                    const [input] = args;
-                    const { Table: table, AttributesToGet, ...rest } = input;
-                    const payload = {
-                        ...rest,
-                        AttributesToGet: AttributesToGet,
-                        TableName: table.tableName,
-                    };
-                    return dynamo.getItem(payload).promise();
-                };
+    return (async (args, preWarmContext) => {
+    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
+    const [input] = args;
+    const { Table: table, AttributesToGet, ...rest } = input;
+    const payload = {
+        ...rest,
+        AttributesToGet: AttributesToGet,
+        TableName: table.tableName,
+    };
+    return dynamo.getItem(payload).promise();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f8() {
   return (function() {
     let c = __f9;
     let preWarmContext = __preWarmContext;
 
-    return function (...args) {
-                                return c(args, preWarmContext);
-                            };
+    return (function __computed(...args) {
+    return c(args, preWarmContext);
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f11(__0, __1) {
   return (function() {
     let function_prewarm_1 = __function_prewarm_1;
 
-    return async (args, preWarmContext) => {
-                    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
-                    const [input] = args;
-                    const { Table: table, ...rest } = input;
-                    return dynamo
-                        .updateItem({
-                        ...rest,
-                        TableName: table.tableName,
-                    })
-                        .promise();
-                };
+    return (async (args, preWarmContext) => {
+    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
+    const [input] = args;
+    const { Table: table, ...rest } = input;
+    return dynamo
+        .updateItem({
+        ...rest,
+        TableName: table.tableName,
+    })
+        .promise();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f10() {
   return (function() {
     let c = __f11;
     let preWarmContext = __preWarmContext;
 
-    return function (...args) {
-                                return c(args, preWarmContext);
-                            };
+    return (function __computed(...args) {
+    return c(args, preWarmContext);
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f13(__0, __1) {
   return (function() {
     let function_prewarm_1 = __function_prewarm_1;
 
-    return async (args, preWarmContext) => {
-                    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
-                    const [input] = args;
-                    const { Table: table, Item, ...rest } = input;
-                    return dynamo
-                        .putItem({
-                        ...rest,
-                        Item: Item,
-                        TableName: table.tableName,
-                    })
-                        .promise();
-                };
+    return (async (args, preWarmContext) => {
+    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
+    const [input] = args;
+    const { Table: table, Item, ...rest } = input;
+    return dynamo
+        .putItem({
+        ...rest,
+        Item: Item,
+        TableName: table.tableName,
+    })
+        .promise();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f12() {
   return (function() {
     let c = __f13;
     let preWarmContext = __preWarmContext;
 
-    return function (...args) {
-                                return c(args, preWarmContext);
-                            };
+    return (function __computed(...args) {
+    return c(args, preWarmContext);
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f15(__0, __1) {
   return (function() {
     let function_prewarm_1 = __function_prewarm_1;
 
-    return async (args, preWarmContext) => {
-                    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
-                    const [input] = args;
-                    const { Table: table, AttributesToGet, ...rest } = input;
-                    return dynamo
-                        .query({
-                        ...rest,
-                        AttributesToGet: AttributesToGet,
-                        TableName: table.tableName,
-                    })
-                        .promise();
-                };
+    return (async (args, preWarmContext) => {
+    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
+    const [input] = args;
+    const { Table: table, AttributesToGet, ...rest } = input;
+    return dynamo
+        .query({
+        ...rest,
+        AttributesToGet: AttributesToGet,
+        TableName: table.tableName,
+    })
+        .promise();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f14() {
   return (function() {
     let c = __f15;
     let preWarmContext = __preWarmContext;
 
-    return function (...args) {
-                                return c(args, preWarmContext);
-                            };
+    return (function __computed(...args) {
+    return c(args, preWarmContext);
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f17(__0, __1) {
   return (function() {
     let function_prewarm_1 = __function_prewarm_1;
 
-    return async (args, preWarmContext) => {
-                    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
-                    const [input] = args;
-                    const { Table: table, AttributesToGet, ...rest } = input;
-                    return dynamo
-                        .scan({
-                        ...rest,
-                        AttributesToGet: AttributesToGet,
-                        TableName: table.tableName,
-                    })
-                        .promise();
-                };
+    return (async (args, preWarmContext) => {
+    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
+    const [input] = args;
+    const { Table: table, AttributesToGet, ...rest } = input;
+    return dynamo
+        .scan({
+        ...rest,
+        AttributesToGet: AttributesToGet,
+        TableName: table.tableName,
+    })
+        .promise();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f16() {
   return (function() {
     let c = __f17;
     let preWarmContext = __preWarmContext;
 
-    return function (...args) {
-                                return c(args, preWarmContext);
-                            };
+    return (function __computed(...args) {
+    return c(args, preWarmContext);
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f18() {
   return (function() {
-    return function () {
-                                    throw new Error();
-                                };
+    return (function __computed() {
+    throw new Error();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f20(__0, __1) {
   return (function() {
     let function_prewarm_1 = __function_prewarm_1;
 
-    return async ([request], preWarmContext) => {
-                    const eventBridge = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.EVENT_BRIDGE);
-                    return eventBridge
-                        .putEvents({
-                        Entries: request.Entries.map((e) => ({
-                            ...e,
-                        })),
-                    })
-                        .promise();
-                };
+    return (async ([request], preWarmContext) => {
+    const eventBridge = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.EVENT_BRIDGE);
+    return eventBridge
+        .putEvents({
+        Entries: request.Entries.map((e) => ({
+            ...e,
+        })),
+    })
+        .promise();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f19() {
   return (function() {
     let c = __f20;
     let preWarmContext = __preWarmContext;
 
-    return function (...args) {
-                                return c(args, preWarmContext);
-                            };
+    return (function __computed(...args) {
+    return c(args, preWarmContext);
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f21() {
   return (function() {
     let m = __m;
     let k = \\"$AWS\\";
 
-    return function () { return m[k]; };
+    return (function __computed() { return m[k]; });;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f22() {
   return (function() {
-    return function () {
-                                    throw new Error();
-                                };
+    return (function __computed() {
+    throw new Error();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f23() {
   return (function() {
-    return function () {
-                                    throw new Error();
-                                };
+    return (function __computed() {
+    throw new Error();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f24() {
   return (function() {
-    return function () {
-                                    throw new Error();
-                                };
+    return (function __computed() {
+    throw new Error();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f25() {
   return (function() {
-    return function () {
-                                    throw new Error();
-                                };
+    return (function __computed() {
+    throw new Error();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f26() {
   return (function() {
-    return function () {
-                                    throw new Error();
-                                };
+    return (function __computed() {
+    throw new Error();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f27() {
   return (function() {
-    return function () {
-                                    throw new Error();
-                                };
+    return (function __computed() {
+    throw new Error();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f0() {
   return (function() {
     let _fnls_1 = __fnls_1;
     let table = __f22;
 
-    return async () => {
-                return _fnls_1.$AWS.DynamoDB.Query({
-                    Table: table,
-                    KeyConditionExpression: \\"#key = :key\\",
-                    ExpressionAttributeValues: {
-                        \\":key\\": { S: \\"key\\" },
-                    },
-                    ExpressionAttributeNames: {
-                        \\"#key\\": \\"key\\",
-                    },
-                });
-            };
+    return (async () => {
+    return _fnls_1.$AWS.DynamoDB.Query({
+        Table: table,
+        KeyConditionExpression: \\"#key = :key\\",
+        ExpressionAttributeValues: {
+            \\":key\\": { S: \\"key\\" },
+        },
+        ExpressionAttributeNames: {
+            \\"#key\\": \\"key\\",
+        },
+    });
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }"
 `;
@@ -19413,6 +19732,7 @@ function __f3(__0, __1) {
       var _a;
       return new (require(\\"aws-sdk\\")).DynamoDB((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key));
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f4(__0, __1) {
@@ -19421,6 +19741,7 @@ function __f4(__0, __1) {
       var _a;
       return new (require(\\"aws-sdk\\")).EventBridge((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key));
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f2(__0, __1) {
@@ -19435,14 +19756,16 @@ function __f2(__0, __1) {
         TableName: input.Table.tableName
       }).promise();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f5(__0) {
   return function() {
-    return function(props) {
+    return function constructor(props) {
       this.props = props;
       this.cache = {};
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f6(__0) {
@@ -19450,25 +19773,28 @@ function __f6(__0) {
     return function(key) {
       return this.cache[key];
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f7(__0) {
   return function() {
-    return function(client) {
+    return function getOrInit(client) {
       if (!this.cache[client.key]) {
         this.cache[client.key] = client.init(client.key, this.props);
       }
       return this.cache[client.key];
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f1() {
   return function() {
     let c = __f2;
     let preWarmContext = __preWarmContext;
-    return function(...args) {
+    return function __computed(...args) {
       return c(args, preWarmContext);
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f9(__0, __1) {
@@ -19485,15 +19811,17 @@ function __f9(__0, __1) {
       };
       return dynamo.getItem(payload).promise();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f8() {
   return function() {
     let c = __f9;
     let preWarmContext = __preWarmContext;
-    return function(...args) {
+    return function __computed(...args) {
       return c(args, preWarmContext);
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f11(__0, __1) {
@@ -19508,15 +19836,17 @@ function __f11(__0, __1) {
         TableName: table.tableName
       }).promise();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f10() {
   return function() {
     let c = __f11;
     let preWarmContext = __preWarmContext;
-    return function(...args) {
+    return function __computed(...args) {
       return c(args, preWarmContext);
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f13(__0, __1) {
@@ -19532,15 +19862,17 @@ function __f13(__0, __1) {
         TableName: table.tableName
       }).promise();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f12() {
   return function() {
     let c = __f13;
     let preWarmContext = __preWarmContext;
-    return function(...args) {
+    return function __computed(...args) {
       return c(args, preWarmContext);
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f15(__0, __1) {
@@ -19556,15 +19888,17 @@ function __f15(__0, __1) {
         TableName: table.tableName
       }).promise();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f14() {
   return function() {
     let c = __f15;
     let preWarmContext = __preWarmContext;
-    return function(...args) {
+    return function __computed(...args) {
       return c(args, preWarmContext);
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f17(__0, __1) {
@@ -19580,22 +19914,25 @@ function __f17(__0, __1) {
         TableName: table.tableName
       }).promise();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f16() {
   return function() {
     let c = __f17;
     let preWarmContext = __preWarmContext;
-    return function(...args) {
+    return function __computed(...args) {
       return c(args, preWarmContext);
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f18() {
   return function() {
-    return function() {
+    return function __computed() {
       throw new Error();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f20(__0, __1) {
@@ -19609,66 +19946,75 @@ function __f20(__0, __1) {
         }))
       }).promise();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f19() {
   return function() {
     let c = __f20;
     let preWarmContext = __preWarmContext;
-    return function(...args) {
+    return function __computed(...args) {
       return c(args, preWarmContext);
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f21() {
   return function() {
     let m = __m;
     let k = \\"$AWS\\";
-    return function() {
+    return function __computed() {
       return m[k];
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f22() {
   return function() {
-    return function() {
+    return function __computed() {
       throw new Error();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f23() {
   return function() {
-    return function() {
+    return function __computed() {
       throw new Error();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f24() {
   return function() {
-    return function() {
+    return function __computed() {
       throw new Error();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f25() {
   return function() {
-    return function() {
+    return function __computed() {
       throw new Error();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f26() {
   return function() {
-    return function() {
+    return function __computed() {
       throw new Error();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f27() {
   return function() {
-    return function() {
+    return function __computed() {
       throw new Error();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f0() {
@@ -19687,6 +20033,7 @@ function __f0() {
         }
       });
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 "
@@ -19745,274 +20092,278 @@ var __f22_appsync = {getItem: __f23, putItem: __f24, updateItem: __f25, deleteIt
 __f22.appsync = __f22_appsync;
 function __f3(__0, __1) {
   return (function() {
-    return (key, props) => { var _a; 
-        // eslint-disable-next-line @typescript-eslint/no-require-imports, import/no-extraneous-dependencies
-        return new (require(\\"aws-sdk\\").DynamoDB)((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key)); };
+    return ((key, props) => {
+    var _a;
+    // eslint-disable-next-line @typescript-eslint/no-require-imports, import/no-extraneous-dependencies
+    return new (require(\\"aws-sdk\\").DynamoDB)((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key));
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f4(__0, __1) {
   return (function() {
-    return (key, props) => { var _a; 
-        // eslint-disable-next-line @typescript-eslint/no-require-imports, import/no-extraneous-dependencies
-        return new (require(\\"aws-sdk\\").EventBridge)((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key)); };
+    return ((key, props) => {
+    var _a;
+    // eslint-disable-next-line @typescript-eslint/no-require-imports, import/no-extraneous-dependencies
+    return new (require(\\"aws-sdk\\").EventBridge)((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key));
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f2(__0, __1) {
   return (function() {
     let function_prewarm_1 = __function_prewarm_1;
 
-    return async (args, preWarmContext) => {
-                    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
-                    const [input] = args;
-                    const { Table: table, ...rest } = input;
-                    return dynamo
-                        .deleteItem({
-                        ...rest,
-                        TableName: input.Table.tableName,
-                    })
-                        .promise();
-                };
+    return (async (args, preWarmContext) => {
+    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
+    const [input] = args;
+    const { Table: table, ...rest } = input;
+    return dynamo
+        .deleteItem({
+        ...rest,
+        TableName: input.Table.tableName,
+    })
+        .promise();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f5(__0) {
   return (function() {
-    return function /*constructor*/(props) {
-        this.props = props;
-        this.cache = {};
-    };
+    return (function constructor(props) {
+    this.props = props;
+    this.cache = {};
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f6(__0) {
   return (function() {
-    return function /*get*/(key) {
-        return this.cache[key];
-    };
+    return (function (key) {
+    return this.cache[key];
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f7(__0) {
   return (function() {
-    return function /*getOrInit*/(client) {
-        if (!this.cache[client.key]) {
-            this.cache[client.key] = client.init(client.key, this.props);
-        }
-        return this.cache[client.key];
-    };
+    return (function getOrInit(client) {
+    if (!this.cache[client.key]) {
+        this.cache[client.key] = client.init(client.key, this.props);
+    }
+    return this.cache[client.key];
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f1() {
   return (function() {
     let c = __f2;
     let preWarmContext = __preWarmContext;
 
-    return function (...args) {
-                                return c(args, preWarmContext);
-                            };
+    return (function __computed(...args) {
+    return c(args, preWarmContext);
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f9(__0, __1) {
   return (function() {
     let function_prewarm_1 = __function_prewarm_1;
 
-    return async (args, preWarmContext) => {
-                    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
-                    const [input] = args;
-                    const { Table: table, AttributesToGet, ...rest } = input;
-                    const payload = {
-                        ...rest,
-                        AttributesToGet: AttributesToGet,
-                        TableName: table.tableName,
-                    };
-                    return dynamo.getItem(payload).promise();
-                };
+    return (async (args, preWarmContext) => {
+    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
+    const [input] = args;
+    const { Table: table, AttributesToGet, ...rest } = input;
+    const payload = {
+        ...rest,
+        AttributesToGet: AttributesToGet,
+        TableName: table.tableName,
+    };
+    return dynamo.getItem(payload).promise();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f8() {
   return (function() {
     let c = __f9;
     let preWarmContext = __preWarmContext;
 
-    return function (...args) {
-                                return c(args, preWarmContext);
-                            };
+    return (function __computed(...args) {
+    return c(args, preWarmContext);
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f11(__0, __1) {
   return (function() {
     let function_prewarm_1 = __function_prewarm_1;
 
-    return async (args, preWarmContext) => {
-                    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
-                    const [input] = args;
-                    const { Table: table, ...rest } = input;
-                    return dynamo
-                        .updateItem({
-                        ...rest,
-                        TableName: table.tableName,
-                    })
-                        .promise();
-                };
+    return (async (args, preWarmContext) => {
+    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
+    const [input] = args;
+    const { Table: table, ...rest } = input;
+    return dynamo
+        .updateItem({
+        ...rest,
+        TableName: table.tableName,
+    })
+        .promise();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f10() {
   return (function() {
     let c = __f11;
     let preWarmContext = __preWarmContext;
 
-    return function (...args) {
-                                return c(args, preWarmContext);
-                            };
+    return (function __computed(...args) {
+    return c(args, preWarmContext);
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f13(__0, __1) {
   return (function() {
     let function_prewarm_1 = __function_prewarm_1;
 
-    return async (args, preWarmContext) => {
-                    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
-                    const [input] = args;
-                    const { Table: table, Item, ...rest } = input;
-                    return dynamo
-                        .putItem({
-                        ...rest,
-                        Item: Item,
-                        TableName: table.tableName,
-                    })
-                        .promise();
-                };
+    return (async (args, preWarmContext) => {
+    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
+    const [input] = args;
+    const { Table: table, Item, ...rest } = input;
+    return dynamo
+        .putItem({
+        ...rest,
+        Item: Item,
+        TableName: table.tableName,
+    })
+        .promise();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f12() {
   return (function() {
     let c = __f13;
     let preWarmContext = __preWarmContext;
 
-    return function (...args) {
-                                return c(args, preWarmContext);
-                            };
+    return (function __computed(...args) {
+    return c(args, preWarmContext);
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f15(__0, __1) {
   return (function() {
     let function_prewarm_1 = __function_prewarm_1;
 
-    return async (args, preWarmContext) => {
-                    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
-                    const [input] = args;
-                    const { Table: table, AttributesToGet, ...rest } = input;
-                    return dynamo
-                        .query({
-                        ...rest,
-                        AttributesToGet: AttributesToGet,
-                        TableName: table.tableName,
-                    })
-                        .promise();
-                };
+    return (async (args, preWarmContext) => {
+    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
+    const [input] = args;
+    const { Table: table, AttributesToGet, ...rest } = input;
+    return dynamo
+        .query({
+        ...rest,
+        AttributesToGet: AttributesToGet,
+        TableName: table.tableName,
+    })
+        .promise();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f14() {
   return (function() {
     let c = __f15;
     let preWarmContext = __preWarmContext;
 
-    return function (...args) {
-                                return c(args, preWarmContext);
-                            };
+    return (function __computed(...args) {
+    return c(args, preWarmContext);
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f17(__0, __1) {
   return (function() {
     let function_prewarm_1 = __function_prewarm_1;
 
-    return async (args, preWarmContext) => {
-                    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
-                    const [input] = args;
-                    const { Table: table, AttributesToGet, ...rest } = input;
-                    return dynamo
-                        .scan({
-                        ...rest,
-                        AttributesToGet: AttributesToGet,
-                        TableName: table.tableName,
-                    })
-                        .promise();
-                };
+    return (async (args, preWarmContext) => {
+    const dynamo = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.DYNAMO);
+    const [input] = args;
+    const { Table: table, AttributesToGet, ...rest } = input;
+    return dynamo
+        .scan({
+        ...rest,
+        AttributesToGet: AttributesToGet,
+        TableName: table.tableName,
+    })
+        .promise();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f16() {
   return (function() {
     let c = __f17;
     let preWarmContext = __preWarmContext;
 
-    return function (...args) {
-                                return c(args, preWarmContext);
-                            };
+    return (function __computed(...args) {
+    return c(args, preWarmContext);
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f18() {
   return (function() {
-    return function () {
-                                    throw new Error();
-                                };
+    return (function __computed() {
+    throw new Error();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f20(__0, __1) {
   return (function() {
     let function_prewarm_1 = __function_prewarm_1;
 
-    return async ([request], preWarmContext) => {
-                    const eventBridge = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.EVENT_BRIDGE);
-                    return eventBridge
-                        .putEvents({
-                        Entries: request.Entries.map((e) => ({
-                            ...e,
-                        })),
-                    })
-                        .promise();
-                };
+    return (async ([request], preWarmContext) => {
+    const eventBridge = preWarmContext.getOrInit(function_prewarm_1.PrewarmClients.EVENT_BRIDGE);
+    return eventBridge
+        .putEvents({
+        Entries: request.Entries.map((e) => ({
+            ...e,
+        })),
+    })
+        .promise();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f19() {
   return (function() {
     let c = __f20;
     let preWarmContext = __preWarmContext;
 
-    return function (...args) {
-                                return c(args, preWarmContext);
-                            };
+    return (function __computed(...args) {
+    return c(args, preWarmContext);
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f21() {
   return (function() {
     let m = __m;
     let k = \\"$AWS\\";
 
-    return function () { return m[k]; };
+    return (function __computed() { return m[k]; });;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f22() {
   return (function() {
-    return function () {
-                                    throw new Error();
-                                };
+    return (function __computed() {
+    throw new Error();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f23() {
   return (function() {
-    return function () {
-                                    throw new Error();
-                                };
+    return (function __computed() {
+    throw new Error();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f24() {
   return (function() {
-    return function () {
-                                    throw new Error();
-                                };
+    return (function __computed() {
+    throw new Error();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f25() {
   return (function() {
-    return function () {
-                                    throw new Error();
-                                };
+    return (function __computed() {
+    throw new Error();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f26() {
   return (function() {
-    return function () {
-                                    throw new Error();
-                                };
+    return (function __computed() {
+    throw new Error();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f27() {
   return (function() {
-    return function () {
-                                    throw new Error();
-                                };
+    return (function __computed() {
+    throw new Error();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f0() {
   return (function() {
     let _fnls_1 = __fnls_1;
     let table = __f22;
 
-    return async () => {
-                return _fnls_1.$AWS.DynamoDB.Scan({
-                    Table: table,
-                });
-            };
+    return (async () => {
+    return _fnls_1.$AWS.DynamoDB.Scan({
+        Table: table,
+    });
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }"
 `;
@@ -20074,6 +20425,7 @@ function __f3(__0, __1) {
       var _a;
       return new (require(\\"aws-sdk\\")).DynamoDB((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key));
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f4(__0, __1) {
@@ -20082,6 +20434,7 @@ function __f4(__0, __1) {
       var _a;
       return new (require(\\"aws-sdk\\")).EventBridge((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key));
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f2(__0, __1) {
@@ -20096,14 +20449,16 @@ function __f2(__0, __1) {
         TableName: input.Table.tableName
       }).promise();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f5(__0) {
   return function() {
-    return function(props) {
+    return function constructor(props) {
       this.props = props;
       this.cache = {};
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f6(__0) {
@@ -20111,25 +20466,28 @@ function __f6(__0) {
     return function(key) {
       return this.cache[key];
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f7(__0) {
   return function() {
-    return function(client) {
+    return function getOrInit(client) {
       if (!this.cache[client.key]) {
         this.cache[client.key] = client.init(client.key, this.props);
       }
       return this.cache[client.key];
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f1() {
   return function() {
     let c = __f2;
     let preWarmContext = __preWarmContext;
-    return function(...args) {
+    return function __computed(...args) {
       return c(args, preWarmContext);
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f9(__0, __1) {
@@ -20146,15 +20504,17 @@ function __f9(__0, __1) {
       };
       return dynamo.getItem(payload).promise();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f8() {
   return function() {
     let c = __f9;
     let preWarmContext = __preWarmContext;
-    return function(...args) {
+    return function __computed(...args) {
       return c(args, preWarmContext);
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f11(__0, __1) {
@@ -20169,15 +20529,17 @@ function __f11(__0, __1) {
         TableName: table.tableName
       }).promise();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f10() {
   return function() {
     let c = __f11;
     let preWarmContext = __preWarmContext;
-    return function(...args) {
+    return function __computed(...args) {
       return c(args, preWarmContext);
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f13(__0, __1) {
@@ -20193,15 +20555,17 @@ function __f13(__0, __1) {
         TableName: table.tableName
       }).promise();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f12() {
   return function() {
     let c = __f13;
     let preWarmContext = __preWarmContext;
-    return function(...args) {
+    return function __computed(...args) {
       return c(args, preWarmContext);
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f15(__0, __1) {
@@ -20217,15 +20581,17 @@ function __f15(__0, __1) {
         TableName: table.tableName
       }).promise();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f14() {
   return function() {
     let c = __f15;
     let preWarmContext = __preWarmContext;
-    return function(...args) {
+    return function __computed(...args) {
       return c(args, preWarmContext);
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f17(__0, __1) {
@@ -20241,22 +20607,25 @@ function __f17(__0, __1) {
         TableName: table.tableName
       }).promise();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f16() {
   return function() {
     let c = __f17;
     let preWarmContext = __preWarmContext;
-    return function(...args) {
+    return function __computed(...args) {
       return c(args, preWarmContext);
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f18() {
   return function() {
-    return function() {
+    return function __computed() {
       throw new Error();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f20(__0, __1) {
@@ -20270,66 +20639,75 @@ function __f20(__0, __1) {
         }))
       }).promise();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f19() {
   return function() {
     let c = __f20;
     let preWarmContext = __preWarmContext;
-    return function(...args) {
+    return function __computed(...args) {
       return c(args, preWarmContext);
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f21() {
   return function() {
     let m = __m;
     let k = \\"$AWS\\";
-    return function() {
+    return function __computed() {
       return m[k];
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f22() {
   return function() {
-    return function() {
+    return function __computed() {
       throw new Error();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f23() {
   return function() {
-    return function() {
+    return function __computed() {
       throw new Error();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f24() {
   return function() {
-    return function() {
+    return function __computed() {
       throw new Error();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f25() {
   return function() {
-    return function() {
+    return function __computed() {
       throw new Error();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f26() {
   return function() {
-    return function() {
+    return function __computed() {
       throw new Error();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f27() {
   return function() {
-    return function() {
+    return function __computed() {
       throw new Error();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 function __f0() {
@@ -20341,6 +20719,7 @@ function __f0() {
         Table: table
       });
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 "
@@ -20352,9 +20731,9 @@ function __f0() {
   return (function() {
     let uuid_1 = require(\\"uuid\\");
 
-    return async () => {
-            return (0, uuid_1.v4)();
-        };
+    return (async () => {
+    return (0, uuid_1.v4)();
+});;
   }).apply(undefined, undefined).apply(this, arguments);
 }"
 `;
@@ -20864,6 +21243,7 @@ function __f0() {
     return async () => {
       return (0, uuid_1.v4)();
     };
+    ;
   }.apply(void 0, void 0).apply(this, arguments);
 }
 "

--- a/test/appsync.localstack.test.ts
+++ b/test/appsync.localstack.test.ts
@@ -3,14 +3,17 @@
 // 2. #return fails when running in the response template - https://github.com/localstack/localstack/issues/5988
 // 3. Need a valid LocalStack Pro license
 
+// @ts-ignore - importing so that tsc will re-write imports as require, see https://github.com/functionless/functionless/issues/341
+import path from "path";
+
 test("fix me", () => {
   expect(true).toBeTruthy();
 });
 
 // import * as appsync from "@aws-cdk/aws-appsync-alpha";
+// import { gql, GraphQLClient } from "graphql-request";
 // import { AppsyncResolver } from "../src";
 // import { localstackTestSuite } from "./localstack";
-// import { gql, GraphQLClient } from "graphql-request";
 
 // localstackTestSuite("appSyncStack", (testResource, stack) => {
 //   const api = new appsync.GraphqlApi(stack, "graphql1", {
@@ -25,20 +28,17 @@ test("fix me", () => {
 //   testResource(
 //     "app sync basic",
 //     () => {
-//       const resolver = new AppsyncResolver(() => {
-//         return { value: "hi2" };
-//       });
-
-//       const valueObjType = new appsync.ObjectType("valueObj", {
-//         definition: {
-//           value: appsync.GraphqlType.string(),
+//       new AppsyncResolver(
+//         api,
+//         "resolver",
+//         {
+//           fieldName: "field",
+//           typeName: "type",
 //         },
-//       });
-
-//       api.addType(valueObjType);
-//       const field = resolver.getField(api, valueObjType.attribute());
-//       api.addQuery("hi5", field);
-
+//         () => {
+//           return { value: "hi2" };
+//         }
+//       );
 //       return {
 //         outputs: {
 //           apiUrl: api.graphqlUrl,

--- a/test/appsync.localstack.test.ts
+++ b/test/appsync.localstack.test.ts
@@ -3,9 +3,6 @@
 // 2. #return fails when running in the response template - https://github.com/localstack/localstack/issues/5988
 // 3. Need a valid LocalStack Pro license
 
-// @ts-ignore - importing so that tsc will re-write imports as require, see https://github.com/functionless/functionless/issues/341
-import path from "path";
-
 test("fix me", () => {
   expect(true).toBeTruthy();
 });

--- a/test/appsync.test.ts
+++ b/test/appsync.test.ts
@@ -4,7 +4,6 @@ import { AttributeType } from "aws-cdk-lib/aws-dynamodb";
 import {
   AppsyncContext,
   AppsyncResolver,
-  reflect,
   StepFunction,
   Function,
   Table,
@@ -25,11 +24,9 @@ describe("step function integration", () => {
   test("machine with no parameters", () => {
     const machine = new StepFunction(stack, "machine", async () => {});
 
-    const templates = appsyncTestCase(
-      reflect(async () => {
-        await machine({});
-      })
-    );
+    const templates = appsyncTestCase(async () => {
+      await machine({});
+    });
 
     testAppsyncVelocity(templates[1], {
       resultMatch: {
@@ -49,11 +46,9 @@ describe("step function integration", () => {
       async () => {}
     );
 
-    const templates = appsyncTestCase(
-      reflect(async () => {
-        await machine({ input: { id: "1" } });
-      })
-    );
+    const templates = appsyncTestCase(async () => {
+      await machine({ input: { id: "1" } });
+    });
 
     testAppsyncVelocity(templates[1], {
       resultMatch: {
@@ -74,9 +69,9 @@ describe("step function integration", () => {
     );
 
     const templates = appsyncTestCase(
-      reflect(async (context: AppsyncContext<{ id: string }>) => {
+      async (context: AppsyncContext<{ id: string }>) => {
         await machine({ input: { id: context.arguments.id } });
-      })
+      }
     );
 
     testAppsyncVelocity(templates[1], {
@@ -95,9 +90,9 @@ describe("step function integration", () => {
     const machine = new StepFunction(stack, "machine", async () => {});
 
     const templates = appsyncTestCase(
-      reflect(async (context: AppsyncContext<{ id: string }>) => {
+      async (context: AppsyncContext<{ id: string }>) => {
         await machine({ name: context.arguments.id });
-      })
+      }
     );
 
     testAppsyncVelocity(templates[1], {
@@ -132,12 +127,10 @@ describe("step function integration", () => {
   test("machine describe exec", () => {
     const machine = new StepFunction(stack, "machine", async () => {});
 
-    const templates = appsyncTestCase(
-      reflect(async () => {
-        const exec = "exec1";
-        await machine.describeExecution(exec);
-      })
-    );
+    const templates = appsyncTestCase(async () => {
+      const exec = "exec1";
+      await machine.describeExecution(exec);
+    });
 
     testAppsyncVelocity(templates[1]);
   });
@@ -162,12 +155,10 @@ test("if first argument is a GraphQLApi, then api can be omitted from the props"
 test("machine describe exec return", () => {
   const machine = new StepFunction(stack, "machine", () => {});
 
-  const templates = appsyncTestCase(
-    reflect(() => {
-      const exec = "exec1";
-      return machine.describeExecution(exec);
-    })
-  );
+  const templates = appsyncTestCase(() => {
+    const exec = "exec1";
+    return machine.describeExecution(exec);
+  });
 
   testAppsyncVelocity(templates[1]);
 });
@@ -175,13 +166,11 @@ test("machine describe exec return", () => {
 test("machine describe exec var", () => {
   const machine = new StepFunction(stack, "machine", () => {});
 
-  const templates = appsyncTestCase(
-    reflect(() => {
-      const exec = "exec1";
-      const v = machine.describeExecution(exec);
-      return v;
-    })
-  );
+  const templates = appsyncTestCase(() => {
+    const exec = "exec1";
+    const v = machine.describeExecution(exec);
+    return v;
+  });
 
   testAppsyncVelocity(templates[1]);
 });
@@ -190,11 +179,9 @@ describe("step function describe execution", () => {
   test("machine describe exec string", () => {
     const machine = new StepFunction(stack, "machine", async () => {});
 
-    const templates = appsyncTestCase(
-      reflect(async () => {
-        await machine.describeExecution("exec1");
-      })
-    );
+    const templates = appsyncTestCase(async () => {
+      await machine.describeExecution("exec1");
+    });
 
     testAppsyncVelocity(templates[1]);
   });
@@ -220,12 +207,12 @@ test("multiple isolated integrations", () => {
   const machine = new StepFunction(stack, "machine", () => {});
 
   const templates = appsyncTestCase(
-    reflect(async () => {
+    async () => {
       await machine.describeExecution("exec1");
       await machine.describeExecution("exec2");
       await machine.describeExecution("exec3");
       await machine.describeExecution("exec4");
-    }),
+    },
     {
       expectedTemplateCount: 10,
     }
@@ -237,13 +224,11 @@ test("multiple isolated integrations", () => {
 test("multiple linked integrations", () => {
   const machine = new StepFunction(stack, "machine", () => {});
 
-  const templates = appsyncTestCase(
-    reflect(async () => {
-      const res1 = await machine({ input: {} });
-      const res2 = await machine({ input: res1 });
-      await machine({ input: res2 });
-    })
-  );
+  const templates = appsyncTestCase(async () => {
+    const res1 = await machine({ input: {} });
+    const res2 = await machine({ input: res1 });
+    await machine({ input: res2 });
+  });
 
   testAppsyncVelocity(templates[1]);
 });
@@ -252,12 +237,12 @@ test("multiple linked integrations pre-compute", () => {
   const machine = new StepFunction(stack, "machine", () => {});
 
   const templates = appsyncTestCase(
-    reflect(async () => {
+    async () => {
       const x = "y";
       const res1 = await machine({ input: { x } });
       const res2 = await machine({ input: res1 });
       await machine({ input: res2 });
-    }),
+    },
     {
       expectedTemplateCount: 8,
     }
@@ -269,14 +254,12 @@ test("multiple linked integrations pre-compute", () => {
 test("multiple linked integrations post-compute", () => {
   const machine = new StepFunction(stack, "machine", () => {});
 
-  const templates = appsyncTestCase(
-    reflect(async () => {
-      const res1 = await machine({ input: {} });
-      const res2 = await machine({ input: res1 });
-      const result = await machine({ input: res2 });
-      return result.startDate;
-    })
-  );
+  const templates = appsyncTestCase(async () => {
+    const res1 = await machine({ input: {} });
+    const res2 = await machine({ input: res1 });
+    const result = await machine({ input: res2 });
+    return result.startDate;
+  });
 
   testAppsyncVelocity(templates[1]);
 });
@@ -285,11 +268,11 @@ test("multiple linked integrations with props", () => {
   const machine = new StepFunction(stack, "machine", () => {});
 
   const templates = appsyncTestCase(
-    reflect(async () => {
+    async () => {
       const res1 = await machine.describeExecution("exec1");
       const res2 = await machine.describeExecution(res1.executionArn);
       await machine.describeExecution(res2.executionArn);
-    }),
+    },
     {
       expectedTemplateCount: 8,
     }
@@ -303,11 +286,11 @@ test("multiple nested integrations", () => {
   const machine = new StepFunction(stack, "machine", () => {});
 
   const templates = appsyncTestCase(
-    reflect(async () => {
+    async () => {
       await machine({
         input: await machine({ input: await machine({ input: {} }) }),
       });
-    }),
+    },
     {
       expectedTemplateCount: 8,
     }
@@ -321,7 +304,7 @@ test("multiple nested integrations prop access", () => {
   const machine = new StepFunction(stack, "machine", () => {});
 
   const templates = appsyncTestCase(
-    reflect(async () => {
+    async () => {
       await machine.describeExecution(
         (
           await machine.describeExecution(
@@ -331,7 +314,7 @@ test("multiple nested integrations prop access", () => {
           )
         ).executionArn
       );
-    }),
+    },
     {
       expectedTemplateCount: 8,
     }
@@ -349,12 +332,12 @@ test("integrations separated by in", () => {
   });
 
   const templates = appsyncTestCase(
-    reflect(async () => {
+    async () => {
       if ((await func({})) in (await func2({}))) {
         return true;
       }
       return false;
-    }),
+    },
     {
       expectedTemplateCount: 6,
     }
@@ -366,13 +349,11 @@ test("integrations separated by in", () => {
 test("multiple linked integrations with mutation", () => {
   const machine = new StepFunction(stack, "machine", () => {});
 
-  const templates = appsyncTestCase(
-    reflect(async () => {
-      const res1 = await machine.describeExecution("exec1");
-      const formatted = `status: ${res1.status}`;
-      await machine({ input: { x: formatted } });
-    })
-  );
+  const templates = appsyncTestCase(async () => {
+    const res1 = await machine.describeExecution("exec1");
+    const formatted = `status: ${res1.status}`;
+    await machine({ input: { x: formatted } });
+  });
 
   testAppsyncVelocity(templates[1]);
 });
@@ -396,7 +377,7 @@ test("return error", () => {
   expect(() => {
     appsyncTestCase<{ num: number }, { pk: string; sk: string }>(
       // source https://github.com/functionless/functionless/issues/266
-      reflect(async ($context) => {
+      async ($context) => {
         const identity = $context.identity;
 
         if (identity && "resolverContext" in identity) {
@@ -410,7 +391,7 @@ test("return error", () => {
         }
 
         return $util.error("Cannot find account.");
-      })
+      }
     );
   }).toThrow(
     "Appsync Integration invocations must be unidirectional and defined statically"

--- a/test/function.test.ts
+++ b/test/function.test.ts
@@ -9,7 +9,6 @@ import {
   AsyncResponseFailure,
   asyncSynth,
 } from "../src";
-import { reflect } from "../src/reflect";
 import { appsyncTestCase } from "./util";
 
 interface Item {
@@ -37,38 +36,32 @@ beforeEach(() => {
 test("call function", () => {
   const fn1 = Function.fromFunction<{ arg: string }, Item>(lambda);
 
-  appsyncTestCase(
-    reflect((context: AppsyncContext<{ arg: string }>) => {
-      return fn1(context.arguments);
-    })
-  );
+  appsyncTestCase((context: AppsyncContext<{ arg: string }>) => {
+    return fn1(context.arguments);
+  });
 });
 
 test("call function and conditional return", () => {
   const fn1 = Function.fromFunction<{ arg: string }, Item>(lambda);
 
-  appsyncTestCase(
-    reflect(async (context: AppsyncContext<{ arg: string }>) => {
-      const result = await fn1(context.arguments);
+  appsyncTestCase(async (context: AppsyncContext<{ arg: string }>) => {
+    const result = await fn1(context.arguments);
 
-      if (result.id === "sam") {
-        return true;
-      } else {
-        return false;
-      }
-    })
-  );
+    if (result.id === "sam") {
+      return true;
+    } else {
+      return false;
+    }
+  });
 });
 
 test("call function omitting optional arg", () => {
   const fn2 = Function.fromFunction<{ arg: string; optional?: string }, Item>(
     lambda
   );
-  appsyncTestCase(
-    reflect((context: AppsyncContext<{ arg: string }>) => {
-      return fn2(context.arguments);
-    })
-  );
+  appsyncTestCase((context: AppsyncContext<{ arg: string }>) => {
+    return fn2(context.arguments);
+  });
 });
 
 test("call function including optional arg", () => {
@@ -76,31 +69,25 @@ test("call function including optional arg", () => {
     lambda
   );
 
-  appsyncTestCase(
-    reflect((context: AppsyncContext<{ arg: string }>) => {
-      return fn2({ arg: context.arguments.arg, optional: "hello" });
-    })
-  );
+  appsyncTestCase((context: AppsyncContext<{ arg: string }>) => {
+    return fn2({ arg: context.arguments.arg, optional: "hello" });
+  });
 });
 
 test("call function including with no parameters", () => {
   const fn3 = Function.fromFunction<undefined, Item>(lambda);
 
-  appsyncTestCase(
-    reflect(() => {
-      return fn3();
-    })
-  );
+  appsyncTestCase(() => {
+    return fn3();
+  });
 });
 
 test("call function including with void result", () => {
   const fn4 = Function.fromFunction<{ arg: string }, void>(lambda);
 
-  appsyncTestCase(
-    reflect((context: AppsyncContext<{ arg: string }>) => {
-      return fn4(context.arguments);
-    })
-  );
+  appsyncTestCase((context: AppsyncContext<{ arg: string }>) => {
+    return fn4(context.arguments);
+  });
 });
 
 test("set on success bus", () => {

--- a/test/reflect.test.ts
+++ b/test/reflect.test.ts
@@ -1,9 +1,9 @@
 import {
   BinaryExpr,
   CallExpr,
-  Err,
   ExprStmt,
   FunctionDecl,
+  FunctionExpr,
   NullLiteralExpr,
   NumberLiteralExpr,
   ObjectLiteralExpr,
@@ -14,21 +14,31 @@ import {
 } from "../src";
 import { assertNodeKind } from "../src/assert";
 
-test("function", () => expect(reflect(() => {}).kind).toEqual("FunctionDecl"));
+test("function", () => {
+  assertNodeKind<FunctionExpr>(
+    reflect(() => {}),
+    "FunctionExpr"
+  );
+});
+
+test("function decl", () => {
+  assertNodeKind<FunctionDecl>(reflect(foo), "FunctionDecl");
+  function foo() {}
+});
 
 test("turns a single line function into a return", () => {
-  const fn = assertNodeKind<FunctionDecl>(
+  const fn = assertNodeKind<FunctionExpr>(
     reflect(() => ""),
-    "FunctionDecl"
+    "FunctionExpr"
   );
 
   expect(fn.body.statements[0].kind).toEqual("ReturnStmt");
 });
 
 test("returns a string", () => {
-  const fn = assertNodeKind<FunctionDecl>(
+  const fn = assertNodeKind<FunctionExpr>(
     reflect(() => ""),
-    "FunctionDecl"
+    "FunctionExpr"
   );
   expect(
     assertNodeKind<ReturnStmt>(fn.body.statements[0], "ReturnStmt").expr.kind
@@ -36,11 +46,11 @@ test("returns a string", () => {
 });
 
 test("parenthesis", () => {
-  const fn = assertNodeKind<FunctionDecl>(
+  const fn = assertNodeKind<FunctionExpr>(
     reflect(() => {
       ("");
     }),
-    "FunctionDecl"
+    "FunctionExpr"
   );
 
   const expr = assertNodeKind<ExprStmt>(fn.body.statements[0], "ExprStmt");
@@ -48,11 +58,11 @@ test("parenthesis", () => {
 });
 
 test("parenthesis are respected", () => {
-  const fn = assertNodeKind<FunctionDecl>(
+  const fn = assertNodeKind<FunctionExpr>(
     reflect(() => {
       2 + (1 + 2);
     }),
-    "FunctionDecl"
+    "FunctionExpr"
   );
 
   const expr = assertNodeKind<ExprStmt>(fn.body.statements[0], "ExprStmt");
@@ -62,11 +72,11 @@ test("parenthesis are respected", () => {
 });
 
 test("parenthesis are respected inverted", () => {
-  const fn = assertNodeKind<FunctionDecl>(
+  const fn = assertNodeKind<FunctionExpr>(
     reflect(() => {
       2 + 1 + 2;
     }),
-    "FunctionDecl"
+    "FunctionExpr"
   );
 
   const expr = assertNodeKind<ExprStmt>(fn.body.statements[0], "ExprStmt");
@@ -76,11 +86,11 @@ test("parenthesis are respected inverted", () => {
 });
 
 test("type casting", () => {
-  const fn = assertNodeKind<FunctionDecl>(
+  const fn = assertNodeKind<FunctionExpr>(
     reflect(() => {
       <any>2;
     }),
-    "FunctionDecl"
+    "FunctionExpr"
   );
 
   const expr = assertNodeKind<ExprStmt>(fn.body.statements[0], "ExprStmt");
@@ -88,11 +98,11 @@ test("type casting", () => {
 });
 
 test("type casting as", () => {
-  const fn = assertNodeKind<FunctionDecl>(
+  const fn = assertNodeKind<FunctionExpr>(
     reflect(() => {
       2 as any;
     }),
-    "FunctionDecl"
+    "FunctionExpr"
   );
 
   const expr = assertNodeKind<ExprStmt>(fn.body.statements[0], "ExprStmt");
@@ -100,11 +110,11 @@ test("type casting as", () => {
 });
 
 test("any function args", () => {
-  const result = assertNodeKind<FunctionDecl>(
+  const result = assertNodeKind<FunctionExpr>(
     reflect(() => {
       (<any>"").startsWith("");
     }),
-    "FunctionDecl"
+    "FunctionExpr"
   );
 
   const expr = assertNodeKind<ExprStmt>(result.body.statements[0], "ExprStmt");
@@ -115,11 +125,11 @@ test("any function args", () => {
 });
 
 test("named function args", () => {
-  const result = assertNodeKind<FunctionDecl>(
+  const result = assertNodeKind<FunctionExpr>(
     reflect(() => {
       "".startsWith("");
     }),
-    "FunctionDecl"
+    "FunctionExpr"
   );
 
   const expr = assertNodeKind<ExprStmt>(result.body.statements[0], "ExprStmt");
@@ -131,9 +141,9 @@ test("named function args", () => {
 });
 
 test("null", () => {
-  const result = assertNodeKind<FunctionDecl>(
+  const result = assertNodeKind<FunctionExpr>(
     reflect(() => null),
-    "FunctionDecl"
+    "FunctionExpr"
   );
 
   const ret = assertNodeKind<ReturnStmt>(
@@ -144,9 +154,9 @@ test("null", () => {
 });
 
 test("undefined", () => {
-  const result = assertNodeKind<FunctionDecl>(
+  const result = assertNodeKind<FunctionExpr>(
     reflect(() => undefined),
-    "FunctionDecl"
+    "FunctionExpr"
   );
 
   const ret = assertNodeKind<ReturnStmt>(
@@ -157,14 +167,14 @@ test("undefined", () => {
 });
 
 test("computed object name", () => {
-  const result = assertNodeKind<FunctionDecl>(
+  const result = assertNodeKind<FunctionExpr>(
     reflect(() => {
       const name = "aName";
       return {
         [name]: "value",
       };
     }),
-    "FunctionDecl"
+    "FunctionExpr"
   );
 
   const ret = assertNodeKind<ReturnStmt>(
@@ -173,12 +183,4 @@ test("computed object name", () => {
   );
   const obj = assertNodeKind<ObjectLiteralExpr>(ret.expr, "ObjectLiteralExpr");
   obj.properties;
-});
-
-test("err", () => {
-  const fn = () => {};
-  const result = assertNodeKind<Err>(reflect(fn), "Err");
-  expect(result.error.message).toEqual(
-    "Functionless reflection only supports function parameters with bodies, no signature only declarations or references. Found fn."
-  );
 });

--- a/test/vtl.test.ts
+++ b/test/vtl.test.ts
@@ -1,140 +1,110 @@
 import "jest";
-import {
-  $util,
-  AppsyncContext,
-  ComparatorOp,
-  MathBinaryOp,
-  ResolverFunction,
-  ValueComparisonBinaryOp,
-} from "../src";
-import { reflect } from "../src/reflect";
+import { $util, AppsyncContext } from "../src";
 import { appsyncTestCase, testAppsyncVelocity } from "./util";
 
 test("empty function returning an argument", () => {
-  appsyncTestCase(
-    reflect((context: AppsyncContext<{ a: string }>) => {
-      return context.arguments.a;
-    })
-  );
+  appsyncTestCase((context: AppsyncContext<{ a: string }>) => {
+    return context.arguments.a;
+  });
 });
 
 test("return literal object with values", () => {
   appsyncTestCase(
-    reflect(
-      (context: AppsyncContext<{ arg: string; obj: Record<string, any> }>) => {
-        const arg = context.arguments.arg;
-        const obj = context.arguments.obj;
-        return {
-          null: null,
-          undefined: undefined,
-          string: "hello",
-          number: 1,
-          ["list"]: ["hello"],
-          obj: {
-            key: "value",
-          },
-          arg,
-          ...obj,
-        };
-      }
-    )
+    (context: AppsyncContext<{ arg: string; obj: Record<string, any> }>) => {
+      const arg = context.arguments.arg;
+      const obj = context.arguments.obj;
+      return {
+        null: null,
+        undefined: undefined,
+        string: "hello",
+        number: 1,
+        ["list"]: ["hello"],
+        obj: {
+          key: "value",
+        },
+        arg,
+        ...obj,
+      };
+    }
   );
 });
 
 test("computed property names", () => {
   appsyncTestCase(
-    reflect(
-      (context: AppsyncContext<{ arg: string; obj: Record<string, any> }>) => {
-        const name = context.arguments.arg;
-        const value = name + "_test";
-        return {
-          [name]: context.arguments.arg,
-          [value]: context.arguments.arg,
-        };
-      }
-    )
+    (context: AppsyncContext<{ arg: string; obj: Record<string, any> }>) => {
+      const name = context.arguments.arg;
+      const value = name + "_test";
+      return {
+        [name]: context.arguments.arg,
+        [value]: context.arguments.arg,
+      };
+    }
   );
 });
 
 test("null and undefined", () => {
   appsyncTestCase(
-    reflect(
-      (_context: AppsyncContext<{ arg: string; obj: Record<string, any> }>) => {
-        return {
-          name: null,
-          value: undefined,
-        };
-      }
-    )
+    (_context: AppsyncContext<{ arg: string; obj: Record<string, any> }>) => {
+      return {
+        name: null,
+        value: undefined,
+      };
+    }
   );
 });
 
 test("call function and return its value", () => {
-  appsyncTestCase(
-    reflect(() => {
-      return $util.autoId();
-    })
-  );
+  appsyncTestCase(() => {
+    return $util.autoId();
+  });
 });
 
 test("call function, assign to variable and return variable reference", () => {
-  appsyncTestCase(
-    reflect(() => {
-      const id = $util.autoId();
-      return id;
-    })
-  );
+  appsyncTestCase(() => {
+    const id = $util.autoId();
+    return id;
+  });
 });
 
 test("return in-line spread object", () => {
-  appsyncTestCase(
-    reflect((context: AppsyncContext<{ obj: { key: string } }>) => {
-      return {
-        id: $util.autoId(),
-        ...context.arguments.obj,
-      };
-    })
-  );
+  appsyncTestCase((context: AppsyncContext<{ obj: { key: string } }>) => {
+    return {
+      id: $util.autoId(),
+      ...context.arguments.obj,
+    };
+  });
 });
 
 test("return in-line list literal", () => {
-  appsyncTestCase(
-    reflect((context: AppsyncContext<{ a: string; b: string }>) => {
-      return [context.arguments.a, context.arguments.b];
-    })
-  );
+  appsyncTestCase((context: AppsyncContext<{ a: string; b: string }>) => {
+    return [context.arguments.a, context.arguments.b];
+  });
 });
 
 test("return list literal variable", () => {
-  appsyncTestCase(
-    reflect((context: AppsyncContext<{ a: string; b: string }>) => {
-      const list = [context.arguments.a, context.arguments.b];
-      return list;
-    })
-  );
+  appsyncTestCase((context: AppsyncContext<{ a: string; b: string }>) => {
+    const list = [context.arguments.a, context.arguments.b];
+    return list;
+  });
 });
 
 test("return list element", () => {
-  appsyncTestCase(
-    reflect((context: AppsyncContext<{ a: string; b: string }>) => {
-      const list = [context.arguments.a, context.arguments.b];
-      return list[0];
-    })
-  );
+  appsyncTestCase((context: AppsyncContext<{ a: string; b: string }>) => {
+    const list = [context.arguments.a, context.arguments.b];
+    return list[0];
+  });
 });
 
 test("push element to array is renamed to add", () => {
-  appsyncTestCase(
-    reflect((context: AppsyncContext<{ list: string[] }>) => {
-      context.arguments.list.push("hello");
-      return context.arguments.list;
-    })
-  );
+  appsyncTestCase((context: AppsyncContext<{ list: string[] }>) => {
+    context.arguments.list.push("hello");
+    return context.arguments.list;
+  });
 });
 
 // TODO https://github.com/functionless/functionless/issues/8
 // test("push multiple args is expanded to multiple add calls", () => {
-//   const template = reflect((context: AppsyncContext<{ list: string[] }>) => {
+//   const template = (context: AppsyncContext<{ list: string[] }>) => {
 //     list.push("hello", "world");
 //     return list;
 //   });
@@ -149,302 +119,258 @@ test("push element to array is renamed to add", () => {
 // });
 
 test("if statement", () => {
-  appsyncTestCase(
-    reflect((context: AppsyncContext<{ list: string[] }>) => {
-      if (context.arguments.list.length > 0) {
-        return true;
-      } else {
-        return false;
-      }
-    })
-  );
+  appsyncTestCase((context: AppsyncContext<{ list: string[] }>) => {
+    if (context.arguments.list.length > 0) {
+      return true;
+    } else {
+      return false;
+    }
+  });
 });
 
 test("blockless if", () => {
-  appsyncTestCase<{ num: number }, void>(
-    reflect(async ($context) => {
-      if (1 === $context.arguments.num) return;
-      if (1 === $context.arguments.num) {
-      } else return;
-    })
-  );
+  appsyncTestCase<{ num: number }, void>(async ($context) => {
+    if (1 === $context.arguments.num) return;
+    if (1 === $context.arguments.num) {
+    } else return;
+  });
 
   // https://github.com/aws-amplify/amplify-category-api/issues/592
   // testAppsyncVelocity(templates[1]);
 });
 
 test("return conditional expression", () => {
-  appsyncTestCase(
-    reflect((context: AppsyncContext<{ list: string[] }>) => {
-      return context.arguments.list.length > 0 ? true : false;
-    })
-  );
+  appsyncTestCase((context: AppsyncContext<{ list: string[] }>) => {
+    return context.arguments.list.length > 0 ? true : false;
+  });
 });
 
 test("property assignment of conditional expression", () => {
-  appsyncTestCase(
-    reflect((context: AppsyncContext<{ list: string[] }>) => {
-      return {
-        prop: context.arguments.list.length > 0 ? true : false,
-      };
-    })
-  );
+  appsyncTestCase((context: AppsyncContext<{ list: string[] }>) => {
+    return {
+      prop: context.arguments.list.length > 0 ? true : false,
+    };
+  });
 });
 
 test("for-of loop", () => {
-  appsyncTestCase(
-    reflect((context: AppsyncContext<{ list: string[] }>) => {
-      const newList = [];
-      for (const item of context.arguments.list) {
-        newList.push(item);
-      }
-      return newList;
-    })
-  );
+  appsyncTestCase((context: AppsyncContext<{ list: string[] }>) => {
+    const newList = [];
+    for (const item of context.arguments.list) {
+      newList.push(item);
+    }
+    return newList;
+  });
 });
 
 test("break from for-loop", () => {
-  appsyncTestCase(
-    reflect((context: AppsyncContext<{ list: string[] }>) => {
-      const newList = [];
-      for (const item of context.arguments.list) {
-        if (item === "hello") {
-          break;
-        }
-        newList.push(item);
+  appsyncTestCase((context: AppsyncContext<{ list: string[] }>) => {
+    const newList = [];
+    for (const item of context.arguments.list) {
+      if (item === "hello") {
+        break;
       }
-      return newList;
-    })
-  );
+      newList.push(item);
+    }
+    return newList;
+  });
 });
 
 test("local variable inside for-of loop is declared as a local variable", () => {
-  appsyncTestCase(
-    reflect((context: AppsyncContext<{ list: string[] }>) => {
-      const newList = [];
-      for (const item of context.arguments.list) {
-        const i = item;
-        newList.push(i);
-      }
-      return newList;
-    })
-  );
+  appsyncTestCase((context: AppsyncContext<{ list: string[] }>) => {
+    const newList = [];
+    for (const item of context.arguments.list) {
+      const i = item;
+      newList.push(i);
+    }
+    return newList;
+  });
 });
 
 test("for-in loop and element access", () => {
   appsyncTestCase(
-    reflect((context: AppsyncContext<{ record: Record<string, any> }>) => {
+    (context: AppsyncContext<{ record: Record<string, any> }>) => {
       const newList = [];
       for (const key in context.arguments.record) {
         newList.push(context.arguments.record[key]);
       }
       return newList;
-    })
+    }
   );
 });
 
 test("template expression", () => {
-  appsyncTestCase(
-    reflect((context: AppsyncContext<{ a: string }>) => {
-      const local = context.arguments.a;
-      return `head ${context.arguments.a} ${local}${context.arguments.a}`;
-    })
-  );
+  appsyncTestCase((context: AppsyncContext<{ a: string }>) => {
+    const local = context.arguments.a;
+    return `head ${context.arguments.a} ${local}${context.arguments.a}`;
+  });
 });
 
 test("conditional expression in template expression", () => {
-  appsyncTestCase(
-    reflect((context: AppsyncContext<{ a: string }>) => {
-      return `head ${
-        context.arguments.a === "hello" ? "world" : context.arguments.a
-      }`;
-    })
-  );
+  appsyncTestCase((context: AppsyncContext<{ a: string }>) => {
+    return `head ${
+      context.arguments.a === "hello" ? "world" : context.arguments.a
+    }`;
+  });
 });
 
 test("map over list", () => {
-  appsyncTestCase(
-    reflect((context: AppsyncContext<{ list: string[] }>) => {
-      return context.arguments.list.map((item) => {
-        return `hello ${item}`;
-      });
-    })
-  );
+  appsyncTestCase((context: AppsyncContext<{ list: string[] }>) => {
+    return context.arguments.list.map((item) => {
+      return `hello ${item}`;
+    });
+  });
 });
 
 test("map over list with in-line return", () => {
-  appsyncTestCase(
-    reflect((context: AppsyncContext<{ list: string[] }>) => {
-      return context.arguments.list.map((item) => `hello ${item}`);
-    })
-  );
+  appsyncTestCase((context: AppsyncContext<{ list: string[] }>) => {
+    return context.arguments.list.map((item) => `hello ${item}`);
+  });
 });
 
 test("chain map over list", () => {
-  appsyncTestCase(
-    reflect((context: AppsyncContext<{ list: string[] }>) => {
-      return context.arguments.list
-        .map((item) => `hello ${item}`)
-        .map((item) => `hello ${item}`);
-    })
-  );
+  appsyncTestCase((context: AppsyncContext<{ list: string[] }>) => {
+    return context.arguments.list
+      .map((item) => `hello ${item}`)
+      .map((item) => `hello ${item}`);
+  });
 });
 
 test("chain map over list multiple array", () => {
-  appsyncTestCase(
-    reflect((context: AppsyncContext<{ list: string[] }>) => {
-      return context.arguments.list
-        .map((item, _i, _arr) => `hello ${item}`)
-        .map((item, _i, _arr) => `hello ${item}`);
-    })
-  );
+  appsyncTestCase((context: AppsyncContext<{ list: string[] }>) => {
+    return context.arguments.list
+      .map((item, _i, _arr) => `hello ${item}`)
+      .map((item, _i, _arr) => `hello ${item}`);
+  });
 });
 
 test("chain map over list complex", () => {
-  appsyncTestCase(
-    reflect((context: AppsyncContext<{ list: string[] }>) => {
-      return context.arguments.list
-        .map((item, i, arr) => {
-          const x = i + 1;
-          return `hello ${item} ${x} ${arr.length}`;
-        })
-        .map((item2, ii) => `hello ${item2} ${ii}`);
-    })
-  );
+  appsyncTestCase((context: AppsyncContext<{ list: string[] }>) => {
+    return context.arguments.list
+      .map((item, i, arr) => {
+        const x = i + 1;
+        return `hello ${item} ${x} ${arr.length}`;
+      })
+      .map((item2, ii) => `hello ${item2} ${ii}`);
+  });
 });
 
 test("forEach over list", () => {
-  appsyncTestCase(
-    reflect((context: AppsyncContext<{ list: string[] }>) => {
-      return context.arguments.list.forEach((item) => {
-        $util.error(item);
-      });
-    })
-  );
+  appsyncTestCase((context: AppsyncContext<{ list: string[] }>) => {
+    return context.arguments.list.forEach((item) => {
+      $util.error(item);
+    });
+  });
 });
 
 test("reduce over list with initial value", () => {
-  appsyncTestCase(
-    reflect((context: AppsyncContext<{ list: string[] }>) => {
-      return context.arguments.list.reduce((newList: string[], item) => {
-        return [...newList, item];
-      }, []);
-    })
-  );
+  appsyncTestCase((context: AppsyncContext<{ list: string[] }>) => {
+    return context.arguments.list.reduce((newList: string[], item) => {
+      return [...newList, item];
+    }, []);
+  });
 });
 
 test("reduce over list without initial value", () => {
-  appsyncTestCase(
-    reflect((context: AppsyncContext<{ list: string[] }>) => {
-      return context.arguments.list.reduce((str: string, item) => {
-        return `${str}${item}`;
-      });
-    })
-  );
+  appsyncTestCase((context: AppsyncContext<{ list: string[] }>) => {
+    return context.arguments.list.reduce((str: string, item) => {
+      return `${str}${item}`;
+    });
+  });
 });
 
 test("map and reduce over list with initial value", () => {
-  appsyncTestCase(
-    reflect((context: AppsyncContext<{ list: string[] }>) => {
-      return context.arguments.list
-        .map((item) => `hello ${item}`)
-        .reduce((newList: string[], item) => {
-          return [...newList, item];
-        }, []);
-    })
-  );
+  appsyncTestCase((context: AppsyncContext<{ list: string[] }>) => {
+    return context.arguments.list
+      .map((item) => `hello ${item}`)
+      .reduce((newList: string[], item) => {
+        return [...newList, item];
+      }, []);
+  });
 });
 
 test("map and reduce with array over list with initial value", () => {
-  appsyncTestCase(
-    reflect((context: AppsyncContext<{ list: string[] }>) => {
-      return context.arguments.list
-        .map((item) => `hello ${item}`)
-        .reduce((newList: string[], item, _i, _arr) => {
-          return [...newList, item];
-        }, []);
-    })
-  );
+  appsyncTestCase((context: AppsyncContext<{ list: string[] }>) => {
+    return context.arguments.list
+      .map((item) => `hello ${item}`)
+      .reduce((newList: string[], item, _i, _arr) => {
+        return [...newList, item];
+      }, []);
+  });
 });
 
 test("map and reduce and map and reduce over list with initial value", () => {
-  appsyncTestCase(
-    reflect((context: AppsyncContext<{ list: string[] }>) => {
-      return context.arguments.list
-        .map((item) => `hello ${item}`)
-        .reduce((newList: string[], item) => {
-          return [...newList, item];
-        }, [])
-        .map((item) => `hello ${item}`)
-        .reduce((newList: string[], item) => {
-          return [...newList, item];
-        }, []);
-    })
-  );
+  appsyncTestCase((context: AppsyncContext<{ list: string[] }>) => {
+    return context.arguments.list
+      .map((item) => `hello ${item}`)
+      .reduce((newList: string[], item) => {
+        return [...newList, item];
+      }, [])
+      .map((item) => `hello ${item}`)
+      .reduce((newList: string[], item) => {
+        return [...newList, item];
+      }, []);
+  });
 });
 
 test("$util.time.nowISO8601", () => {
-  appsyncTestCase(
-    reflect(() => {
-      return $util.time.nowISO8601();
-    })
-  );
+  appsyncTestCase(() => {
+    return $util.time.nowISO8601();
+  });
 });
 
 test("$util.log.info(message)", () => {
-  appsyncTestCase(
-    reflect(() => {
-      return $util.log.info("hello world");
-    })
-  );
+  appsyncTestCase(() => {
+    return $util.log.info("hello world");
+  });
 });
 
 test("$util.log.info(message, ...Object)", () => {
-  appsyncTestCase(
-    reflect(() => {
-      return $util.log.info("hello world", { a: 1 }, { b: 2 });
-    })
-  );
+  appsyncTestCase(() => {
+    return $util.log.info("hello world", { a: 1 }, { b: 2 });
+  });
 });
 
 test("$util.log.error(message)", () => {
-  appsyncTestCase(
-    reflect(() => {
-      return $util.log.error("hello world");
-    })
-  );
+  appsyncTestCase(() => {
+    return $util.log.error("hello world");
+  });
 });
 
 test("$util.log.error(message, ...Object)", () => {
-  appsyncTestCase(
-    reflect(() => {
-      return $util.log.error("hello world", { a: 1 }, { b: 2 });
-    })
-  );
+  appsyncTestCase(() => {
+    return $util.log.error("hello world", { a: 1 }, { b: 2 });
+  });
 });
 
 test("BinaryExpr and UnaryExpr are evaluated to temporary variables", () => {
-  appsyncTestCase(
-    reflect(() => {
-      return {
-        x: -1,
-        y: -(1 + 1),
-        z: !(true && false),
-      };
-    })
-  );
+  appsyncTestCase(() => {
+    return {
+      x: -1,
+      y: -(1 + 1),
+      z: !(true && false),
+    };
+  });
 });
 
 test("binary expr in", () => {
   const templates = appsyncTestCase(
-    reflect<
-      ResolverFunction<{ key: string } | { key2: string }, { out: string }, any>
-    >(($context) => {
+    (
+      $context: AppsyncContext<
+        | {
+            key: string;
+          }
+        | {
+            key2: string;
+          },
+        any
+      >
+    ) => {
       if ("key" in $context.arguments) {
         return { out: $context.arguments.key };
       }
       return { out: $context.arguments.key2 };
-    })
+    }
   );
 
   testAppsyncVelocity(templates[1], {
@@ -466,18 +392,23 @@ test("binary expr in", () => {
 
 test("binary expr ==", () => {
   const templates = appsyncTestCase(
-    reflect<ResolverFunction<{ key: string }, { out: boolean[] }, any>>(
-      ($context) => {
-        return {
-          out: [
-            $context.arguments.key == "key",
-            "key" == $context.arguments.key,
-            $context.arguments.key === "key",
-            "key" === $context.arguments.key,
-          ],
-        };
-      }
-    )
+    (
+      $context: AppsyncContext<
+        {
+          key: string;
+        },
+        any
+      >
+    ) => {
+      return {
+        out: [
+          $context.arguments.key == "key",
+          "key" == $context.arguments.key,
+          $context.arguments.key === "key",
+          "key" === $context.arguments.key,
+        ],
+      };
+    }
   );
 
   testAppsyncVelocity(templates[1], {
@@ -487,22 +418,20 @@ test("binary expr ==", () => {
 });
 
 test("binary expr in map", () => {
-  const templates = appsyncTestCase(
-    reflect<ResolverFunction<{}, { in: boolean; notIn: boolean }, any>>(() => {
-      const obj = {
-        key: "value",
-        // $null does not appear to work in amplify simulator
-        // keyNull: null,
-        keyEmpty: "",
-      };
-      return {
-        in: "key" in obj,
-        notIn: "otherKey" in obj,
-        // inNull: "keyNull" in obj,
-        inEmpty: "keyEmpty" in obj,
-      };
-    })
-  );
+  const templates = appsyncTestCase(() => {
+    const obj = {
+      key: "value",
+      // $null does not appear to work in amplify simulator
+      // keyNull: null,
+      keyEmpty: "",
+    };
+    return {
+      in: "key" in obj,
+      notIn: "otherKey" in obj,
+      // inNull: "keyNull" in obj,
+      inEmpty: "keyEmpty" in obj,
+    };
+  });
 
   testAppsyncVelocity(templates[1], {
     resultMatch: {
@@ -518,14 +447,19 @@ test("binary expr in map", () => {
 // https://github.com/aws-amplify/amplify-cli/issues/10575
 test.skip("binary expr in array", () => {
   const templates = appsyncTestCase(
-    reflect<ResolverFunction<{ arr: string[] }, { out: string }, any>>(
-      ($context) => {
-        if (1 in $context.arguments.arr) {
-          return { out: $context.arguments.arr[1] };
-        }
-        return { out: $context.arguments.arr[0] };
+    (
+      $context: AppsyncContext<
+        {
+          arr: string[];
+        },
+        any
+      >
+    ) => {
+      if (1 in $context.arguments.arr) {
+        return { out: $context.arguments.arr[1] };
       }
-    )
+      return { out: $context.arguments.arr[0] };
+    }
   );
 
   testAppsyncVelocity(templates[1], {
@@ -546,13 +480,15 @@ test.skip("binary expr in array", () => {
 
 test("binary exprs value comparison", () => {
   const templates = appsyncTestCase(
-    reflect<
-      ResolverFunction<
-        { a: number; b: number },
-        Record<ValueComparisonBinaryOp, boolean>,
+    (
+      $context: AppsyncContext<
+        {
+          a: number;
+          b: number;
+        },
         any
       >
-    >(($context) => {
+    ) => {
       const a = $context.arguments.a;
       const b = $context.arguments.b;
       return {
@@ -565,7 +501,7 @@ test("binary exprs value comparison", () => {
         ">": a > b,
         ">=": a >= b,
       };
-    })
+    }
   );
 
   testAppsyncVelocity(templates[1], {
@@ -606,16 +542,14 @@ test("binary exprs value comparison", () => {
 });
 
 test("null coalescing", () => {
-  const templates = appsyncTestCase(
-    reflect(() => {
-      return {
-        "??": null ?? "a",
-        "not ??": "a" ?? "b",
-        neither: null ?? null,
-        undefined: undefined ?? "a",
-      };
-    })
-  );
+  const templates = appsyncTestCase(() => {
+    return {
+      "??": null ?? "a",
+      "not ??": "a" ?? "b",
+      neither: null ?? null,
+      undefined: undefined ?? "a",
+    };
+  });
 
   testAppsyncVelocity(templates[1], {
     resultMatch: {
@@ -630,13 +564,15 @@ test("null coalescing", () => {
 
 test("binary exprs logical", () => {
   const templates = appsyncTestCase(
-    reflect<
-      ResolverFunction<
-        { a: boolean; b: boolean },
-        Record<ComparatorOp, boolean>,
+    (
+      $context: AppsyncContext<
+        {
+          a: boolean;
+          b: boolean;
+        },
         any
       >
-    >(($context) => {
+    ) => {
       const a = $context.arguments.a;
       const b = $context.arguments.b;
       return {
@@ -644,7 +580,7 @@ test("binary exprs logical", () => {
         "||": a || b,
         "??": a ?? b,
       };
-    })
+    }
   );
 
   testAppsyncVelocity(templates[1], {
@@ -677,13 +613,15 @@ test("binary exprs logical", () => {
 
 test("binary exprs math", () => {
   const templates = appsyncTestCase(
-    reflect<
-      ResolverFunction<
-        { a: number; b: number },
-        Record<MathBinaryOp, number>,
+    (
+      $context: AppsyncContext<
+        {
+          a: number;
+          b: number;
+        },
         any
       >
-    >(($context) => {
+    ) => {
       const a = $context.arguments.a;
       const b = $context.arguments.b;
       return {
@@ -693,7 +631,7 @@ test("binary exprs math", () => {
         "/": a / b,
         "%": a % b,
       };
-    })
+    }
   );
 
   testAppsyncVelocity(templates[1], {
@@ -710,17 +648,22 @@ test("binary exprs math", () => {
 
 test("binary expr =", () => {
   const templates = appsyncTestCase(
-    reflect<ResolverFunction<{ key: string }, { out: string }, any>>(
-      ($context) => {
-        if ($context.arguments.key == "help me") {
-          $context.arguments.key = "hello";
-        }
-        if ($context.arguments.key == "hello") {
-          return { out: "ohh hi" };
-        }
-        return { out: "wot" };
+    (
+      $context: AppsyncContext<
+        {
+          key: string;
+        },
+        any
+      >
+    ) => {
+      if ($context.arguments.key == "help me") {
+        $context.arguments.key = "hello";
       }
-    )
+      if ($context.arguments.key == "hello") {
+        return { out: "ohh hi" };
+      }
+      return { out: "wot" };
+    }
   );
 
   testAppsyncVelocity(templates[1], {
@@ -741,24 +684,22 @@ test("binary expr =", () => {
 
 // https://github.com/functionless/functionless/issues/232
 test("binary mutation", () => {
-  const templates = appsyncTestCase(
-    reflect(() => {
-      var n = 9;
-      const plus_n = (n += 1);
-      const minus_n = (n -= 1);
-      const multi_n = (n *= 2);
-      const div_n = (n /= 3);
-      const mod_n = (n %= 2);
-      return {
-        "+=": plus_n,
-        "-=": minus_n,
-        "*=": multi_n,
-        "/=": div_n,
-        "%=": mod_n,
-        n,
-      };
-    })
-  );
+  const templates = appsyncTestCase(() => {
+    var n = 9;
+    const plus_n = (n += 1);
+    const minus_n = (n -= 1);
+    const multi_n = (n *= 2);
+    const div_n = (n /= 3);
+    const mod_n = (n %= 2);
+    return {
+      "+=": plus_n,
+      "-=": minus_n,
+      "*=": multi_n,
+      "/=": div_n,
+      "%=": mod_n,
+      n,
+    };
+  });
 
   testAppsyncVelocity(templates[1], {
     resultMatch: {
@@ -774,17 +715,15 @@ test("binary mutation", () => {
 
 // https://github.com/functionless/functionless/issues/232
 test("unary mutation", () => {
-  const templates = appsyncTestCase(
-    reflect(() => {
-      var n = 9;
-      return {
-        "post--": n--,
-        "--pre": --n,
-        "post++": n++,
-        "++pre": ++n,
-      };
-    })
-  );
+  const templates = appsyncTestCase(() => {
+    var n = 9;
+    return {
+      "post--": n--,
+      "--pre": --n,
+      "post++": n++,
+      "++pre": ++n,
+    };
+  });
 
   testAppsyncVelocity(templates[1], {
     resultMatch: {
@@ -798,15 +737,13 @@ test("unary mutation", () => {
 
 // https://github.com/functionless/functionless/issues/232
 test("unary", () => {
-  const templates = appsyncTestCase(
-    reflect(() => {
-      return {
-        "!": !false,
-        "-": -10,
-        "-(-)": -(-10),
-      };
-    })
-  );
+  const templates = appsyncTestCase(() => {
+    return {
+      "!": !false,
+      "-": -10,
+      "-(-)": -(-10),
+    };
+  });
 
   testAppsyncVelocity(templates[1], {
     resultMatch: {
@@ -819,12 +756,10 @@ test("unary", () => {
 
 // https://github.com/functionless/functionless/issues/150
 test("assignment in object", () => {
-  const templates = appsyncTestCase(
-    reflect(() => {
-      let y = 1;
-      return { x: (y = 2), y };
-    })
-  );
+  const templates = appsyncTestCase(() => {
+    let y = 1;
+    return { x: (y = 2), y };
+  });
 
   testAppsyncVelocity(templates[1], {
     resultMatch: {
@@ -835,20 +770,18 @@ test("assignment in object", () => {
 });
 
 test("var args push", () => {
-  const templates = appsyncTestCase(
-    reflect(() => {
-      const y1 = [];
-      const y2 = [];
-      const y3 = [];
-      const y4 = [];
-      const x = [1, 2, 3];
-      y1.push(...x);
-      y2.push(...x, 4);
-      y3.push(0, ...x);
-      y4.push(0, ...x, 4);
-      return { y1, y2, y3, y4 };
-    })
-  );
+  const templates = appsyncTestCase(() => {
+    const y1 = [];
+    const y2 = [];
+    const y3 = [];
+    const y4 = [];
+    const x = [1, 2, 3];
+    y1.push(...x);
+    y2.push(...x, 4);
+    y3.push(0, ...x);
+    y4.push(0, ...x, 4);
+    return { y1, y2, y3, y4 };
+  });
 
   testAppsyncVelocity(templates[1], {
     resultMatch: {
@@ -871,18 +804,16 @@ test("deconstruct variable", () => {
       d: string;
     },
     string
-  >(
-    reflect(($context) => {
-      const {
-        a,
-        bb: { ["value"]: b, ["a" + "b"]: z },
-        c = "what",
-        arr: [d, , e, f = "sir", ...arrRest],
-        ...objRest
-      } = $context.arguments;
-      return a + b + c + d + e + f + objRest.d + arrRest[0] + z;
-    })
-  );
+  >(($context) => {
+    const {
+      a,
+      bb: { ["value"]: b, ["a" + "b"]: z },
+      c = "what",
+      arr: [d, , e, f = "sir", ...arrRest],
+      ...objRest
+    } = $context.arguments;
+    return a + b + c + d + e + f + objRest.d + arrRest[0] + z;
+  });
 
   testAppsyncVelocity(templates[1], {
     arguments: {
@@ -900,19 +831,17 @@ test("deconstruct parameter", () => {
     { a: string; bb: { value: string }; c?: string; arr: string[]; d: string },
     string
   >(
-    reflect(
-      ({
-        arguments: {
-          a,
-          bb: { value: b },
-          c = "what",
-          arr: [d, , e, f = "sir", ...arrRest],
-          ...objRest
-        },
-      }) => {
-        return a + b + c + d + e + f + objRest.d + arrRest[0];
-      }
-    )
+    ({
+      arguments: {
+        a,
+        bb: { value: b },
+        c = "what",
+        arr: [d, , e, f = "sir", ...arrRest],
+        ...objRest
+      },
+    }) => {
+      return a + b + c + d + e + f + objRest.d + arrRest[0];
+    }
   );
 
   testAppsyncVelocity(templates[1], {
@@ -938,20 +867,18 @@ test("deconstruct for of", () => {
       }[];
     },
     string
-  >(
-    reflect(($context) => {
-      for (const {
-        a,
-        bb: { value: b },
-        c = "what",
-        arr: [d, , e, f = "sir", ...arrRest],
-        ...objRest
-      } of $context.arguments.items) {
-        return a + b + c + d + e + f + objRest.d + arrRest[0];
-      }
-      return "";
-    })
-  );
+  >(($context) => {
+    for (const {
+      a,
+      bb: { value: b },
+      c = "what",
+      arr: [d, , e, f = "sir", ...arrRest],
+      ...objRest
+    } of $context.arguments.items) {
+      return a + b + c + d + e + f + objRest.d + arrRest[0];
+    }
+    return "";
+  });
 
   testAppsyncVelocity(templates[1], {
     arguments: {


### PR DESCRIPTION
This is the first step in supporting higher-order functions. Instead of only converting a function within specific contexts, such as `new Function` or `new StepFunction`, now all function declarations, function expressions and arrow expressions are wrapped in a call to `functionless.associateAST(func, new FunctionExpr([..], ..))` which associates a reference to a Function to its `FunctionExpr` or `FunctionDecl` AST form. Behind the scenes, a global `WeakMap` stores the association.

Fixes https://github.com/functionless/functionless/issues/309 - by consequence, we now support passing references to closures.