### PR TITLE
feat: remove logic in compile.ts to flatten references to expressions

### DIFF
--- a/src/appsync.ts
+++ b/src/appsync.ts
@@ -466,14 +466,19 @@ function synthesizeFunctions(api: appsync.GraphqlApi, decl: FunctionLike) {
         // we find the range of nodes to hoist so that we avoid visiting the middle nodes.
         // The start node is the first node in the integration pattern (integ, await, or promise)
         // The end is always the integration.
+
         const end = getIntegrationExprFromIntegrationCallPattern(node);
 
-        const updatedChild = visitSpecificChildren(node, [end], (expr) =>
-          normalizeAST(expr, hoist)
-        );
-        // when we find an integration call,
-        // if it is nested, hoist it up (create variable, add above, replace expr with variable)
-        return hoist && doHoist(node) ? hoist(updatedChild) : updatedChild;
+        if (end) {
+          const updatedChild = visitSpecificChildren(node, [end], (expr) =>
+            normalizeAST(expr, hoist)
+          );
+
+          // when we find an integration call,
+          // if it is nested, hoist it up (create variable, add above, replace expr with variable)
+          return hoist && doHoist(node) ? hoist(updatedChild) : updatedChild;
+        }
+        return visitEachChild(node, normalizeAST);
       } else if (isVariableStmt(node) && node.declList.decls.length > 1) {
         /**
          * Flatten variable declarations into multiple variable statements.

--- a/src/appsync.ts
+++ b/src/appsync.ts
@@ -478,7 +478,6 @@ function synthesizeFunctions(api: appsync.GraphqlApi, decl: FunctionLike) {
           // if it is nested, hoist it up (create variable, add above, replace expr with variable)
           return hoist && doHoist(node) ? hoist(updatedChild) : updatedChild;
         }
-        return visitEachChild(node, normalizeAST);
       } else if (isVariableStmt(node) && node.declList.decls.length > 1) {
         /**
          * Flatten variable declarations into multiple variable statements.

--- a/src/asl.ts
+++ b/src/asl.ts
@@ -110,10 +110,10 @@ import {
   isQuasiString,
 } from "./guards";
 import {
-  Integration,
   IntegrationImpl,
   isIntegration,
   isIntegrationCallPattern,
+  tryFindIntegration,
 } from "./integration";
 import { FunctionlessNode } from "./node";
 import {
@@ -1647,75 +1647,66 @@ export class ASL {
         };
       });
     } else if (isCallExpr(expr)) {
-      if (isReferenceExpr(expr.expr)) {
-        const ref = expr.expr.ref();
-        if (isIntegration<Integration>(ref)) {
-          const serviceCall = new IntegrationImpl(ref);
-          const integStates = serviceCall.asl(expr, this);
+      const integration = tryFindIntegration(expr.expr);
+      if (integration) {
+        const serviceCall = new IntegrationImpl(integration);
+        const integStates = serviceCall.asl(expr, this);
 
-          if (
-            ASLGraph.isLiteralValue(integStates) ||
-            ASLGraph.isJsonPath(integStates)
-          ) {
-            return integStates;
-          }
-
-          const updateState = (
-            state: ASLGraph.NodeState
-          ): ASLGraph.NodeState => {
-            const throwOrPass = this.throw(expr);
-            if (
-              throwOrPass?.Next &&
-              (isTaskState(state) ||
-                isMapTaskState(state) ||
-                isParallelTaskState(state))
-            ) {
-              return {
-                ...state,
-                Catch: [
-                  {
-                    ErrorEquals: ["States.ALL"],
-                    Next: throwOrPass.Next,
-                    ResultPath: throwOrPass.ResultPath,
-                  },
-                ],
-              };
-            } else {
-              return state;
-            }
-          };
-
-          const updateStates = (
-            states: ASLGraph.NodeState | ASLGraph.SubState
-          ): ASLGraph.NodeState | ASLGraph.SubState => {
-            return ASLGraph.isSubState(states)
-              ? {
-                  ...states,
-                  states: Object.fromEntries(
-                    Object.entries(states.states ?? {}).map(
-                      ([stateName, state]) => {
-                        if (ASLGraph.isSubState(state)) {
-                          return [stateName, updateStates(state)];
-                        } else {
-                          return [stateName, updateState(state)];
-                        }
-                      }
-                    )
-                  ),
-                }
-              : updateState(states);
-          };
-
-          return {
-            ...integStates,
-            ...updateStates(integStates),
-          };
-        } else {
-          throw new SynthError(
-            ErrorCodes.Unexpected_Error,
-            "Called references are expected to be an integration."
-          );
+        if (
+          ASLGraph.isLiteralValue(integStates) ||
+          ASLGraph.isJsonPath(integStates)
+        ) {
+          return integStates;
         }
+
+        const updateState = (state: ASLGraph.NodeState): ASLGraph.NodeState => {
+          const throwOrPass = this.throw(expr);
+          if (
+            throwOrPass?.Next &&
+            (isTaskState(state) ||
+              isMapTaskState(state) ||
+              isParallelTaskState(state))
+          ) {
+            return {
+              ...state,
+              Catch: [
+                {
+                  ErrorEquals: ["States.ALL"],
+                  Next: throwOrPass.Next,
+                  ResultPath: throwOrPass.ResultPath,
+                },
+              ],
+            };
+          } else {
+            return state;
+          }
+        };
+
+        const updateStates = (
+          states: ASLGraph.NodeState | ASLGraph.SubState
+        ): ASLGraph.NodeState | ASLGraph.SubState => {
+          return ASLGraph.isSubState(states)
+            ? {
+                ...states,
+                states: Object.fromEntries(
+                  Object.entries(states.states ?? {}).map(
+                    ([stateName, state]) => {
+                      if (ASLGraph.isSubState(state)) {
+                        return [stateName, updateStates(state)];
+                      } else {
+                        return [stateName, updateState(state)];
+                      }
+                    }
+                  )
+                ),
+              }
+            : updateState(states);
+        };
+
+        return {
+          ...integStates,
+          ...updateStates(integStates),
+        };
       } else if (isMapOrForEach(expr)) {
         const throwTransition = this.throw(expr);
 

--- a/src/checker.ts
+++ b/src/checker.ts
@@ -402,7 +402,8 @@ export function makeFunctionlessChecker(
         return updatedSymbol ? isSymbolOutOfScope(updatedSymbol, scope) : false;
       } else if (
         ts.isVariableDeclaration(symbol.valueDeclaration) ||
-        ts.isClassDeclaration(symbol.valueDeclaration)
+        ts.isClassDeclaration(symbol.valueDeclaration) ||
+        ts.isParameter(symbol.valueDeclaration)
       ) {
         return !hasParent(symbol.valueDeclaration, scope);
       } else if (ts.isBindingElement(symbol.valueDeclaration)) {

--- a/src/compile.ts
+++ b/src/compile.ts
@@ -414,6 +414,10 @@ export function compile(
             return ref(node);
           }
 
+          if (node.text === "table") {
+            checker.isIdentifierOutOfScope(node, scope);
+          }
+
           return newExpr(NodeKind.Identifier, [
             ts.factory.createStringLiteral(node.text),
           ]);

--- a/src/compile.ts
+++ b/src/compile.ts
@@ -414,10 +414,6 @@ export function compile(
             return ref(node);
           }
 
-          if (node.text === "table") {
-            checker.isIdentifierOutOfScope(node, scope);
-          }
-
           return newExpr(NodeKind.Identifier, [
             ts.factory.createStringLiteral(node.text),
           ]);

--- a/src/compile.ts
+++ b/src/compile.ts
@@ -418,18 +418,6 @@ export function compile(
             ts.factory.createStringLiteral(node.text),
           ]);
         } else if (ts.isPropertyAccessExpression(node)) {
-          if (checker.isIntegrationNode(node)) {
-            // if this is a reference to a Table or Lambda, retain it
-            const _ref = checker.getOutOfScopeValueNode(node, scope);
-            if (_ref) {
-              return ref(_ref);
-            } else {
-              throw new SynthError(
-                ErrorCodes.Unable_to_find_reference_out_of_application_function,
-                `Unable to find reference out of application function: ${node.getText()}`
-              );
-            }
-          }
           return newExpr(NodeKind.PropAccessExpr, [
             toExpr(node.expression, scope),
             toExpr(node.name, scope),

--- a/src/compile.ts
+++ b/src/compile.ts
@@ -400,18 +400,6 @@ export function compile(
           } else if (node.text === "null") {
             return newExpr(NodeKind.NullLiteralExpr, []);
           }
-          if (checker.isIntegrationNode(node)) {
-            // if this is a reference to a Table or Lambda, retain it
-            const _ref = checker.getOutOfScopeValueNode(node, scope);
-            if (_ref) {
-              return ref(_ref);
-            } else {
-              throw new SynthError(
-                ErrorCodes.Unable_to_find_reference_out_of_application_function,
-                `Unable to find reference out of application function: ${node.getText()}`
-              );
-            }
-          }
 
           /**
            * If the identifier is not within the closure, we attempt to enclose the reference in its own closure.
@@ -423,10 +411,7 @@ export function compile(
            * return { value: () => val };
            */
           if (checker.isIdentifierOutOfScope(node, scope)) {
-            const _ref = checker.getOutOfScopeValueNode(node, scope);
-            if (_ref) {
-              return ref(_ref);
-            }
+            return ref(node);
           }
 
           return newExpr(NodeKind.Identifier, [

--- a/src/expression.ts
+++ b/src/expression.ts
@@ -187,11 +187,13 @@ export class Argument extends BaseExpr<NodeKind.Argument, CallExpr | NewExpr> {
   }
 }
 
-export class CallExpr extends BaseExpr<NodeKind.CallExpr> {
-  constructor(
-    readonly expr: Expr | SuperKeyword | ImportKeyword,
-    readonly args: Argument[]
-  ) {
+export class CallExpr<
+  E extends Expr | SuperKeyword | ImportKeyword =
+    | Expr
+    | SuperKeyword
+    | ImportKeyword
+> extends BaseExpr<NodeKind.CallExpr> {
+  constructor(readonly expr: E, readonly args: Argument[]) {
     super(NodeKind.CallExpr, arguments);
   }
 }

--- a/src/function.ts
+++ b/src/function.ts
@@ -31,7 +31,7 @@ import { ApiGatewayVtlIntegration } from "./api";
 import type { AppSyncVtlIntegration } from "./appsync";
 import { ASL, ASLGraph } from "./asl";
 import { BindFunctionName, RegisterFunctionName } from "./compile";
-import { FunctionLike, IntegrationInvocation } from "./declaration";
+import { IntegrationInvocation } from "./declaration";
 import { ErrorCodes, formatErrorMessage, SynthError } from "./error-code";
 import {
   IEventBus,
@@ -49,19 +49,16 @@ import {
   PrewarmProps,
 } from "./function-prewarm";
 import {
+  findDeepIntegrations,
   Integration,
-  IntegrationCallExpr,
   IntegrationImpl,
   INTEGRATION_TYPE_KEYS,
   isIntegration,
-  isIntegrationCallExpr,
 } from "./integration";
-import { FunctionlessNode } from "./node";
 import { ReflectionSymbols, validateFunctionLike } from "./reflect";
 import { isStepFunction } from "./step-function";
 import { isTable } from "./table";
 import { AnyAsyncFunction, AnyFunction } from "./util";
-import { visitEachChild } from "./visit";
 
 export function isFunction<Payload = any, Output = any>(
   a: any
@@ -659,7 +656,7 @@ export class Function<
 
     super(_resource);
 
-    const integrations = getInvokedIntegrations(ast).map(
+    const integrations = findDeepIntegrations(ast).map(
       (i) =>
         <IntegrationInvocation>{
           args: i.args,
@@ -721,19 +718,6 @@ export class Function<
       })()
     );
   }
-}
-
-function getInvokedIntegrations(ast: FunctionLike): IntegrationCallExpr[] {
-  const nodes: IntegrationCallExpr[] = [];
-  visitEachChild(ast, function visit(node: FunctionlessNode): FunctionlessNode {
-    if (isIntegrationCallExpr(node)) {
-      nodes.push(node);
-    }
-
-    return visitEachChild(node, visit);
-  });
-
-  return nodes;
 }
 
 /**

--- a/src/node-ctor.ts
+++ b/src/node-ctor.ts
@@ -93,9 +93,9 @@ export function getCtor<Kind extends NodeKind>(
   return n[kind] as any;
 }
 
-export type NodeInstance<Kind extends NodeKind> = InstanceType<
-  typeof nodes[Kind]
->;
+export type NodeCtor<Kind extends NodeKind> = typeof nodes[Kind];
+
+export type NodeInstance<Kind extends NodeKind> = InstanceType<NodeCtor<Kind>>;
 
 export const declarations = {
   [NodeKind.ArrayBinding]: ArrayBinding,

--- a/src/node.ts
+++ b/src/node.ts
@@ -58,7 +58,8 @@ export interface HasParent<Parent extends FunctionlessNode> {
   set parent(parent: Parent);
 }
 
-type Binding = [string, VariableDecl | ParameterDecl | BindingElem];
+type Binding = [string, BindingDecl];
+type BindingDecl = VariableDecl | ParameterDecl | BindingElem;
 
 export abstract class BaseNode<
   Kind extends NodeKind,
@@ -111,6 +112,11 @@ export abstract class BaseNode<
     ];
   }
 
+  /**
+   * Forks the tree starting from `this` node with {@link node} as its child
+   *
+   * This function simply sets the {@link node}'s parent and returns it.
+   */
   public fork<N extends this["parent"]>(node: N): N {
     // @ts-ignore
     node.parent = this;
@@ -374,7 +380,7 @@ export abstract class BaseNode<
   /**
    * @returns a mapping of name to the node visible in this node's scope.
    */
-  public getLexicalScope(): Map<string, Binding[1]> {
+  public getLexicalScope(): Map<string, BindingDecl> {
     return new Map(getLexicalScope(this as unknown as FunctionlessNode));
 
     function getLexicalScope(node: FunctionlessNode | undefined): Binding[] {

--- a/src/util.ts
+++ b/src/util.ts
@@ -209,14 +209,7 @@ export function isConstant(x: any): x is Constant {
 export const evalToConstant = (
   expr: Expr | QuasiString
 ): Constant | undefined => {
-  if (isIdentifier(expr)) {
-    // const decl = expr.lookup();
-    // if (decl) {
-    //   if (isVariableDecl(decl) && decl.initializer) {
-    //     return evalToConstant(decl.initializer);
-    //   }
-    // }
-  } else if (
+  if (
     isStringLiteralExpr(expr) ||
     isNumberLiteralExpr(expr) ||
     isBooleanLiteralExpr(expr) ||

--- a/src/util.ts
+++ b/src/util.ts
@@ -209,7 +209,14 @@ export function isConstant(x: any): x is Constant {
 export const evalToConstant = (
   expr: Expr | QuasiString
 ): Constant | undefined => {
-  if (
+  if (isIdentifier(expr)) {
+    // const decl = expr.lookup();
+    // if (decl) {
+    //   if (isVariableDecl(decl) && decl.initializer) {
+    //     return evalToConstant(decl.initializer);
+    //   }
+    // }
+  } else if (
     isStringLiteralExpr(expr) ||
     isNumberLiteralExpr(expr) ||
     isBooleanLiteralExpr(expr) ||

--- a/src/visit.ts
+++ b/src/visit.ts
@@ -24,9 +24,8 @@ export function visitEachChild<T extends FunctionlessNode>(
 ): T {
   const ctor = getCtor(node.kind);
   const args = node._arguments.map((argument) => {
-    if (!(typeof argument === "object" || Array.isArray(argument))) {
+    if (argument === null || typeof argument !== "object") {
       // all primitives are simply returned as-is
-      // all objects are assumed
       return argument;
     } else if (isNode(argument)) {
       const transformed = visit(argument);

--- a/src/visit.ts
+++ b/src/visit.ts
@@ -23,48 +23,38 @@ export function visitEachChild<T extends FunctionlessNode>(
   ) => FunctionlessNode | FunctionlessNode[] | undefined
 ): T {
   const ctor = getCtor(node.kind);
-  const args = Array.from(node._arguments).map(
-    (
-      argument:
-        | FunctionlessNode
-        | FunctionlessNode[]
-        | string
-        | number
-        | boolean
-        | undefined
-    ): typeof argument => {
-      if (!(typeof argument === "object" || Array.isArray(argument))) {
-        // all primitives are simply returned as-is
-        // all objects are assumed
-        return argument;
-      } else if (isNode(argument)) {
-        const transformed = visit(argument);
-        if (transformed === undefined || isNode(transformed)) {
-          return transformed;
-        } else {
-          throw new Error(
-            `cannot spread nodes into an argument taking a single ${argument.kindName} node`
-          );
-        }
-      } else if (Array.isArray(argument)) {
-        // is an Array of nodes
-        return argument.flatMap((item) => {
-          const transformed = visit(item);
-          if (transformed === undefined) {
-            // the item was deleted, so remove it from the array
-            return [];
-          } else if (isNode(transformed)) {
-            return [transformed];
-          } else {
-            // spread the nodes into the array
-            return transformed;
-          }
-        });
+  const args = node._arguments.map((argument) => {
+    if (!(typeof argument === "object" || Array.isArray(argument))) {
+      // all primitives are simply returned as-is
+      // all objects are assumed
+      return argument;
+    } else if (isNode(argument)) {
+      const transformed = visit(argument);
+      if (transformed === undefined || isNode(transformed)) {
+        return transformed;
       } else {
-        return argument;
+        throw new Error(
+          `cannot spread nodes into an argument taking a single ${argument.kindName} node`
+        );
       }
+    } else if (Array.isArray(argument)) {
+      // is an Array of nodes
+      return argument.flatMap((item) => {
+        const transformed = visit(item);
+        if (transformed === undefined) {
+          // the item was deleted, so remove it from the array
+          return [];
+        } else if (isNode(transformed)) {
+          return [transformed];
+        } else {
+          // spread the nodes into the array
+          return transformed;
+        }
+      });
+    } else {
+      return argument;
     }
-  );
+  });
 
   return new ctor(...args) as T;
 }
@@ -83,11 +73,10 @@ export function visitBlock(
     const nestedTasks: FunctionlessNode[] = [];
     function hoist(expr: Expr): Identifier {
       const id = new Identifier(nameGenerator.generateOrGet(expr));
-      nestedTasks.push(
-        new VariableStmt(
-          new VariableDeclList([new VariableDecl(id.clone(), expr)])
-        )
+      const stmt = new VariableStmt(
+        new VariableDeclList([new VariableDecl(id.clone(), expr.clone())])
       );
+      nestedTasks.push(stmt);
       return id;
     }
 

--- a/test/reflect.test.ts
+++ b/test/reflect.test.ts
@@ -209,7 +209,7 @@ test("ObjectBinding with out-of-bound reference", () => {
   assertNodeKind(binding2.propertyName, NodeKind.Identifier);
   assertNodeKind(binding3.name, NodeKind.Identifier);
   assertNodeKind(binding3.propertyName, NodeKind.Identifier);
-  assertNodeKind(binding3.initializer, NodeKind.ReferenceExpr);
+  assertNodeKind(binding3.initializer, NodeKind.Identifier);
 });
 
 test("ArrayBinding with out-of-bound reference", () => {
@@ -243,7 +243,7 @@ test("ArrayBinding with out-of-bound reference", () => {
 
   assertNodeKind(binding1.name, NodeKind.Identifier);
   assertNodeKind(binding2.name, NodeKind.Identifier);
-  assertNodeKind(binding2.initializer, NodeKind.ReferenceExpr);
+  assertNodeKind(binding2.initializer, NodeKind.Identifier);
 });
 
 test("reflect on a bound function declaration", () => {

--- a/test/s-expression.test.ts
+++ b/test/s-expression.test.ts
@@ -15,7 +15,7 @@ test("s-expression isomorphism", () => {
 function equals(self: any, other: any): boolean {
   if (isNode(self) && isNode(other)) {
     if (self.kind === other.kind) {
-      return Array.from(self._arguments).every((thisArg, i) =>
+      return (self._arguments as any[]).every((thisArg, i) =>
         equals(thisArg, other._arguments[i])
       );
     } else {


### PR DESCRIPTION
Partial #374 

- [x] remove flattening logic from compile.ts
```ts
function foo() {
  $AWS.DynamoDB.GetItem(..)

  // before:
  CallExpr(ReferenceExpr(() => $AWS.DynamoDB.GetItem), ..)

  // now:
  CallExpr(PropAccessExpr(GetItem, PropAccessExpr(DynamoDB, ReferenceExpr(() => $AWS)))
}
```

- [x] update interpreters to resolve FucntionlessAST to ReferenceExpr as we can no longer rely on that work being done during tsc.