### PR TITLE
fix(compile): update external module indicator

### DIFF
--- a/src/compile.ts
+++ b/src/compile.ts
@@ -61,7 +61,7 @@ export function compile(
       }
 
       const functionlessContext = {
-        requireFunctionless: true,
+        requireFunctionless: false,
         get functionless() {
           this.requireFunctionless = true;
           return functionless;

--- a/src/compile.ts
+++ b/src/compile.ts
@@ -61,7 +61,7 @@ export function compile(
       }
 
       const functionlessContext = {
-        requireFunctionless: false,
+        requireFunctionless: true,
         get functionless() {
           this.requireFunctionless = true;
           return functionless;
@@ -83,7 +83,7 @@ export function compile(
         (stmt) => visitor(stmt) as ts.Statement
       );
 
-      return ts.factory.updateSourceFile(
+      const updatedSourceFile = ts.factory.updateSourceFile(
         sf,
         [
           // only require functionless if it is used.
@@ -98,6 +98,24 @@ export function compile(
         sf.hasNoDefaultLib,
         sf.libReferenceDirectives
       );
+
+      /**
+       * Hack that forces the source file to update the external module indicator.
+       * This is important when we add new imports to files without imports.
+       *
+       * This is generally only set on the initial parse:
+       * https://github.com/microsoft/TypeScript/blob/main/src/compiler/parser.ts#L769-L775
+       */
+
+      functionlessContext.requireFunctionless &&
+        // @ts-ignore
+        !updatedSourceFile.externalModuleIndicator &&
+        // @ts-ignore
+        updatedSourceFile.setExternalModuleIndicator &&
+        // @ts-ignore
+        updatedSourceFile.setExternalModuleIndicator(updatedSourceFile);
+
+      return updatedSourceFile;
 
       function visitor(node: ts.Node): ts.Node | ts.Node[] {
         const visit = () => {


### PR DESCRIPTION
Closes #341

Typescript [determines whether or not to mutate the module part of a file](https://cs.github.com/microsoft/TypeScript/blob/28dc248e5c500c7be9a8c3a7341d303e026b023f/src/compiler/transformers/module/module.ts#L58-L64) based on a few factors, including [if the module is an external module](https://cs.github.com/microsoft/TypeScript/blob/28dc248e5c500c7be9a8c3a7341d303e026b023f/src/compiler/utilities.ts#L815-L817).

This computation is only done on [file parse](https://github.com/microsoft/TypeScript/blob/main/src/compiler/parser.ts#L769-L775), but sometimes functionless may change a non-external module into an external module when adding the functionless import at the top of the file (see #341). 

Added a hack to re-compute the module-ness of the file after we make our changes.

```ts
      functionlessContext.requireFunctionless &&
        // @ts-ignore
        !updatedSourceFile.externalModuleIndicator &&
        // @ts-ignore
        updatedSourceFile.setExternalModuleIndicator &&
        // @ts-ignore
        updatedSourceFile.setExternalModuleIndicator(updatedSourceFile);
```