### PR TITLE
chore: turn off coverage for faster tests

### DIFF
--- a/.projenrc.js
+++ b/.projenrc.js
@@ -153,6 +153,7 @@ const project = new CustomTypescriptProject({
   releaseToNpm: true,
   jestOptions: {
     jestConfig: {
+      collectCoverage: false,
       coveragePathIgnorePatterns: ["/test/", "/node_modules/", "/lib"],
       moduleNameMapper: {
         "^@fnls$": "<rootDir>/lib/index",

--- a/package.json
+++ b/package.json
@@ -91,6 +91,7 @@
   "license": "Apache-2.0",
   "version": "0.0.0",
   "jest": {
+    "collectCoverage": false,
     "coveragePathIgnorePatterns": [
       "/test/",
       "/node_modules/",
@@ -104,7 +105,6 @@
       "<rootDir>/(test|src)/**/*(*.)@(spec|test).ts?(x)"
     ],
     "clearMocks": true,
-    "collectCoverage": true,
     "coverageReporters": [
       "json",
       "lcov",


### PR DESCRIPTION
Seeing 14m test runs, down from 18-30m