### PR TITLE
feat: add GetAccessorDecl, SetAccessorDecl, TaggedTemplateExpr, OmittedExpr

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -803,7 +803,7 @@ export class APIGatewayVTL extends VTL {
             }
           } else if (isSpreadAssignExpr(prop)) {
             const key = context.newLocalVarName();
-            const map = this.eval(prop?.expr);
+            const map = this.eval(prop.expr);
             return `#foreach(${key} in ${map}.keySet())"${key}":${this.json(
               `${map}.get(${key})`
             )}#if($foreach.hasNext),#end#end`;

--- a/src/api.ts
+++ b/src/api.ts
@@ -37,6 +37,7 @@ import {
   isThisExpr,
   isVariableDecl,
   isParenthesizedExpr,
+  isSpreadAssignExpr,
 } from "./guards";
 import { Integration, IntegrationImpl, isIntegration } from "./integration";
 import { Stmt } from "./statement";
@@ -800,9 +801,9 @@ export class APIGatewayVTL extends VTL {
                 isIdentifier(prop.name) ? prop.name.name : prop.name.value
               }":${this.exprToJson(prop.expr)}`;
             }
-          } else {
+          } else if (isSpreadAssignExpr(prop)) {
             const key = context.newLocalVarName();
-            const map = this.eval(prop.expr);
+            const map = this.eval(prop?.expr);
             return `#foreach(${key} in ${map}.keySet())"${key}":${this.json(
               `${map}.get(${key})`
             )}#if($foreach.hasNext),#end#end`;

--- a/src/appsync.ts
+++ b/src/appsync.ts
@@ -495,8 +495,13 @@ function synthesizeFunctions(api: appsync.GraphqlApi, decl: FunctionDecl) {
           );
 
           const rightClassName = new PropAccessExpr(
-            new PropAccessExpr(updatedNode.right, new Identifier("class")),
-            new Identifier("name")
+            new PropAccessExpr(
+              updatedNode.right,
+              new Identifier("class"),
+              false
+            ),
+            new Identifier("name"),
+            false
           );
 
           return new ConditionExpr(
@@ -504,25 +509,35 @@ function synthesizeFunctions(api: appsync.GraphqlApi, decl: FunctionDecl) {
               new CallExpr(
                 new PropAccessExpr(
                   rightClassName,
-                  new Identifier("startsWith")
+                  new Identifier("startsWith"),
+                  false
                 ),
                 [new Argument(new StringLiteralExpr("[L"))]
               ),
               "||",
               new CallExpr(
-                new PropAccessExpr(rightClassName, new Identifier("contains")),
+                new PropAccessExpr(
+                  rightClassName,
+                  new Identifier("contains"),
+                  false
+                ),
                 [new Argument(new StringLiteralExpr("ArrayList"))]
               )
             ),
             new BinaryExpr(
-              new PropAccessExpr(updatedNode.right, new Identifier("length")),
+              new PropAccessExpr(
+                updatedNode.right,
+                new Identifier("length"),
+                false
+              ),
               ">=",
               updatedNode.left
             ),
             new CallExpr(
               new PropAccessExpr(
                 updatedNode.right,
-                new Identifier("containsKey")
+                new Identifier("containsKey"),
+                false
               ),
               [new Argument(updatedNode.left)]
             )

--- a/src/appsync.ts
+++ b/src/appsync.ts
@@ -495,28 +495,37 @@ function synthesizeFunctions(api: appsync.GraphqlApi, decl: FunctionDecl) {
           );
 
           const rightClassName = new PropAccessExpr(
-            new PropAccessExpr(updatedNode.right, "class"),
-            "name"
+            new PropAccessExpr(updatedNode.right, new Identifier("class")),
+            new Identifier("name")
           );
 
           return new ConditionExpr(
             new BinaryExpr(
-              new CallExpr(new PropAccessExpr(rightClassName, "startsWith"), [
-                new Argument(new StringLiteralExpr("[L")),
-              ]),
+              new CallExpr(
+                new PropAccessExpr(
+                  rightClassName,
+                  new Identifier("startsWith")
+                ),
+                [new Argument(new StringLiteralExpr("[L"))]
+              ),
               "||",
-              new CallExpr(new PropAccessExpr(rightClassName, "contains"), [
-                new Argument(new StringLiteralExpr("ArrayList")),
-              ])
+              new CallExpr(
+                new PropAccessExpr(rightClassName, new Identifier("contains")),
+                [new Argument(new StringLiteralExpr("ArrayList"))]
+              )
             ),
             new BinaryExpr(
-              new PropAccessExpr(updatedNode.right, "length"),
+              new PropAccessExpr(updatedNode.right, new Identifier("length")),
               ">=",
               updatedNode.left
             ),
-            new CallExpr(new PropAccessExpr(updatedNode.right, "containsKey"), [
-              new Argument(updatedNode.left),
-            ])
+            new CallExpr(
+              new PropAccessExpr(
+                updatedNode.right,
+                new Identifier("containsKey")
+              ),
+              [new Argument(updatedNode.left)]
+            )
           );
         }
       }

