### PR TITLE
fix: apig vtl stringify

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -654,6 +654,37 @@ export class APIGatewayVTL extends VTL {
   }
 
   /**
+   * Attempt to return the expression as a valid escaped json string.
+   *
+   * ```ts
+   * {
+   *    x: input
+   * }
+   * ```
+   *
+   * =>
+   *
+   * ```ts
+   * { "x": $input.json('$') }
+   * ```
+   *
+   * =>
+   *
+   * ```ts
+   * "{ \"x\": $util.escapeJavaScript($input.json('$')) }"
+   * ```
+   */
+  public stringify(expr: Expr): string {
+    const json = this.exprToJson(expr);
+    return `"${json
+      .replace(/"/g, '\\"')
+      .replace(
+        /\$input\.json\('([^']*)'\)/g,
+        "$util.escapeJavaScript($input.json('$1'))"
+      )}"`;
+  }
+
+  /**
    * Renders a VTL string that will emit a JSON String representation of the {@link expr} to the VTL output.
    *
    * @param expr the {@link Expr} to convert to JSON

--- a/src/step-function.ts
+++ b/src/step-function.ts
@@ -571,9 +571,7 @@ abstract class BaseStepFunction<
         .map(([argName, argVal]) => {
           if (argName === "input") {
             // stringify the JSON input
-            return `"${argName}":"$util.escapeJavaScript(${context.exprToJson(
-              argVal
-            )})"`;
+            return `"${argName}":${context.stringify(argVal)}`;
           } else {
             return `"${argName}":${context.exprToJson(argVal)}`;
           }

--- a/test/__snapshots__/api.test.ts.snap
+++ b/test/__snapshots__/api.test.ts.snap
@@ -46,7 +46,7 @@ $input.json('$.error')
   "requestTemplates": Object {
     "application/json": "{
 \\"stateMachineArn\\":\\"__REPLACED_TOKEN\\",
-\\"input\\":\\"$util.escapeJavaScript({\\"num\\":$input.params('num'),\\"str\\":\\"$input.params('str')\\"})\\"
+\\"input\\":\\"{\\\\\\"num\\\\\\":$input.params('num'),\\\\\\"str\\\\\\":\\\\\\"$input.params('str')\\\\\\"}\\"
 }",
   },
 }
@@ -81,7 +81,26 @@ Object {
   "requestTemplates": Object {
     "application/json": "{
 \\"stateMachineArn\\":\\"__REPLACED_TOKEN\\",
-\\"input\\":\\"$util.escapeJavaScript({\\"num\\":$input.params('num'),\\"str\\":\\"$input.params('str')\\"})\\"
+\\"input\\":\\"{\\\\\\"num\\\\\\":$input.params('num'),\\\\\\"str\\\\\\":\\\\\\"$input.params('str')\\\\\\"}\\"
+}",
+  },
+}
+`;
+
+exports[`AWS integration with Standard Step Function using input data 1`] = `
+Object {
+  "integrationResponses": Array [
+    Object {
+      "responseTemplates": Object {
+        "application/json": "$input.json('$.executionArn')",
+      },
+      "statusCode": "200",
+    },
+  ],
+  "requestTemplates": Object {
+    "application/json": "{
+\\"stateMachineArn\\":\\"__REPLACED_TOKEN\\",
+\\"input\\":\\"{\\\\\\"num\\\\\\":$input.params('num'),\\\\\\"obj\\\\\\":$util.escapeJavaScript($input.json('$'))}\\"
 }",
   },
 }

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -167,6 +167,52 @@ test("AWS integration with Standard Step Function", () => {
   expect(getTemplates(method)).toMatchSnapshot();
 });
 
+test("AWS integration with Standard Step Function using input data", () => {
+  const api = new aws_apigateway.RestApi(stack, "API");
+
+  const sfn = new StepFunction(
+    stack,
+    "SFN",
+    (_input: {
+      num: number;
+      obj: {
+        value: string;
+      };
+    }) => {
+      return "done";
+    }
+  );
+
+  const method = new AwsMethod(
+    {
+      httpMethod: "GET",
+      resource: api.root,
+    },
+    (
+      $input: ApiGatewayInput<{
+        query: {
+          num: string;
+          str: string;
+        };
+        body: {
+          value: string;
+        };
+      }>
+    ) =>
+      sfn({
+        input: {
+          num: Number($input.params("num")),
+          obj: $input.data,
+        },
+      }),
+    ($input) => {
+      return $input.data.executionArn;
+    }
+  );
+
+  expect(getTemplates(method)).toMatchSnapshot();
+});
+
 test("AWS integration with DynamoDB Table", () => {
   const api = new aws_apigateway.RestApi(stack, "API");
   const table = Table.fromTable(


### PR DESCRIPTION
Do things that don't scale?

```ts
new AwsMethod(
  {
    httpMethod: "POST",
    resource: saga,
  },
  (
    $input: ApiGatewayInput<
      ApiRequest<
        {},
        Reservation & { [index: string]: ApiBody },
        { run_type?: RunType }
      >
    >
  ) => {
    return sagaFunction.func({
      input: {
        reservation: $input.data!,
        run_type: $input.params("run_type")!,
      },
    });
  },
  (result) => {
    return result.data;
  }
);
```

```velocity
{
"stateMachineArn":"arn:aws:states:us-east-1:180727192481:stateMachine:sagasagaFunction54D97EEF-B6WfpKLDY3QV",
"input":"{\"reservation\":$util.escapeJavaScript($input.json('$')),\"run_type\":\"$input.params('run_type')\"}"
}
```