### PR TITLE
feat: add QuasiString NodeKind for representing quasi strings in a TemplateExpr

### DIFF
--- a/src/checker.ts
+++ b/src/checker.ts
@@ -847,6 +847,9 @@ export function makeFunctionlessChecker(
     if (
       ts.isStringLiteral(node) ||
       ts.isNumericLiteral(node) ||
+      ts.isTemplateHead(node) ||
+      ts.isTemplateMiddle(node) ||
+      ts.isTemplateTail(node) ||
       node.kind === ts.SyntaxKind.TrueKeyword ||
       node.kind === ts.SyntaxKind.FalseKeyword ||
       node.kind === ts.SyntaxKind.NullKeyword ||

--- a/src/event-bridge/target-input.ts
+++ b/src/event-bridge/target-input.ts
@@ -22,6 +22,7 @@ import {
   isPromiseExpr,
   isPropAccessExpr,
   isPropAssignExpr,
+  isQuasiString,
   isReferenceExpr,
   isStringLiteralExpr,
   isTemplateExpr,
@@ -197,7 +198,9 @@ export const synthesizeEventBridgeTargets = (
       }
     } else if (isTemplateExpr(expr)) {
       return {
-        value: expr.exprs.map((x) => exprToStringLiteral(x)).join(""),
+        value: expr.spans
+          .map((x) => (isQuasiString(x) ? x.value : exprToStringLiteral(x)))
+          .join(""),
         type: "string",
       };
     } else if (isObjectLiteralExpr(expr) || isArrayLiteralExpr(expr)) {

--- a/src/event-bridge/utils.ts
+++ b/src/event-bridge/utils.ts
@@ -28,6 +28,7 @@ import {
   isParenthesizedExpr,
   isPropAccessExpr,
   isPropAssignExpr,
+  isQuasiString,
   isReturnStmt,
   isSetAccessorDecl,
   isSpreadElementExpr,
@@ -244,8 +245,8 @@ export const flattenExpression = (expr: Expr, scope: EventScope): Expr => {
       }, [] as PropAssignExpr[])
     );
   } else if (isTemplateExpr(expr)) {
-    const flattenedExpressions = expr.exprs.map((x) =>
-      flattenExpression(x, scope)
+    const flattenedExpressions = expr.spans.map((x) =>
+      isQuasiString(x) ? x : flattenExpression(x, scope)
     );
 
     const flattenedConstants = flattenedExpressions.map((e) =>
@@ -258,7 +259,11 @@ export const flattenExpression = (expr: Expr, scope: EventScope): Expr => {
       ? new StringLiteralExpr(
           (<Constant[]>flattenedConstants).map((e) => e.constant).join("")
         )
-      : new TemplateExpr(expr.exprs.map((x) => flattenExpression(x, scope)));
+      : new TemplateExpr(
+          expr.spans.map((x) =>
+            isQuasiString(x) ? x : flattenExpression(x, scope)
+          )
+        );
   } else {
     return expr;
   }

--- a/src/expression.ts
+++ b/src/expression.ts
@@ -388,19 +388,46 @@ export class SpreadElementExpr extends BaseExpr<
 }
 
 /**
+ * A quasi string in a {@link TemplateExpr} or {@link TaggedTemplateExpr}.
+ *
+ * ```ts
+ * const s = `abc${def}`
+ *          // ^ quasi
+ * ```
+ */
+export class QuasiString extends BaseNode<NodeKind.QuasiString> {
+  readonly nodeKind = "Node";
+  constructor(readonly value: string) {
+    super(NodeKind.QuasiString, arguments);
+  }
+}
+
+/**
+ * A span of text within a {@link TemplateExpr} or {@link TaggedTemplateExpr}.
+ *
+ * ```ts
+ * const s = `quasi ${expr}`
+ *           // ^ Quasi string
+ * const s = `quasi ${expr}`
+ *                  // ^ expression to splice
+ * ```
+ */
+export type TemplateSpan = QuasiString | Expr;
+
+/**
  * Interpolates a TemplateExpr to a string `this ${is} a template expression`
  */
 export class TemplateExpr extends BaseExpr<NodeKind.TemplateExpr> {
-  constructor(readonly exprs: Expr[]) {
+  constructor(readonly spans: TemplateSpan[]) {
     super(NodeKind.TemplateExpr, arguments);
-    this.ensureArrayOf(exprs, "expr", ["Expr"]);
+    this.ensureArrayOf(spans, "span", [NodeKind.QuasiString, "Expr"]);
   }
 }
 
 export class TaggedTemplateExpr extends BaseExpr<NodeKind.TaggedTemplateExpr> {
-  constructor(readonly tag: Expr, readonly exprs: Expr[]) {
+  constructor(readonly tag: Expr, readonly spans: TemplateSpan[]) {
     super(NodeKind.TaggedTemplateExpr, arguments);
-    this.ensureArrayOf(exprs, "expr", ["Expr"]);
+    this.ensureArrayOf(spans, "span", [NodeKind.QuasiString, "Expr"]);
   }
 }
 

--- a/src/guards.ts
+++ b/src/guards.ts
@@ -44,6 +44,7 @@ export const isPromiseArrayExpr = typeGuard(NodeKind.PromiseArrayExpr);
 export const isPromiseExpr = typeGuard(NodeKind.PromiseExpr);
 export const isPropAccessExpr = typeGuard(NodeKind.PropAccessExpr);
 export const isPropAssignExpr = typeGuard(NodeKind.PropAssignExpr);
+export const isQuasiString = typeGuard(NodeKind.QuasiString);
 export const isReferenceExpr = typeGuard(NodeKind.ReferenceExpr);
 export const isRegexExpr = typeGuard(NodeKind.RegexExpr);
 export const isSpreadAssignExpr = typeGuard(NodeKind.SpreadAssignExpr);

--- a/src/node-ctor.ts
+++ b/src/node-ctor.ts
@@ -44,6 +44,7 @@ import {
   PromiseExpr,
   PropAccessExpr,
   PropAssignExpr,
+  QuasiString,
   ReferenceExpr,
   RegexExpr,
   SpreadAssignExpr,
@@ -111,6 +112,7 @@ export const declarations = {
   [NodeKind.SetAccessorDecl]: SetAccessorDecl,
   [NodeKind.VariableDecl]: VariableDecl,
   [NodeKind.VariableDeclList]: VariableDeclList,
+  [NodeKind.QuasiString]: QuasiString,
 } as const;
 
 export const error = {

--- a/src/node-kind.ts
+++ b/src/node-kind.ts
@@ -78,6 +78,7 @@ export enum NodeKind {
   WhileStmt = 76,
   WithStmt = 77,
   YieldExpr = 78,
+  QuasiString = 79,
 }
 
 export namespace NodeKind {

--- a/src/node.ts
+++ b/src/node.ts
@@ -13,7 +13,12 @@ import {
   ensureArrayOf,
 } from "./ensure";
 import type { Err } from "./error";
-import type { Expr, ImportKeyword, SuperKeyword } from "./expression";
+import type {
+  Expr,
+  ImportKeyword,
+  QuasiString,
+  SuperKeyword,
+} from "./expression";
 import {
   isBindingElem,
   isBindingPattern,
@@ -44,7 +49,8 @@ export type FunctionlessNode =
   | SuperKeyword
   | ImportKeyword
   | BindingPattern
-  | VariableDeclList;
+  | VariableDeclList
+  | QuasiString;
 
 export interface HasParent<Parent extends FunctionlessNode> {
   get parent(): Parent;

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,6 +1,12 @@
 import { Construct } from "constructs";
 import ts from "typescript";
-import { BinaryOp, CallExpr, Expr, PropAccessExpr } from "./expression";
+import {
+  BinaryOp,
+  CallExpr,
+  Expr,
+  PropAccessExpr,
+  QuasiString,
+} from "./expression";
 import {
   isArrayLiteralExpr,
   isBinaryExpr,
@@ -16,6 +22,7 @@ import {
   isPrivateIdentifier,
   isPropAccessExpr,
   isPropAssignExpr,
+  isQuasiString,
   isReferenceExpr,
   isSpreadAssignExpr,
   isSpreadElementExpr,
@@ -199,13 +206,16 @@ export function isConstant(x: any): x is Constant {
  * const obj = { val: "hello" };
  * obj.val -> { constant: "hello" }
  */
-export const evalToConstant = (expr: Expr): Constant | undefined => {
+export const evalToConstant = (
+  expr: Expr | QuasiString
+): Constant | undefined => {
   if (
     isStringLiteralExpr(expr) ||
     isNumberLiteralExpr(expr) ||
     isBooleanLiteralExpr(expr) ||
     isNullLiteralExpr(expr) ||
-    isUndefinedLiteralExpr(expr)
+    isUndefinedLiteralExpr(expr) ||
+    isQuasiString(expr)
   ) {
     return { constant: expr.value };
   } else if (isArrayLiteralExpr(expr)) {
@@ -311,7 +321,7 @@ export const evalToConstant = (expr: Expr): Constant | undefined => {
       }
     }
   } else if (isTemplateExpr(expr)) {
-    const values = expr.exprs.map(evalToConstant);
+    const values = expr.spans.map(evalToConstant);
     if (values.every((v): v is Constant => !!v)) {
       return { constant: values.map((v) => v.constant).join("") };
     }

--- a/src/vtl.ts
+++ b/src/vtl.ts
@@ -69,6 +69,7 @@ import {
   isPropAccessExpr,
   isPropAssignExpr,
   isPropDecl,
+  isQuasiString,
   isReferenceExpr,
   isRegexExpr,
   isReturnStmt,
@@ -634,9 +635,9 @@ export abstract class VTL {
     } else if (isStringLiteralExpr(node)) {
       return this.str(node.value);
     } else if (isTemplateExpr(node)) {
-      return `"${node.exprs
+      return `"${node.spans
         .map((expr) => {
-          if (isStringLiteralExpr(expr)) {
+          if (isQuasiString(expr) || isStringLiteralExpr(expr)) {
             return expr.value;
           }
           const text = this.eval(expr, returnVar);


### PR DESCRIPTION
Fixes #373

Adds a new NodeKind, `QuasiString`, to represent the raw strings in a `TemplateExpr` and `TaggedTemplateExpr`:

```ts
const a = `quasi string ${expr}`
// parses as
new TemplateExpr(new Quasi("quasi string "), new Identifier("expr"))
```