--- a/src/aws.ts
+++ b/src/aws.ts
@@ -26,10 +26,14 @@ import { Function, isFunction, NativeIntegration } from "./function";
 import { NativePreWarmContext, PrewarmClients } from "./function-prewarm";
 import {
   isArgument,
+  isGetAccessorDecl,
   isIdentifier,
+  isMethodDecl,
   isObjectLiteralExpr,
   isPropAssignExpr,
   isReferenceExpr,
+  isSetAccessorDecl,
+  isSpreadAssignExpr,
   isStringLiteralExpr,
 } from "./guards";
 import {
@@ -427,26 +431,47 @@ export namespace $AWS {
             "The first argument ('input') into $AWS.Lambda.Invoke must be an object."
           );
         }
-        const functionName = input.getProperty("Function")?.expr;
+        const functionName = input.getProperty("Function");
         if (functionName === undefined) {
           throw new Error("missing required property 'Function'");
-        } else if (functionName.kind !== "ReferenceExpr") {
+        } else if (!isPropAssignExpr(functionName)) {
+          throw new SynthError(
+            ErrorCodes.StepFunctions_property_names_must_be_constant,
+            `the Function property must reference a Function construct`
+          );
+        }
+
+        if (functionName.expr.kind !== "ReferenceExpr") {
           throw new Error(
             "property 'Function' must reference a functionless.Function"
           );
         }
-        const functionRef = functionName.ref();
+        const functionRef = functionName.expr.ref();
         if (!isFunction(functionRef)) {
           throw new Error(
             "property 'Function' must reference a functionless.Function"
           );
         }
-        const payload = input.getProperty("Payload")?.expr;
+        const payload = input.getProperty("Payload");
         if (payload === undefined) {
           throw new Error("missing property 'payload'");
+        } else if (
+          isGetAccessorDecl(payload) ||
+          isSetAccessorDecl(payload) ||
+          isMethodDecl(payload)
+        ) {
+          throw new SynthError(
+            ErrorCodes.Unsupported_Feature,
+            `${payload.kind} is not supported by Step Functions`
+          );
+        } else if (isSpreadAssignExpr(payload)) {
+          throw new SynthError(
+            ErrorCodes.Expected_an_object_literal,
+            `Payload property must be an object literal with no getters, setters or methods`
+          );
         }
 
-        return context.evalExpr(payload, (output) => {
+        return context.evalExpr(payload.expr, (output) => {
           return context.stateWithHeapOutput({
             Type: "Task",
             Resource: "arn:aws:states:::lambda:invoke",

--- a/src/aws.ts
+++ b/src/aws.ts
@@ -26,14 +26,10 @@ import { Function, isFunction, NativeIntegration } from "./function";
 import { NativePreWarmContext, PrewarmClients } from "./function-prewarm";
 import {
   isArgument,
-  isGetAccessorDecl,
   isIdentifier,
-  isMethodDecl,
   isObjectLiteralExpr,
   isPropAssignExpr,
   isReferenceExpr,
-  isSetAccessorDecl,
-  isSpreadAssignExpr,
   isStringLiteralExpr,
 } from "./guards";
 import {
@@ -432,6 +428,7 @@ export namespace $AWS {
           );
         }
         const functionName = input.getProperty("Function");
+
         if (functionName === undefined) {
           throw new Error("missing required property 'Function'");
         } else if (!isPropAssignExpr(functionName)) {
@@ -439,9 +436,7 @@ export namespace $AWS {
             ErrorCodes.StepFunctions_property_names_must_be_constant,
             `the Function property must reference a Function construct`
           );
-        }
-
-        if (functionName.expr.kind !== "ReferenceExpr") {
+        } else if (!isReferenceExpr(functionName.expr)) {
           throw new Error(
             "property 'Function' must reference a functionless.Function"
           );
@@ -455,19 +450,10 @@ export namespace $AWS {
         const payload = input.getProperty("Payload");
         if (payload === undefined) {
           throw new Error("missing property 'payload'");
-        } else if (
-          isGetAccessorDecl(payload) ||
-          isSetAccessorDecl(payload) ||
-          isMethodDecl(payload)
-        ) {
+        } else if (!isPropAssignExpr(payload)) {
           throw new SynthError(
             ErrorCodes.Unsupported_Feature,
             `${payload.kind} is not supported by Step Functions`
-          );
-        } else if (isSpreadAssignExpr(payload)) {
-          throw new SynthError(
-            ErrorCodes.Expected_an_object_literal,
-            `Payload property must be an object literal with no getters, setters or methods`
           );
         }
 

--- a/src/compile.ts
+++ b/src/compile.ts
@@ -585,11 +585,7 @@ export function compile(
         } else if (ts.isArrayBindingPattern(node)) {
           return newExpr("ArrayBinding", [
             ts.factory.createArrayLiteralExpression(
-              node.elements.map((e) =>
-                ts.isOmittedExpression(e)
-                  ? ts.factory.createIdentifier("undefined")
-                  : toExpr(e, scope)
-              )
+              node.elements.map((e) => toExpr(e, scope))
             ),
           ]);
         } else if (ts.isBindingElement(node)) {
@@ -898,6 +894,8 @@ export function compile(
               ? ts.factory.createTrue()
               : ts.factory.createFalse(),
           ]);
+        } else if (ts.isOmittedExpression(node)) {
+          return newExpr("OmittedExpr", []);
         }
 
         throw new Error(

--- a/src/compile.ts
+++ b/src/compile.ts
@@ -462,6 +462,11 @@ export function compile(
                   newExpr("Argument", [toExpr(arg, scope)])
                 ) ?? []
               ),
+              ts.isPropertyAccessExpression(node.parent) &&
+              ts.isCallExpression(node) &&
+              node.questionDotToken
+                ? ts.factory.createTrue()
+                : ts.factory.createFalse(),
             ]
           );
 
@@ -529,13 +534,12 @@ export function compile(
               );
             }
           }
-          const type = checker.getTypeAtLocation(node.name);
           return newExpr("PropAccessExpr", [
             toExpr(node.expression, scope),
             toExpr(node.name, scope),
-            type
-              ? ts.factory.createStringLiteral(checker.typeToString(type))
-              : ts.factory.createIdentifier("undefined"),
+            node.questionDotToken
+              ? ts.factory.createTrue()
+              : ts.factory.createFalse(),
           ]);
         } else if (ts.isElementAccessExpression(node)) {
           const type = checker.getTypeAtLocation(node.argumentExpression);

--- a/src/compile.ts
+++ b/src/compile.ts
@@ -532,7 +532,7 @@ export function compile(
           const type = checker.getTypeAtLocation(node.name);
           return newExpr("PropAccessExpr", [
             toExpr(node.expression, scope),
-            ts.factory.createStringLiteral(node.name.text),
+            toExpr(node.name, scope),
             type
               ? ts.factory.createStringLiteral(checker.typeToString(type))
               : ts.factory.createIdentifier("undefined"),

--- a/src/declaration.ts
+++ b/src/declaration.ts
@@ -133,7 +133,7 @@ export class GetAccessorDecl extends BaseDecl<
     super("GetAccessorDecl", arguments);
   }
   public clone(): this {
-    throw new Error("Method not implemented.");
+    return new GetAccessorDecl(this.name.clone(), this.body.clone()) as this;
   }
 }
 export class SetAccessorDecl extends BaseDecl<
@@ -148,7 +148,11 @@ export class SetAccessorDecl extends BaseDecl<
     super("SetAccessorDecl", arguments);
   }
   public clone(): this {
-    throw new Error("Method not implemented.");
+    return new SetAccessorDecl(
+      this.name.clone(),
+      this.parameter.clone(),
+      this.body.clone()
+    ) as this;
   }
 }
 

--- a/src/declaration.ts
+++ b/src/declaration.ts
@@ -7,6 +7,7 @@ import {
   FunctionExpr,
   Identifier,
   ObjectLiteralExpr,
+  OmittedExpr,
   PropName,
   StringLiteralExpr,
 } from "./expression";
@@ -336,7 +337,7 @@ export class ObjectBinding extends BaseNode<"ObjectBinding", VariableDecl> {
 export class ArrayBinding extends BaseNode<"ArrayBinding", VariableDecl> {
   readonly nodeKind: "Node" = "Node";
 
-  constructor(readonly bindings: (BindingElem | undefined)[]) {
+  constructor(readonly bindings: (BindingElem | OmittedExpr)[]) {
     super("ArrayBinding", arguments);
   }
 

--- a/src/event-bridge/utils.ts
+++ b/src/event-bridge/utils.ts
@@ -21,12 +21,15 @@ import {
   isBindingPattern,
   isComputedPropertyNameExpr,
   isElementAccessExpr,
+  isGetAccessorDecl,
   isIdentifier,
+  isMethodDecl,
   isObjectLiteralExpr,
   isParenthesizedExpr,
   isPropAccessExpr,
   isPropAssignExpr,
   isReturnStmt,
+  isSetAccessorDecl,
   isSpreadElementExpr,
   isStringLiteralExpr,
   isTemplateExpr,
@@ -180,7 +183,7 @@ export const flattenExpression = (expr: Expr, scope: EventScope): Expr => {
       throw new Error("Array access must be a number.");
     }
     return typeof key === "string"
-      ? new PropAccessExpr(parent, key)
+      ? new PropAccessExpr(parent, new Identifier(key))
       : new ElementAccessExpr(parent, new NumberLiteralExpr(key));
   } else if (isComputedPropertyNameExpr(expr)) {
     return flattenExpression(expr.expr, scope);
@@ -222,6 +225,12 @@ export const flattenExpression = (expr: Expr, scope: EventScope): Expr => {
             ),
           ];
         } else {
+          if (isSetAccessorDecl(e) || isGetAccessorDecl(e) || isMethodDecl(e)) {
+            throw new SynthError(
+              ErrorCodes.Unsupported_Feature,
+              `${e.kind} is not supported by Event Bridge`
+            );
+          }
           const flattened = flattenExpression(e.expr, scope);
           if (isObjectLiteralExpr(flattened)) {
             const spreadProps = flattened.properties.filter(isPropAssignExpr);

--- a/src/event-bridge/utils.ts
+++ b/src/event-bridge/utils.ts
@@ -183,7 +183,7 @@ export const flattenExpression = (expr: Expr, scope: EventScope): Expr => {
       throw new Error("Array access must be a number.");
     }
     return typeof key === "string"
-      ? new PropAccessExpr(parent, new Identifier(key))
+      ? new PropAccessExpr(parent, new Identifier(key), false)
       : new ElementAccessExpr(parent, new NumberLiteralExpr(key));
   } else if (isComputedPropertyNameExpr(expr)) {
     return flattenExpression(expr.expr, scope);

--- a/src/expression.ts
+++ b/src/expression.ts
@@ -2,7 +2,10 @@ import type {
   BindingElem,
   ClassMember,
   Decl,
+  GetAccessorDecl,
+  MethodDecl,
   ParameterDecl,
+  SetAccessorDecl,
   VariableDecl,
 } from "./declaration";
 import {
@@ -52,6 +55,7 @@ export type Expr =
   | SpreadAssignExpr
   | SpreadElementExpr
   | StringLiteralExpr
+  | TaggedTemplateExpr
   | TemplateExpr
   | ThisExpr
   | TypeOfExpr
@@ -171,14 +175,11 @@ export class PrivateIdentifier extends BaseExpr<"PrivateIdentifier"> {
 }
 
 export class PropAccessExpr extends BaseExpr<"PropAccessExpr"> {
-  readonly name: Identifier | PrivateIdentifier;
   constructor(
     readonly expr: Expr,
-    name: string | Identifier | PrivateIdentifier,
-    readonly type?: string
+    readonly name: Identifier | PrivateIdentifier
   ) {
     super("PropAccessExpr", arguments);
-    this.name = typeof name === "string" ? new Identifier(name) : name;
   }
 
   public clone(): this {
@@ -187,11 +188,7 @@ export class PropAccessExpr extends BaseExpr<"PropAccessExpr"> {
 }
 
 export class ElementAccessExpr extends BaseExpr<"ElementAccessExpr"> {
-  constructor(
-    readonly expr: Expr,
-    readonly element: Expr,
-    readonly type?: string
-  ) {
+  constructor(readonly expr: Expr, readonly element: Expr) {
     super("ElementAccessExpr", arguments);
   }
 
@@ -392,7 +389,12 @@ export class ArrayLiteralExpr extends BaseExpr<"ArrayLiteralExpr"> {
   }
 }
 
-export type ObjectElementExpr = PropAssignExpr | SpreadAssignExpr;
+export type ObjectElementExpr =
+  | GetAccessorDecl
+  | MethodDecl
+  | PropAssignExpr
+  | SetAccessorDecl
+  | SpreadAssignExpr;
 
 export class ObjectLiteralExpr extends BaseExpr<"ObjectLiteralExpr"> {
   constructor(readonly properties: ObjectElementExpr[]) {
@@ -404,6 +406,7 @@ export class ObjectLiteralExpr extends BaseExpr<"ObjectLiteralExpr"> {
       this.properties.map((prop) => prop.clone())
     ) as this;
   }
+
   public getProperty(name: string) {
     return this.properties.find((prop) => {
       if (isPropAssignExpr(prop)) {
@@ -492,6 +495,19 @@ export class TemplateExpr extends BaseExpr<"TemplateExpr"> {
 
   public clone(): this {
     return new TemplateExpr(this.exprs.map((expr) => expr.clone())) as this;
+  }
+}
+
+export class TaggedTemplateExpr extends BaseExpr<"TaggedTemplateExpr"> {
+  constructor(readonly tag: Expr, readonly exprs: Expr[]) {
+    super("TaggedTemplateExpr", arguments);
+  }
+
+  public clone(): this {
+    return new TaggedTemplateExpr(
+      this.tag.clone(),
+      this.exprs.map((expr) => expr.clone())
+    ) as this;
   }
 }
 

--- a/src/expression.ts
+++ b/src/expression.ts
@@ -43,6 +43,7 @@ export type Expr =
   | NullLiteralExpr
   | NumberLiteralExpr
   | ObjectLiteralExpr
+  | OmittedExpr
   | ParenthesizedExpr
   | PostfixUnaryExpr
   | PrivateIdentifier
@@ -659,6 +660,15 @@ export class ParenthesizedExpr extends BaseExpr<"ParenthesizedExpr"> {
       return this.expr.unwrap();
     }
     return this.expr;
+  }
+}
+
+export class OmittedExpr extends BaseExpr<"OmittedExpr"> {
+  constructor() {
+    super("OmittedExpr", arguments);
+  }
+  public clone(): this {
+    return new OmittedExpr() as this;
   }
 }
 

--- a/src/expression.ts
+++ b/src/expression.ts
@@ -186,7 +186,7 @@ export class PropAccessExpr extends BaseExpr<"PropAccessExpr"> {
   public clone(): this {
     return new PropAccessExpr(
       this.expr.clone(),
-      this.name,
+      this.name.clone(),
       this.isOptional
     ) as this;
   }

--- a/src/expression.ts
+++ b/src/expression.ts
@@ -177,13 +177,18 @@ export class PrivateIdentifier extends BaseExpr<"PrivateIdentifier"> {
 export class PropAccessExpr extends BaseExpr<"PropAccessExpr"> {
   constructor(
     readonly expr: Expr,
-    readonly name: Identifier | PrivateIdentifier
+    readonly name: Identifier | PrivateIdentifier,
+    readonly isOptional: boolean
   ) {
     super("PropAccessExpr", arguments);
   }
 
   public clone(): this {
-    return new PropAccessExpr(this.expr.clone(), this.name) as this;
+    return new PropAccessExpr(
+      this.expr.clone(),
+      this.name,
+      this.isOptional
+    ) as this;
   }
 }
 

--- a/src/guards.ts
+++ b/src/guards.ts
@@ -33,6 +33,7 @@ export const isNewExpr = typeGuard("NewExpr");
 export const isNullLiteralExpr = typeGuard("NullLiteralExpr");
 export const isNumberLiteralExpr = typeGuard("NumberLiteralExpr");
 export const isObjectLiteralExpr = typeGuard("ObjectLiteralExpr");
+export const isOmittedExpr = typeGuard("OmittedExpr");
 export const isParenthesizedExpr = typeGuard("ParenthesizedExpr");
 export const isPostfixUnaryExpr = typeGuard("PostfixUnaryExpr");
 export const isPrivateIdentifier = typeGuard("PrivateIdentifier");

--- a/src/guards.ts
+++ b/src/guards.ts
@@ -80,7 +80,6 @@ export function isStmt(a: any): a is Stmt {
   return isNode(a) && a.nodeKind === "Stmt";
 }
 export const isBlockStmt = typeGuard("BlockStmt");
-export const isForStmt = typeGuard("ForStmt");
 export const isBreakStmt = typeGuard("BreakStmt");
 export const isCaseClause = typeGuard("CaseClause");
 export const isCatchClause = typeGuard("CatchClause");
@@ -92,10 +91,12 @@ export const isEmptyStmt = typeGuard("EmptyStmt");
 export const isExprStmt = typeGuard("ExprStmt");
 export const isForInStmt = typeGuard("ForInStmt");
 export const isForOfStmt = typeGuard("ForOfStmt");
+export const isForStmt = typeGuard("ForStmt");
 export const isIfStmt = typeGuard("IfStmt");
 export const isLabelledStmt = typeGuard("LabelledStmt");
 export const isReturnStmt = typeGuard("ReturnStmt");
 export const isSwitchStmt = typeGuard("SwitchStmt");
+export const isTaggedTemplateExpr = typeGuard("TaggedTemplateExpr");
 export const isThrowStmt = typeGuard("ThrowStmt");
 export const isTryStmt = typeGuard("TryStmt");
 export const isVariableStmt = typeGuard("VariableStmt");
@@ -112,9 +113,11 @@ export const isClassDecl = typeGuard("ClassDecl");
 export const isClassStaticBlockDecl = typeGuard("ClassStaticBlockDecl");
 export const isConstructorDecl = typeGuard("ConstructorDecl");
 export const isFunctionDecl = typeGuard("FunctionDecl");
+export const isGetAccessorDecl = typeGuard("GetAccessorDecl");
 export const isMethodDecl = typeGuard("MethodDecl");
 export const isParameterDecl = typeGuard("ParameterDecl");
 export const isPropDecl = typeGuard("PropDecl");
+export const isSetAccessorDecl = typeGuard("SetAccessorDecl");
 export const isClassMember = typeGuard(
   "ClassStaticBlockDecl",
   "ConstructorDecl",
@@ -128,8 +131,9 @@ export const isBindingElem = typeGuard("BindingElem");
 export const isObjectBinding = typeGuard("ObjectBinding");
 
 export const isPropName = typeGuard(
-  "Identifier",
   "ComputedPropertyNameExpr",
+  "Identifier",
+  "NumberLiteralExpr",
   "StringLiteralExpr"
 );
 

--- a/src/node.ts
+++ b/src/node.ts
@@ -83,14 +83,11 @@ export abstract class BaseNode<
     }
   }
 
-  public as<K extends FunctionlessNode["kind"]>(
-    kind: K
-  ): Extract<this, { kind: K }> {
-    // @ts-ignore
-    if (this.kind !== kind) {
-      throw new Error(`expected to be a ${kind} but was ${this.kind}`);
+  public as<T>(guard: (a: any) => a is T): T | undefined {
+    if (guard(this)) {
+      return this;
     }
-    return this as any;
+    return undefined;
   }
 
   public is<N extends this>(is: (node: this) => node is N): this is N {

--- a/src/step-function.ts
+++ b/src/step-function.ts
@@ -28,10 +28,13 @@ import {
   isErr,
   isFunctionDecl,
   isFunctionExpr,
+  isGetAccessorDecl,
   isIdentifier,
+  isMethodDecl,
   isNumberLiteralExpr,
   isObjectLiteralExpr,
   isPropAssignExpr,
+  isSetAccessorDecl,
   isSpreadAssignExpr,
 } from "./guards";
 import {
@@ -983,11 +986,29 @@ function retrieveMachineArgs(call: CallExpr) {
     );
   }
 
+  const [name, traceHeader, input] = ["name", "traceHeader", "input"].map(
+    (name) => {
+      const prop = arg.getProperty(name);
+      if (
+        prop &&
+        (isGetAccessorDecl(prop) ||
+          isSetAccessorDecl(prop) ||
+          isMethodDecl(prop))
+      ) {
+        throw new SynthError(
+          ErrorCodes.Unsupported_Feature,
+          `${prop.kind} is not suppported by Step Functions`
+        );
+      }
+      return prop?.expr;
+    }
+  );
+
   // we know the keys cannot be computed, so it is safe to use getProperty
   return {
-    name: arg.getProperty("name")?.expr,
-    traceHeader: arg.getProperty("traceHeader")?.expr,
-    input: arg.getProperty("input")?.expr,
+    name,
+    traceHeader,
+    input,
   };
 }
 

--- a/src/visit.ts
+++ b/src/visit.ts
@@ -141,6 +141,7 @@ import {
   isGetAccessorDecl,
   isSetAccessorDecl,
   isTaggedTemplateExpr,
+  isOmittedExpr,
 } from "./guards";
 import { FunctionlessNode } from "./node";
 
@@ -769,6 +770,8 @@ export function visitEachChild<T extends FunctionlessNode>(
     ensure(body, isBlockStmt, "SetAccessorDecl's body must be a BlockStmt");
 
     return new SetAccessorDecl(name, parameter, body) as T;
+  } else if (isOmittedExpr(node)) {
+    return node.clone() as T;
   }
   return assertNever(node);
 }

--- a/src/visit.ts
+++ b/src/visit.ts
@@ -866,36 +866,5 @@ export function visitSpecificChildren<T extends FunctionlessNode>(
   });
 }
 
-/**
- * Rename all {@link PropAssignExpr} expressions within the {@link obj} where the
- * name is statically known and matches a property in the {@link rename} map.
- */
-export function renameObjectProperties(
-  obj: ObjectLiteralExpr,
-  rename: Record<string, string>
-) {
-  const newObj = visitEachChild(obj, (node) => {
-    if (isPropAssignExpr(node)) {
-      const propName = isIdentifier(node.name)
-        ? node.name.name
-        : isStringLiteralExpr(node.name)
-        ? node.name.value
-        : undefined;
-
-      if (propName !== undefined && propName in rename) {
-        const substituteName = rename[propName];
-
-        return new PropAssignExpr(
-          new Identifier(substituteName),
-          node.expr.clone()
-        );
-      }
-    }
-    return node;
-  });
-  newObj.parent = obj.parent;
-  return newObj;
-}
-
 // to prevent the closure serializer from trying to import all of functionless.
 export const deploymentOnlyModule = true;

--- a/src/visit.ts
+++ b/src/visit.ts
@@ -627,7 +627,12 @@ export function visitEachChild<T extends FunctionlessNode>(
     property &&
       ensure(
         property,
-        anyOf(isComputedPropertyNameExpr, isIdentifier, isStringLiteralExpr),
+        anyOf(
+          isComputedPropertyNameExpr,
+          isIdentifier,
+          isStringLiteralExpr,
+          isNumberLiteralExpr
+        ),
         "A BindingElm's propertyName property must be an Identifier, Computed, String, or undefined"
       );
     const initializer = node.initializer
@@ -646,16 +651,13 @@ export function visitEachChild<T extends FunctionlessNode>(
       initializer as BindingElem["initializer"]
     ) as T;
   } else if (isBindingPattern(node)) {
-    const bindings = node.bindings.map((b) => {
-      const binding = b ? visitor(b) : undefined;
-      binding &&
-        ensure(
-          binding,
-          isBindingElem,
-          "Bindings property on BindingPatterns must be a BindingElm or undefined"
-        );
-      return binding;
-    });
+    const bindings = node.bindings.flatMap((b) =>
+      ensureSingleOrArray(
+        visitor(b),
+        anyOf(isBindingElem, isOmittedExpr),
+        "Bindings property on BindingPatterns must be a BindingElm or OmittedExpr"
+      )
+    );
 
     if (isObjectBinding(node)) {
       return new ObjectBinding(bindings as ObjectBinding["bindings"]) as T;

--- a/src/visit.ts
+++ b/src/visit.ts
@@ -457,7 +457,7 @@ export function visitEachChild<T extends FunctionlessNode>(
       isExpr,
       "a PropAccessExpr's expr property must be an Expr node type"
     );
-    return new PropAccessExpr(expr, node.name) as T;
+    return new PropAccessExpr(expr, node.name, node.isOptional) as T;
   } else if (isPropAssignExpr(node)) {
     const name = visitor(node.name);
     const expr = visitor(node.expr);

--- a/src/vtl.ts
+++ b/src/vtl.ts
@@ -1,5 +1,5 @@
 import { assertNever, assertNodeKind } from "./assert";
-import { BindingPattern, VariableDecl } from "./declaration";
+import { BindingElem, BindingPattern, VariableDecl } from "./declaration";
 import { ErrorCodes, SynthError } from "./error-code";
 import {
   CallExpr,
@@ -17,6 +17,7 @@ import {
   isAwaitExpr,
   isBigIntExpr,
   isBinaryExpr,
+  isBindingElem,
   isBindingPattern,
   isBlockStmt,
   isBooleanLiteralExpr,
@@ -849,13 +850,16 @@ export abstract class VTL {
     target: string,
     variablePrefix: string = "$"
   ) {
-    const rest = pattern.bindings.find((binding) => binding?.rest);
-    const properties = pattern.bindings.map((binding, i) => {
+    const rest = pattern.bindings.find(
+      (binding): binding is BindingElem =>
+        binding.as(isBindingElem)?.rest ?? false
+    ) as BindingElem | undefined;
+    const properties = pattern.bindings.flatMap((binding, i) => {
       /**
        * OmitElement for ArrayBinding, skip
        */
-      if (!binding || binding === rest) {
-        return;
+      if (isOmittedExpr(binding) || binding === rest) {
+        return [];
       }
 
       const accessor: string | undefined = isArrayBinding(pattern)
@@ -897,7 +901,7 @@ export abstract class VTL {
         this.set(`${variablePrefix}${binding.name.name}`, next);
       }
 
-      return accessor;
+      return [accessor];
     });
 
     if (rest) {
@@ -913,12 +917,10 @@ export abstract class VTL {
         );
       } else {
         // compute an array of the properties bound from the object
-        const userProps = properties
-          .filter((p): p is string => !!p)
-          .map((p) =>
-            // strip off the accessor patterns
-            p.startsWith(".") ? p.slice(1) : p.slice(1, p.length - 1)
-          );
+        const userProps = properties.map((p) =>
+          // strip off the accessor patterns
+          p.startsWith(".") ? p.slice(1) : p.slice(1, p.length - 1)
+        );
         // create a new object
         this.set(restTemp, `{}`);
         // create a new variable to use in the loop

--- a/src/vtl.ts
+++ b/src/vtl.ts
@@ -53,6 +53,7 @@ import {
   isNullLiteralExpr,
   isNumberLiteralExpr,
   isObjectLiteralExpr,
+  isOmittedExpr,
   isParameterDecl,
   isParenthesizedExpr,
   isPostfixUnaryExpr,
@@ -576,7 +577,11 @@ export abstract class VTL {
       return `${this.eval(node.expr)}.${node.name.name}`;
     } else if (isElementAccessExpr(node)) {
       return `${this.eval(node.expr)}[${this.eval(node.element)}]`;
-    } else if (isNullLiteralExpr(node) || isUndefinedLiteralExpr(node)) {
+    } else if (
+      isNullLiteralExpr(node) ||
+      isUndefinedLiteralExpr(node) ||
+      isOmittedExpr(node)
+    ) {
       return "$null";
     } else if (isNumberLiteralExpr(node) || isBigIntExpr(node)) {
       return node.value.toString(10);

--- a/src/vtl.ts
+++ b/src/vtl.ts
@@ -43,6 +43,7 @@ import {
   isForStmt,
   isFunctionDecl,
   isFunctionExpr,
+  isGetAccessorDecl,
   isIdentifier,
   isIfStmt,
   isImportKeyword,
@@ -64,12 +65,14 @@ import {
   isReferenceExpr,
   isRegexExpr,
   isReturnStmt,
+  isSetAccessorDecl,
   isSpreadAssignExpr,
   isSpreadElementExpr,
   isStmt,
   isStringLiteralExpr,
   isSuperKeyword,
   isSwitchStmt,
+  isTaggedTemplateExpr,
   isTemplateExpr,
   isThisExpr,
   isThrowStmt,
@@ -587,6 +590,15 @@ export abstract class VTL {
           this.put(obj, name, prop.expr);
         } else if (isSpreadAssignExpr(prop)) {
           this.putAll(obj, prop.expr);
+        } else if (
+          isGetAccessorDecl(prop) ||
+          isSetAccessorDecl(prop) ||
+          isMethodDecl(prop)
+        ) {
+          throw new SynthError(
+            ErrorCodes.Unsupported_Feature,
+            `${prop.kind} is not supported by VTL`
+          );
         } else {
           assertNever(prop);
         }
@@ -721,6 +733,7 @@ export abstract class VTL {
       isRegexExpr(node) ||
       isSuperKeyword(node) ||
       isSwitchStmt(node) ||
+      isTaggedTemplateExpr(node) ||
       isVoidExpr(node) ||
       isWithStmt(node) ||
       isYieldExpr(node)


### PR DESCRIPTION
Adds new AST nodes:
* `GetAccessorDecl`
* `SetAccessorDecl`
* `TaggedTemplateExpr`
* `OmittedExpr`

Allows `GetAccessorDecl`, `SetAccessorDecl` and `MethodDecl` in `ObjectLiteralExpr`.
```ts
const obj = {
  get foo() { }
  set foo(f) { }
  method() { }
}
```

Add `isOptional` to `PropAccessExpr` and `CallExpr`.
```ts
call?.();
prop?.access;
```