### PR TITLE
feat: add Span information to F-AST

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -22,6 +22,7 @@
     },
     {
       "name": "@functionless/ast-reflection",
+      "version": "file:../ast-reflection",
       "type": "build"
     },
     {

--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -22,7 +22,7 @@
     },
     {
       "name": "@functionless/ast-reflection",
-      "version": "file:../ast-reflection",
+      "version": "^0.1.0",
       "type": "build"
     },
     {

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -259,19 +259,19 @@
           "exec": "yarn upgrade npm-check-updates"
         },
         {
-          "exec": "npm-check-updates --dep dev --upgrade --target=minor --reject='@aws-cdk/aws-appsync-alpha,@aws-cdk/cloud-assembly-schema,@aws-cdk/cloudformation-diff,@aws-cdk/cx-api,@functionless/ast-reflection,aws-cdk-lib,aws-cdk,cdk-assets,constructs,typesafe-dynamodb,typescript'"
+          "exec": "npm-check-updates --dep dev --upgrade --target=minor --reject='@aws-cdk/aws-appsync-alpha,@aws-cdk/cloud-assembly-schema,@aws-cdk/cloudformation-diff,@aws-cdk/cx-api,aws-cdk-lib,aws-cdk,cdk-assets,constructs,typesafe-dynamodb,typescript'"
         },
         {
-          "exec": "npm-check-updates --dep optional --upgrade --target=minor --reject='@aws-cdk/aws-appsync-alpha,@aws-cdk/cloud-assembly-schema,@aws-cdk/cloudformation-diff,@aws-cdk/cx-api,@functionless/ast-reflection,aws-cdk-lib,aws-cdk,cdk-assets,constructs,typesafe-dynamodb,typescript'"
+          "exec": "npm-check-updates --dep optional --upgrade --target=minor --reject='@aws-cdk/aws-appsync-alpha,@aws-cdk/cloud-assembly-schema,@aws-cdk/cloudformation-diff,@aws-cdk/cx-api,aws-cdk-lib,aws-cdk,cdk-assets,constructs,typesafe-dynamodb,typescript'"
         },
         {
-          "exec": "npm-check-updates --dep peer --upgrade --target=minor --reject='@aws-cdk/aws-appsync-alpha,@aws-cdk/cloud-assembly-schema,@aws-cdk/cloudformation-diff,@aws-cdk/cx-api,@functionless/ast-reflection,aws-cdk-lib,aws-cdk,cdk-assets,constructs,typesafe-dynamodb,typescript'"
+          "exec": "npm-check-updates --dep peer --upgrade --target=minor --reject='@aws-cdk/aws-appsync-alpha,@aws-cdk/cloud-assembly-schema,@aws-cdk/cloudformation-diff,@aws-cdk/cx-api,aws-cdk-lib,aws-cdk,cdk-assets,constructs,typesafe-dynamodb,typescript'"
         },
         {
-          "exec": "npm-check-updates --dep prod --upgrade --target=minor --reject='@aws-cdk/aws-appsync-alpha,@aws-cdk/cloud-assembly-schema,@aws-cdk/cloudformation-diff,@aws-cdk/cx-api,@functionless/ast-reflection,aws-cdk-lib,aws-cdk,cdk-assets,constructs,typesafe-dynamodb,typescript'"
+          "exec": "npm-check-updates --dep prod --upgrade --target=minor --reject='@aws-cdk/aws-appsync-alpha,@aws-cdk/cloud-assembly-schema,@aws-cdk/cloudformation-diff,@aws-cdk/cx-api,aws-cdk-lib,aws-cdk,cdk-assets,constructs,typesafe-dynamodb,typescript'"
         },
         {
-          "exec": "npm-check-updates --dep bundle --upgrade --target=minor --reject='@aws-cdk/aws-appsync-alpha,@aws-cdk/cloud-assembly-schema,@aws-cdk/cloudformation-diff,@aws-cdk/cx-api,@functionless/ast-reflection,aws-cdk-lib,aws-cdk,cdk-assets,constructs,typesafe-dynamodb,typescript'"
+          "exec": "npm-check-updates --dep bundle --upgrade --target=minor --reject='@aws-cdk/aws-appsync-alpha,@aws-cdk/cloud-assembly-schema,@aws-cdk/cloudformation-diff,@aws-cdk/cx-api,aws-cdk-lib,aws-cdk,cdk-assets,constructs,typesafe-dynamodb,typescript'"
         },
         {
           "exec": "yarn install --check-files"

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -259,19 +259,19 @@
           "exec": "yarn upgrade npm-check-updates"
         },
         {
-          "exec": "npm-check-updates --dep dev --upgrade --target=minor --reject='@aws-cdk/aws-appsync-alpha,@aws-cdk/cloud-assembly-schema,@aws-cdk/cloudformation-diff,@aws-cdk/cx-api,aws-cdk-lib,aws-cdk,cdk-assets,constructs,typesafe-dynamodb,typescript'"
+          "exec": "npm-check-updates --dep dev --upgrade --target=minor --reject='@aws-cdk/aws-appsync-alpha,@aws-cdk/cloud-assembly-schema,@aws-cdk/cloudformation-diff,@aws-cdk/cx-api,@functionless/ast-reflection,aws-cdk-lib,aws-cdk,cdk-assets,constructs,typesafe-dynamodb,typescript'"
         },
         {
-          "exec": "npm-check-updates --dep optional --upgrade --target=minor --reject='@aws-cdk/aws-appsync-alpha,@aws-cdk/cloud-assembly-schema,@aws-cdk/cloudformation-diff,@aws-cdk/cx-api,aws-cdk-lib,aws-cdk,cdk-assets,constructs,typesafe-dynamodb,typescript'"
+          "exec": "npm-check-updates --dep optional --upgrade --target=minor --reject='@aws-cdk/aws-appsync-alpha,@aws-cdk/cloud-assembly-schema,@aws-cdk/cloudformation-diff,@aws-cdk/cx-api,@functionless/ast-reflection,aws-cdk-lib,aws-cdk,cdk-assets,constructs,typesafe-dynamodb,typescript'"
         },
         {
-          "exec": "npm-check-updates --dep peer --upgrade --target=minor --reject='@aws-cdk/aws-appsync-alpha,@aws-cdk/cloud-assembly-schema,@aws-cdk/cloudformation-diff,@aws-cdk/cx-api,aws-cdk-lib,aws-cdk,cdk-assets,constructs,typesafe-dynamodb,typescript'"
+          "exec": "npm-check-updates --dep peer --upgrade --target=minor --reject='@aws-cdk/aws-appsync-alpha,@aws-cdk/cloud-assembly-schema,@aws-cdk/cloudformation-diff,@aws-cdk/cx-api,@functionless/ast-reflection,aws-cdk-lib,aws-cdk,cdk-assets,constructs,typesafe-dynamodb,typescript'"
         },
         {
-          "exec": "npm-check-updates --dep prod --upgrade --target=minor --reject='@aws-cdk/aws-appsync-alpha,@aws-cdk/cloud-assembly-schema,@aws-cdk/cloudformation-diff,@aws-cdk/cx-api,aws-cdk-lib,aws-cdk,cdk-assets,constructs,typesafe-dynamodb,typescript'"
+          "exec": "npm-check-updates --dep prod --upgrade --target=minor --reject='@aws-cdk/aws-appsync-alpha,@aws-cdk/cloud-assembly-schema,@aws-cdk/cloudformation-diff,@aws-cdk/cx-api,@functionless/ast-reflection,aws-cdk-lib,aws-cdk,cdk-assets,constructs,typesafe-dynamodb,typescript'"
         },
         {
-          "exec": "npm-check-updates --dep bundle --upgrade --target=minor --reject='@aws-cdk/aws-appsync-alpha,@aws-cdk/cloud-assembly-schema,@aws-cdk/cloudformation-diff,@aws-cdk/cx-api,aws-cdk-lib,aws-cdk,cdk-assets,constructs,typesafe-dynamodb,typescript'"
+          "exec": "npm-check-updates --dep bundle --upgrade --target=minor --reject='@aws-cdk/aws-appsync-alpha,@aws-cdk/cloud-assembly-schema,@aws-cdk/cloudformation-diff,@aws-cdk/cx-api,@functionless/ast-reflection,aws-cdk-lib,aws-cdk,cdk-assets,constructs,typesafe-dynamodb,typescript'"
         },
         {
           "exec": "yarn install --check-files"

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -116,7 +116,7 @@ const project = new CustomTypescriptProject({
     "@swc/core",
     "@swc/register",
     "@swc/jest",
-    "@functionless/ast-reflection@file:../ast-reflection",
+    "@functionless/ast-reflection@^0.1.0",
   ],
   jestOptions: {
     jestConfig: {

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -116,7 +116,7 @@ const project = new CustomTypescriptProject({
     "@swc/core",
     "@swc/register",
     "@swc/jest",
-    "@functionless/ast-reflection",
+    "@functionless/ast-reflection@file:../ast-reflection",
   ],
   jestOptions: {
     jestConfig: {

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@aws-cdk/cloud-assembly-schema": "2.28.1",
     "@aws-cdk/cloudformation-diff": "2.28.1",
     "@aws-cdk/cx-api": "2.28.1",
-    "@functionless/ast-reflection": "file:../ast-reflection",
+    "@functionless/ast-reflection": "^0.1.0",
     "@swc/cli": "^0.1.57",
     "@swc/core": "1.2.218",
     "@swc/jest": "^0.2.22",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@aws-cdk/cloud-assembly-schema": "2.28.1",
     "@aws-cdk/cloudformation-diff": "2.28.1",
     "@aws-cdk/cx-api": "2.28.1",
-    "@functionless/ast-reflection": "0.0.1",
+    "@functionless/ast-reflection": "file:../ast-reflection",
     "@swc/cli": "^0.1.57",
     "@swc/core": "1.2.218",
     "@swc/jest": "^0.2.22",

--- a/src/api.ts
+++ b/src/api.ts
@@ -651,7 +651,9 @@ export class APIGatewayVTL extends VTL {
   public eval(node?: Expr | Stmt, returnVar?: string): string | void {
     if (isReturnStmt(node)) {
       return this.add(
-        this.exprToJson(node.expr ?? node.fork(new UndefinedLiteralExpr()))
+        this.exprToJson(
+          node.expr ?? node.fork(new UndefinedLiteralExpr(node.span))
+        )
       );
     } else if (
       isPropAccessExpr(node) &&

--- a/src/declaration.ts
+++ b/src/declaration.ts
@@ -11,6 +11,7 @@ import {
 import { Integration } from "./integration";
 import { BaseNode, FunctionlessNode } from "./node";
 import { NodeKind } from "./node-kind";
+import { Span } from "./span";
 import type {
   BlockStmt,
   CatchClause,
@@ -42,11 +43,15 @@ export class ClassDecl<C extends AnyClass = AnyClass> extends BaseDecl<
 > {
   readonly _classBrand?: C;
   constructor(
+    /**
+     * Range of text in the source file where this Node resides.
+     */
+    span: Span,
     readonly name: string,
     readonly heritage: Expr | undefined,
     readonly members: ClassMember[]
   ) {
-    super(NodeKind.ClassDecl, arguments);
+    super(NodeKind.ClassDecl, span, arguments);
     this.ensure(name, "name", ["string"]);
     this.ensureArrayOf(members, "members", NodeKind.ClassMember);
   }
@@ -61,15 +66,28 @@ export type ClassMember =
   | SetAccessorDecl;
 
 export class ClassStaticBlockDecl extends BaseDecl<NodeKind.ClassStaticBlockDecl> {
-  constructor(readonly block: BlockStmt) {
-    super(NodeKind.ClassStaticBlockDecl, arguments);
+  constructor(
+    /**
+     * Range of text in the source file where this Node resides.
+     */
+    span: Span,
+    readonly block: BlockStmt
+  ) {
+    super(NodeKind.ClassStaticBlockDecl, span, arguments);
     this.ensure(block, "block", [NodeKind.BlockStmt]);
   }
 }
 
 export class ConstructorDecl extends BaseDecl<NodeKind.ConstructorDecl> {
-  constructor(readonly parameters: ParameterDecl[], readonly body: BlockStmt) {
-    super(NodeKind.ConstructorDecl, arguments);
+  constructor(
+    /**
+     * Range of text in the source file where this Node resides.
+     */
+    span: Span,
+    readonly parameters: ParameterDecl[],
+    readonly body: BlockStmt
+  ) {
+    super(NodeKind.ConstructorDecl, span, arguments);
     this.ensureArrayOf(parameters, "parameters", [NodeKind.ParameterDecl]);
     this.ensure(body, "body", [NodeKind.BlockStmt]);
   }
@@ -77,6 +95,10 @@ export class ConstructorDecl extends BaseDecl<NodeKind.ConstructorDecl> {
 
 export class MethodDecl extends BaseDecl<NodeKind.MethodDecl> {
   constructor(
+    /**
+     * Range of text in the source file where this Node resides.
+     */
+    span: Span,
     readonly name: PropName,
     readonly parameters: ParameterDecl[],
     readonly body: BlockStmt,
@@ -107,7 +129,7 @@ export class MethodDecl extends BaseDecl<NodeKind.MethodDecl> {
      */
     readonly isAsterisk: boolean
   ) {
-    super(NodeKind.MethodDecl, arguments);
+    super(NodeKind.MethodDecl, span, arguments);
     this.ensure(name, "name", NodeKind.PropName);
     this.ensureArrayOf(parameters, "parameters", [NodeKind.ParameterDecl]);
     this.ensure(body, "body", [NodeKind.BlockStmt]);
@@ -118,11 +140,15 @@ export class MethodDecl extends BaseDecl<NodeKind.MethodDecl> {
 
 export class PropDecl extends BaseDecl<NodeKind.PropDecl> {
   constructor(
+    /**
+     * Range of text in the source file where this Node resides.
+     */
+    span: Span,
     readonly name: PropName,
     readonly isStatic: boolean,
     readonly initializer?: Expr
   ) {
-    super(NodeKind.PropDecl, arguments);
+    super(NodeKind.PropDecl, span, arguments);
     this.ensure(name, "name", NodeKind.PropName);
     this.ensure(isStatic, "isStatic", ["boolean"]);
     this.ensure(initializer, "initializer", ["undefined", "Expr"]);
@@ -133,8 +159,15 @@ export class GetAccessorDecl extends BaseDecl<
   NodeKind.GetAccessorDecl,
   ClassDecl | ClassExpr | ObjectLiteralExpr
 > {
-  constructor(readonly name: PropName, readonly body: BlockStmt) {
-    super(NodeKind.GetAccessorDecl, arguments);
+  constructor(
+    /**
+     * Range of text in the source file where this Node resides.
+     */
+    span: Span,
+    readonly name: PropName,
+    readonly body: BlockStmt
+  ) {
+    super(NodeKind.GetAccessorDecl, span, arguments);
     this.ensure(name, "name", NodeKind.PropName);
     this.ensure(body, "body", [NodeKind.BlockStmt]);
   }
@@ -144,11 +177,15 @@ export class SetAccessorDecl extends BaseDecl<
   ClassDecl | ClassExpr | ObjectLiteralExpr
 > {
   constructor(
+    /**
+     * Range of text in the source file where this Node resides.
+     */
+    span: Span,
     readonly name: PropName,
     readonly parameter: ParameterDecl,
     readonly body: BlockStmt
   ) {
-    super(NodeKind.SetAccessorDecl, arguments);
+    super(NodeKind.SetAccessorDecl, span, arguments);
     this.ensure(name, "name", NodeKind.PropName);
     this.ensure(parameter, "parameter", [NodeKind.ParameterDecl]);
     this.ensure(body, "body", [NodeKind.BlockStmt]);
@@ -165,6 +202,10 @@ export class FunctionDecl<
 > extends BaseDecl<NodeKind.FunctionDecl> {
   readonly _functionBrand?: F;
   constructor(
+    /**
+     * Range of text in the source file where this Node resides.
+     */
+    span: Span,
     // TODO: narrow to string once we migrate compile.ts to produce a 1:1 AST node
     // right now, Arrow and FunctionExpr are parsed to FunctionDecl, so name can be undefined
     // according to the spec, name is mandatory on a FunctionDecl and FunctionExpr
@@ -192,7 +233,7 @@ export class FunctionDecl<
      */
     readonly isAsterisk: boolean
   ) {
-    super(NodeKind.FunctionDecl, arguments);
+    super(NodeKind.FunctionDecl, span, arguments);
     this.ensure(name, "name", ["undefined", "string"]);
     this.ensureArrayOf(parameters, "parameters", [NodeKind.ParameterDecl]);
     this.ensure(body, "body", [NodeKind.BlockStmt]);
@@ -210,6 +251,10 @@ export class ParameterDecl extends BaseDecl<
   ArrowFunctionExpr | FunctionDecl | FunctionExpr | SetAccessorDecl
 > {
   constructor(
+    /**
+     * Range of text in the source file where this Node resides.
+     */
+    span: Span,
     readonly name: BindingName,
     readonly initializer: Expr | undefined,
     /**
@@ -219,7 +264,7 @@ export class ParameterDecl extends BaseDecl<
      * ```
      */ readonly isRest: boolean
   ) {
-    super(NodeKind.ParameterDecl, arguments);
+    super(NodeKind.ParameterDecl, span, arguments);
     this.ensure(name, "name", NodeKind.BindingNames);
     this.ensure(initializer, "initializer", ["undefined", "Expr"]);
     this.ensure(isRest, "isRest", ["boolean"]);
@@ -267,12 +312,16 @@ export class BindingElem extends BaseDecl<
   BindingPattern
 > {
   constructor(
+    /**
+     * Range of text in the source file where this Node resides.
+     */
+    span: Span,
     readonly name: BindingName,
     readonly rest: boolean,
     readonly propertyName?: PropName,
     readonly initializer?: Expr
   ) {
-    super(NodeKind.BindingElem, arguments);
+    super(NodeKind.BindingElem, span, arguments);
     this.ensure(name, "name", NodeKind.BindingNames);
     this.ensure(rest, "rest", ["boolean"]);
     this.ensure(propertyName, "propertyName", [
@@ -310,8 +359,14 @@ export class ObjectBinding extends BaseNode<
 > {
   readonly nodeKind: "Node" = "Node";
 
-  constructor(readonly bindings: BindingElem[]) {
-    super(NodeKind.ObjectBinding, arguments);
+  constructor(
+    /**
+     * Range of text in the source file where this Node resides.
+     */
+    span: Span,
+    readonly bindings: BindingElem[]
+  ) {
+    super(NodeKind.ObjectBinding, span, arguments);
     this.ensureArrayOf(bindings, "bindings", [NodeKind.BindingElem]);
   }
 }
@@ -342,8 +397,14 @@ export class ArrayBinding extends BaseNode<
 > {
   readonly nodeKind: "Node" = "Node";
 
-  constructor(readonly bindings: (BindingElem | OmittedExpr)[]) {
-    super(NodeKind.ArrayBinding, arguments);
+  constructor(
+    /**
+     * Range of text in the source file where this Node resides.
+     */
+    span: Span,
+    readonly bindings: (BindingElem | OmittedExpr)[]
+  ) {
+    super(NodeKind.ArrayBinding, span, arguments);
     this.ensureArrayOf(bindings, "bindings", [
       NodeKind.BindingElem,
       NodeKind.OmittedExpr,
@@ -366,8 +427,15 @@ export enum VariableDeclKind {
 export class VariableDecl<
   E extends Expr | undefined = Expr | undefined
 > extends BaseDecl<NodeKind.VariableDecl, VariableDeclParent> {
-  constructor(readonly name: BindingName, readonly initializer: E) {
-    super(NodeKind.VariableDecl, arguments);
+  constructor(
+    /**
+     * Range of text in the source file where this Node resides.
+     */
+    span: Span,
+    readonly name: BindingName,
+    readonly initializer: E
+  ) {
+    super(NodeKind.VariableDecl, span, arguments);
     this.ensure(name, "name", NodeKind.BindingNames);
     this.ensure(initializer, "initializer", ["undefined", "Expr"]);
   }
@@ -382,10 +450,14 @@ export class VariableDeclList extends BaseNode<
   readonly nodeKind: "Node" = "Node";
 
   constructor(
+    /**
+     * Range of text in the source file where this Node resides.
+     */
+    span: Span,
     readonly decls: VariableDecl[],
     readonly varKind: VariableDeclKind
   ) {
-    super(NodeKind.VariableDeclList, arguments);
+    super(NodeKind.VariableDeclList, span, arguments);
     this.ensureArrayOf(decls, "decls", [NodeKind.VariableDecl]);
   }
 }

--- a/src/error.ts
+++ b/src/error.ts
@@ -1,11 +1,18 @@
 import { BaseNode } from "./node";
 import { NodeKind } from "./node-kind";
+import { Span } from "./span";
 
 export class Err extends BaseNode<NodeKind.Err> {
   readonly nodeKind: "Err" = "Err";
 
-  constructor(readonly error: Error) {
-    super(NodeKind.Err, arguments);
+  constructor(
+    /**
+     * Range of text in the source file where this Node resides.
+     */
+    span: Span,
+    readonly error: Error
+  ) {
+    super(NodeKind.Err, span, arguments);
   }
 }
 

--- a/src/expression.ts
+++ b/src/expression.ts
@@ -18,6 +18,7 @@ import {
 } from "./guards";
 import { BaseNode, FunctionlessNode } from "./node";
 import { NodeKind } from "./node-kind";
+import { Span } from "./span";
 import type { BlockStmt, Stmt } from "./statement";
 import type { AnyClass, AnyFunction } from "./util";
 
@@ -82,6 +83,10 @@ export class ArrowFunctionExpr<
 > extends BaseExpr<NodeKind.ArrowFunctionExpr> {
   readonly _functionBrand?: F;
   constructor(
+    /**
+     * Range of text in the source file where this Node resides.
+     */
+    span: Span,
     readonly parameters: ParameterDecl[],
     readonly body: BlockStmt,
     /**
@@ -92,7 +97,7 @@ export class ArrowFunctionExpr<
      */
     readonly isAsync: boolean
   ) {
-    super(NodeKind.ArrowFunctionExpr, arguments);
+    super(NodeKind.ArrowFunctionExpr, span, arguments);
     this.ensure(body, "body", [NodeKind.BlockStmt]);
     this.ensureArrayOf(parameters, "parameters", [NodeKind.ParameterDecl]);
     this.ensure(isAsync, "isAsync", ["boolean"]);
@@ -104,6 +109,10 @@ export class FunctionExpr<
 > extends BaseExpr<NodeKind.FunctionExpr> {
   readonly _functionBrand?: F;
   constructor(
+    /**
+     * Range of text in the source file where this Node resides.
+     */
+    span: Span,
     readonly name: string | undefined,
     readonly parameters: ParameterDecl[],
     readonly body: BlockStmt,
@@ -128,7 +137,7 @@ export class FunctionExpr<
      */
     readonly isAsterisk: boolean
   ) {
-    super(NodeKind.FunctionExpr, arguments);
+    super(NodeKind.FunctionExpr, span, arguments);
     this.ensure(name, "name", ["undefined", "string"]);
     this.ensureArrayOf(parameters, "parameters", [NodeKind.ParameterDecl]);
     this.ensure(body, "body", [NodeKind.BlockStmt]);
@@ -143,11 +152,15 @@ export class ClassExpr<C extends AnyClass = AnyClass> extends BaseExpr<
 > {
   readonly _classBrand?: C;
   constructor(
+    /**
+     * Range of text in the source file where this Node resides.
+     */
+    span: Span,
     readonly name: string | undefined,
     readonly heritage: Expr | undefined,
     readonly members: ClassMember[]
   ) {
-    super(NodeKind.ClassExpr, arguments);
+    super(NodeKind.ClassExpr, span, arguments);
     this.ensure(name, "name", ["undefined", "string"]);
     this.ensure(heritage, "heritage", ["undefined", "Expr"]);
     this.ensureArrayOf(members, "members", NodeKind.ClassMember);
@@ -157,8 +170,15 @@ export class ClassExpr<C extends AnyClass = AnyClass> extends BaseExpr<
 export class ReferenceExpr<
   R = unknown
 > extends BaseExpr<NodeKind.ReferenceExpr> {
-  constructor(readonly name: string, readonly ref: () => R) {
-    super(NodeKind.ReferenceExpr, arguments);
+  constructor(
+    /**
+     * Range of text in the source file where this Node resides.
+     */
+    span: Span,
+    readonly name: string,
+    readonly ref: () => R
+  ) {
+    super(NodeKind.ReferenceExpr, span, arguments);
     this.ensure(name, "name", ["undefined", "string"]);
     this.ensure(ref, "ref", ["function"]);
   }
@@ -167,8 +187,14 @@ export class ReferenceExpr<
 export type VariableReference = Identifier | PropAccessExpr | ElementAccessExpr;
 
 export class Identifier extends BaseExpr<NodeKind.Identifier> {
-  constructor(readonly name: string) {
-    super(NodeKind.Identifier, arguments);
+  constructor(
+    /**
+     * Range of text in the source file where this Node resides.
+     */
+    span: Span,
+    readonly name: string
+  ) {
+    super(NodeKind.Identifier, span, arguments);
     this.ensure(name, "name", ["string"]);
   }
 
@@ -178,8 +204,14 @@ export class Identifier extends BaseExpr<NodeKind.Identifier> {
 }
 
 export class PrivateIdentifier extends BaseExpr<NodeKind.PrivateIdentifier> {
-  constructor(readonly name: `#${string}`) {
-    super(NodeKind.PrivateIdentifier, arguments);
+  constructor(
+    /**
+     * Range of text in the source file where this Node resides.
+     */
+    span: Span,
+    readonly name: `#${string}`
+  ) {
+    super(NodeKind.PrivateIdentifier, span, arguments);
     this.ensure(name, "name", ["string"]);
   }
 
@@ -190,6 +222,10 @@ export class PrivateIdentifier extends BaseExpr<NodeKind.PrivateIdentifier> {
 
 export class PropAccessExpr extends BaseExpr<NodeKind.PropAccessExpr> {
   constructor(
+    /**
+     * Range of text in the source file where this Node resides.
+     */
+    span: Span,
     readonly expr: Expr,
     readonly name: Identifier | PrivateIdentifier,
     /**
@@ -200,7 +236,7 @@ export class PropAccessExpr extends BaseExpr<NodeKind.PropAccessExpr> {
      */
     readonly isOptional: boolean
   ) {
-    super(NodeKind.PropAccessExpr, arguments);
+    super(NodeKind.PropAccessExpr, span, arguments);
     this.ensure(expr, "expr", ["Expr"]);
     this.ensure(name, "ref", [NodeKind.Identifier, NodeKind.PrivateIdentifier]);
   }
@@ -208,6 +244,10 @@ export class PropAccessExpr extends BaseExpr<NodeKind.PropAccessExpr> {
 
 export class ElementAccessExpr extends BaseExpr<NodeKind.ElementAccessExpr> {
   constructor(
+    /**
+     * Range of text in the source file where this Node resides.
+     */
+    span: Span,
     readonly expr: Expr,
     readonly element: Expr,
     /**
@@ -218,7 +258,7 @@ export class ElementAccessExpr extends BaseExpr<NodeKind.ElementAccessExpr> {
      */
     readonly isOptional: boolean
   ) {
-    super(NodeKind.ElementAccessExpr, arguments);
+    super(NodeKind.ElementAccessExpr, span, arguments);
     this.ensure(expr, "expr", ["Expr"]);
     this.ensure(element, "element", ["Expr"]);
     this.ensure(isOptional, "isOptional", ["undefined", "boolean"]);
@@ -226,8 +266,14 @@ export class ElementAccessExpr extends BaseExpr<NodeKind.ElementAccessExpr> {
 }
 
 export class Argument extends BaseExpr<NodeKind.Argument, CallExpr | NewExpr> {
-  constructor(readonly expr: Expr) {
-    super(NodeKind.Argument, arguments);
+  constructor(
+    /**
+     * Range of text in the source file where this Node resides.
+     */
+    span: Span,
+    readonly expr: Expr
+  ) {
+    super(NodeKind.Argument, span, arguments);
     this.ensure(expr, "element", ["Expr"]);
   }
 }
@@ -238,22 +284,44 @@ export class CallExpr<
     | SuperKeyword
     | ImportKeyword
 > extends BaseExpr<NodeKind.CallExpr> {
-  constructor(readonly expr: E, readonly args: Argument[]) {
-    super(NodeKind.CallExpr, arguments);
+  constructor(
+    /**
+     * Range of text in the source file where this Node resides.
+     */
+    span: Span,
+    readonly expr: E,
+    readonly args: Argument[]
+  ) {
+    super(NodeKind.CallExpr, span, arguments);
   }
 }
 
 export class NewExpr extends BaseExpr<NodeKind.NewExpr> {
-  constructor(readonly expr: Expr, readonly args: Argument[]) {
-    super(NodeKind.NewExpr, arguments);
+  constructor(
+    /**
+     * Range of text in the source file where this Node resides.
+     */
+    span: Span,
+    readonly expr: Expr,
+    readonly args: Argument[]
+  ) {
+    super(NodeKind.NewExpr, span, arguments);
     this.ensure(expr, "expr", ["Expr"]);
     this.ensureArrayOf(args, "args", [NodeKind.Argument]);
   }
 }
 
 export class ConditionExpr extends BaseExpr<NodeKind.ConditionExpr> {
-  constructor(readonly when: Expr, readonly then: Expr, readonly _else: Expr) {
-    super(NodeKind.ConditionExpr, arguments);
+  constructor(
+    /**
+     * Range of text in the source file where this Node resides.
+     */
+    span: Span,
+    readonly when: Expr,
+    readonly then: Expr,
+    readonly _else: Expr
+  ) {
+    super(NodeKind.ConditionExpr, span, arguments);
     this.ensure(when, "when", ["Expr"]);
     this.ensure(then, "then", ["Expr"]);
     this.ensure(_else, "else", ["Expr"]);
@@ -331,11 +399,15 @@ export type BinaryOp =
 
 export class BinaryExpr extends BaseExpr<NodeKind.BinaryExpr> {
   constructor(
+    /**
+     * Range of text in the source file where this Node resides.
+     */
+    span: Span,
     readonly left: Expr,
     readonly op: BinaryOp,
     readonly right: Expr
   ) {
-    super(NodeKind.BinaryExpr, arguments);
+    super(NodeKind.BinaryExpr, span, arguments);
     this.ensure(left, "left", ["Expr"]);
     this.ensure(right, "right", ["Expr"]);
   }
@@ -352,15 +424,29 @@ export type PostfixUnaryOp = "--" | "++";
 export type UnaryOp = "!" | "+" | "-" | "~" | PostfixUnaryOp;
 
 export class UnaryExpr extends BaseExpr<NodeKind.UnaryExpr> {
-  constructor(readonly op: UnaryOp, readonly expr: Expr) {
-    super(NodeKind.UnaryExpr, arguments);
+  constructor(
+    /**
+     * Range of text in the source file where this Node resides.
+     */
+    span: Span,
+    readonly op: UnaryOp,
+    readonly expr: Expr
+  ) {
+    super(NodeKind.UnaryExpr, span, arguments);
     this.ensure(expr, "expr", ["Expr"]);
   }
 }
 
 export class PostfixUnaryExpr extends BaseExpr<NodeKind.PostfixUnaryExpr> {
-  constructor(readonly op: PostfixUnaryOp, readonly expr: Expr) {
-    super(NodeKind.PostfixUnaryExpr, arguments);
+  constructor(
+    /**
+     * Range of text in the source file where this Node resides.
+     */
+    span: Span,
+    readonly op: PostfixUnaryOp,
+    readonly expr: Expr
+  ) {
+    super(NodeKind.PostfixUnaryExpr, span, arguments);
     this.ensure(expr, "expr", ["Expr"]);
   }
 }
@@ -369,50 +455,90 @@ export class PostfixUnaryExpr extends BaseExpr<NodeKind.PostfixUnaryExpr> {
 
 export class NullLiteralExpr extends BaseExpr<NodeKind.NullLiteralExpr> {
   readonly value = null;
-  constructor() {
-    super(NodeKind.NullLiteralExpr, arguments);
+  constructor(
+    /**
+     * Range of text in the source file where this Node resides.
+     */
+    span: Span
+  ) {
+    super(NodeKind.NullLiteralExpr, span, arguments);
   }
 }
 
 export class UndefinedLiteralExpr extends BaseExpr<NodeKind.UndefinedLiteralExpr> {
   readonly value = undefined;
 
-  constructor() {
-    super(NodeKind.UndefinedLiteralExpr, arguments);
+  constructor(
+    /**
+     * Range of text in the source file where this Node resides.
+     */
+    span: Span
+  ) {
+    super(NodeKind.UndefinedLiteralExpr, span, arguments);
   }
 }
 
 export class BooleanLiteralExpr extends BaseExpr<NodeKind.BooleanLiteralExpr> {
-  constructor(readonly value: boolean) {
-    super(NodeKind.BooleanLiteralExpr, arguments);
+  constructor(
+    /**
+     * Range of text in the source file where this Node resides.
+     */
+    span: Span,
+    readonly value: boolean
+  ) {
+    super(NodeKind.BooleanLiteralExpr, span, arguments);
     this.ensure(value, "value", ["boolean"]);
   }
 }
 
 export class BigIntExpr extends BaseExpr<NodeKind.BigIntExpr> {
-  constructor(readonly value: bigint) {
-    super(NodeKind.BigIntExpr, arguments);
+  constructor(
+    /**
+     * Range of text in the source file where this Node resides.
+     */
+    span: Span,
+    readonly value: bigint
+  ) {
+    super(NodeKind.BigIntExpr, span, arguments);
     this.ensure(value, "value", ["bigint"]);
   }
 }
 
 export class NumberLiteralExpr extends BaseExpr<NodeKind.NumberLiteralExpr> {
-  constructor(readonly value: number) {
-    super(NodeKind.NumberLiteralExpr, arguments);
+  constructor(
+    /**
+     * Range of text in the source file where this Node resides.
+     */
+    span: Span,
+    readonly value: number
+  ) {
+    super(NodeKind.NumberLiteralExpr, span, arguments);
     this.ensure(value, "value", ["number"]);
   }
 }
 
 export class StringLiteralExpr extends BaseExpr<NodeKind.StringLiteralExpr> {
-  constructor(readonly value: string) {
-    super(NodeKind.StringLiteralExpr, arguments);
+  constructor(
+    /**
+     * Range of text in the source file where this Node resides.
+     */
+    span: Span,
+    readonly value: string
+  ) {
+    super(NodeKind.StringLiteralExpr, span, arguments);
     this.ensure(value, "value", ["string"]);
   }
 }
 
 export class ArrayLiteralExpr extends BaseExpr<NodeKind.ArrayLiteralExpr> {
-  constructor(readonly items: Expr[]) {
-    super(NodeKind.ArrayLiteralExpr, arguments);
+  constructor(
+    /**
+     * Range of text in the source file where this Node resides.
+     */
+    span: Span,
+    readonly items: Expr[]
+  ) {
+    super(NodeKind.ArrayLiteralExpr, span, arguments);
     this.ensureArrayOf(items, "items", ["Expr"]);
   }
 }
@@ -425,8 +551,14 @@ export type ObjectElementExpr =
   | SpreadAssignExpr;
 
 export class ObjectLiteralExpr extends BaseExpr<NodeKind.ObjectLiteralExpr> {
-  constructor(readonly properties: ObjectElementExpr[]) {
-    super(NodeKind.ObjectLiteralExpr, arguments);
+  constructor(
+    /**
+     * Range of text in the source file where this Node resides.
+     */
+    span: Span,
+    readonly properties: ObjectElementExpr[]
+  ) {
+    super(NodeKind.ObjectLiteralExpr, span, arguments);
     this.ensureArrayOf(properties, "properties", NodeKind.ObjectElementExpr);
   }
 
@@ -460,8 +592,15 @@ export class PropAssignExpr extends BaseExpr<
   NodeKind.PropAssignExpr,
   ObjectLiteralExpr
 > {
-  constructor(readonly name: PropName, readonly expr: Expr) {
-    super(NodeKind.PropAssignExpr, arguments);
+  constructor(
+    /**
+     * Range of text in the source file where this Node resides.
+     */
+    span: Span,
+    readonly name: PropName,
+    readonly expr: Expr
+  ) {
+    super(NodeKind.PropAssignExpr, span, arguments);
     this.ensure(expr, "expr", ["Expr"]);
   }
 }
@@ -470,8 +609,14 @@ export class ComputedPropertyNameExpr extends BaseExpr<
   NodeKind.ComputedPropertyNameExpr,
   PropAssignExpr
 > {
-  constructor(readonly expr: Expr) {
-    super(NodeKind.ComputedPropertyNameExpr, arguments);
+  constructor(
+    /**
+     * Range of text in the source file where this Node resides.
+     */
+    span: Span,
+    readonly expr: Expr
+  ) {
+    super(NodeKind.ComputedPropertyNameExpr, span, arguments);
     this.ensure(expr, "expr", ["Expr"]);
   }
 }
@@ -480,8 +625,14 @@ export class SpreadAssignExpr extends BaseExpr<
   NodeKind.SpreadAssignExpr,
   ObjectLiteralExpr
 > {
-  constructor(readonly expr: Expr) {
-    super(NodeKind.SpreadAssignExpr, arguments);
+  constructor(
+    /**
+     * Range of text in the source file where this Node resides.
+     */
+    span: Span,
+    readonly expr: Expr
+  ) {
+    super(NodeKind.SpreadAssignExpr, span, arguments);
     this.ensure(expr, "expr", ["Expr"]);
   }
 }
@@ -490,8 +641,14 @@ export class SpreadElementExpr extends BaseExpr<
   NodeKind.SpreadElementExpr,
   ObjectLiteralExpr
 > {
-  constructor(readonly expr: Expr) {
-    super(NodeKind.SpreadElementExpr, arguments);
+  constructor(
+    /**
+     * Range of text in the source file where this Node resides.
+     */
+    span: Span,
+    readonly expr: Expr
+  ) {
+    super(NodeKind.SpreadElementExpr, span, arguments);
     this.ensure(expr, "expr", ["Expr"]);
   }
 }
@@ -506,8 +663,14 @@ export type TemplateLiteral = TemplateExpr | NoSubstitutionTemplateLiteralExpr;
  * ```
  */
 export class NoSubstitutionTemplateLiteralExpr extends BaseExpr<NodeKind.NoSubstitutionTemplateLiteral> {
-  constructor(readonly text: string) {
-    super(NodeKind.NoSubstitutionTemplateLiteral, arguments);
+  constructor(
+    /**
+     * Range of text in the source file where this Node resides.
+     */
+    span: Span,
+    readonly text: string
+  ) {
+    super(NodeKind.NoSubstitutionTemplateLiteral, span, arguments);
     this.ensure(text, "text", ["string"]);
   }
 }
@@ -521,6 +684,10 @@ export class NoSubstitutionTemplateLiteralExpr extends BaseExpr<NodeKind.NoSubst
  */
 export class TemplateExpr extends BaseExpr<NodeKind.TemplateExpr> {
   constructor(
+    /**
+     * Range of text in the source file where this Node resides.
+     */
+    span: Span,
     /**
      * The literal text prefix of the template.
      * ```
@@ -538,7 +705,7 @@ export class TemplateExpr extends BaseExpr<NodeKind.TemplateExpr> {
       TemplateSpan<TemplateTail>
     ]
   ) {
-    super(NodeKind.TemplateExpr, arguments);
+    super(NodeKind.TemplateExpr, span, arguments);
     this.ensure(head, "head", [NodeKind.TemplateHead]);
     this.ensureArrayOf(spans, "spans", [NodeKind.TemplateSpan]);
   }
@@ -552,8 +719,15 @@ export class TemplateExpr extends BaseExpr<NodeKind.TemplateExpr> {
  * ```
  */
 export class TaggedTemplateExpr extends BaseExpr<NodeKind.TaggedTemplateExpr> {
-  constructor(readonly tag: Expr, readonly template: TemplateLiteral) {
-    super(NodeKind.TaggedTemplateExpr, arguments);
+  constructor(
+    /**
+     * Range of text in the source file where this Node resides.
+     */
+    span: Span,
+    readonly tag: Expr,
+    readonly template: TemplateLiteral
+  ) {
+    super(NodeKind.TaggedTemplateExpr, span, arguments);
     this.ensure(tag, "tag", ["Expr"]);
     this.ensure(template, "template", [
       NodeKind.TemplateExpr,
@@ -579,8 +753,14 @@ export class TaggedTemplateExpr extends BaseExpr<NodeKind.TaggedTemplateExpr> {
 export class TemplateHead extends BaseNode<NodeKind.TemplateHead> {
   readonly nodeKind = "Node";
 
-  constructor(readonly text: string) {
-    super(NodeKind.TemplateHead, arguments);
+  constructor(
+    /**
+     * Range of text in the source file where this Node resides.
+     */
+    span: Span,
+    readonly text: string
+  ) {
+    super(NodeKind.TemplateHead, span, arguments);
     this.ensure(text, "text", ["string"]);
   }
 }
@@ -597,8 +777,15 @@ export class TemplateSpan<
 > extends BaseNode<NodeKind.TemplateSpan> {
   readonly nodeKind = "Node";
 
-  constructor(readonly expr: Expr, readonly literal: Literal) {
-    super(NodeKind.TemplateSpan, arguments);
+  constructor(
+    /**
+     * Range of text in the source file where this Node resides.
+     */
+    span: Span,
+    readonly expr: Expr,
+    readonly literal: Literal
+  ) {
+    super(NodeKind.TemplateSpan, span, arguments);
     this.ensure(expr, "expr", ["Expr"]);
     this.ensure(literal, "literal", [
       NodeKind.TemplateMiddle,
@@ -610,8 +797,14 @@ export class TemplateSpan<
 export class TemplateMiddle extends BaseNode<NodeKind.TemplateMiddle> {
   readonly nodeKind = "Node";
 
-  constructor(readonly text: string) {
-    super(NodeKind.TemplateMiddle, arguments);
+  constructor(
+    /**
+     * Range of text in the source file where this Node resides.
+     */
+    span: Span,
+    readonly text: string
+  ) {
+    super(NodeKind.TemplateMiddle, span, arguments);
     this.ensure(text, "text", ["string"]);
   }
 }
@@ -619,22 +812,40 @@ export class TemplateMiddle extends BaseNode<NodeKind.TemplateMiddle> {
 export class TemplateTail extends BaseNode<NodeKind.TemplateTail> {
   readonly nodeKind = "Node";
 
-  constructor(readonly text: string) {
-    super(NodeKind.TemplateTail, arguments);
+  constructor(
+    /**
+     * Range of text in the source file where this Node resides.
+     */
+    span: Span,
+    readonly text: string
+  ) {
+    super(NodeKind.TemplateTail, span, arguments);
     this.ensure(text, "text", ["string"]);
   }
 }
 
 export class TypeOfExpr extends BaseExpr<NodeKind.TypeOfExpr> {
-  constructor(readonly expr: Expr) {
-    super(NodeKind.TypeOfExpr, arguments);
+  constructor(
+    /**
+     * Range of text in the source file where this Node resides.
+     */
+    span: Span,
+    readonly expr: Expr
+  ) {
+    super(NodeKind.TypeOfExpr, span, arguments);
     this.ensure(expr, "expr", ["Expr"]);
   }
 }
 
 export class AwaitExpr extends BaseExpr<NodeKind.AwaitExpr> {
-  constructor(readonly expr: Expr) {
-    super(NodeKind.AwaitExpr, arguments);
+  constructor(
+    /**
+     * Range of text in the source file where this Node resides.
+     */
+    span: Span,
+    readonly expr: Expr
+  ) {
+    super(NodeKind.AwaitExpr, span, arguments);
     this.ensure(expr, "expr", ["Expr"]);
   }
 }
@@ -642,11 +853,15 @@ export class AwaitExpr extends BaseExpr<NodeKind.AwaitExpr> {
 export class ThisExpr<T = any> extends BaseExpr<NodeKind.ThisExpr> {
   constructor(
     /**
+     * Range of text in the source file where this Node resides.
+     */
+    span: Span,
+    /**
      * Produce the value of `this`
      */
     readonly ref: () => T
   ) {
-    super(NodeKind.ThisExpr, arguments);
+    super(NodeKind.ThisExpr, span, arguments);
     this.ensure(ref, "ref", ["function"]);
   }
 }
@@ -657,20 +872,34 @@ export class SuperKeyword extends BaseNode<NodeKind.SuperKeyword> {
   // 1. call in a constructor - `super(..)`
   // 2. call a method on it - `super.method(..)`.
   readonly nodeKind = "Node";
-  constructor() {
-    super(NodeKind.SuperKeyword, arguments);
+  constructor(
+    /**
+     * Range of text in the source file where this Node resides.
+     */
+    span: Span
+  ) {
+    super(NodeKind.SuperKeyword, span, arguments);
   }
 }
 
 export class ImportKeyword extends BaseNode<NodeKind.ImportKeyword> {
   readonly nodeKind = "Node";
-  constructor() {
-    super(NodeKind.ImportKeyword, arguments);
+  constructor(
+    /**
+     * Range of text in the source file where this Node resides.
+     */
+    span: Span
+  ) {
+    super(NodeKind.ImportKeyword, span, arguments);
   }
 }
 
 export class YieldExpr extends BaseExpr<NodeKind.YieldExpr> {
   constructor(
+    /**
+     * Range of text in the source file where this Node resides.
+     */
+    span: Span,
     /**
      * The expression to yield (or delegate) to.
      */
@@ -680,33 +909,49 @@ export class YieldExpr extends BaseExpr<NodeKind.YieldExpr> {
      */
     readonly delegate: boolean
   ) {
-    super(NodeKind.YieldExpr, arguments);
+    super(NodeKind.YieldExpr, span, arguments);
     this.ensure(expr, "expr", ["undefined", "Expr"]);
     this.ensure(delegate, "delegate", ["boolean"]);
   }
 }
 
 export class RegexExpr extends BaseExpr<NodeKind.RegexExpr> {
-  constructor(readonly regex: RegExp) {
-    super(NodeKind.RegexExpr, arguments);
+  constructor(
+    /**
+     * Range of text in the source file where this Node resides.
+     */
+    span: Span,
+    readonly regex: RegExp
+  ) {
+    super(NodeKind.RegexExpr, span, arguments);
   }
 }
 
 export class VoidExpr extends BaseExpr<NodeKind.VoidExpr> {
   constructor(
     /**
+     * Range of text in the source file where this Node resides.
+     */
+    span: Span,
+    /**
      * The expression to yield (or delegate) to.
      */
     readonly expr: Expr
   ) {
-    super(NodeKind.VoidExpr, arguments);
+    super(NodeKind.VoidExpr, span, arguments);
     this.ensure(expr, "expr", ["Expr"]);
   }
 }
 
 export class DeleteExpr extends BaseExpr<NodeKind.DeleteExpr> {
-  constructor(readonly expr: PropAccessExpr | ElementAccessExpr) {
-    super(NodeKind.DeleteExpr, arguments);
+  constructor(
+    /**
+     * Range of text in the source file where this Node resides.
+     */
+    span: Span,
+    readonly expr: PropAccessExpr | ElementAccessExpr
+  ) {
+    super(NodeKind.DeleteExpr, span, arguments);
     this.ensure(expr, "expr", [
       NodeKind.PropAccessExpr,
       NodeKind.ElementAccessExpr,
@@ -715,8 +960,14 @@ export class DeleteExpr extends BaseExpr<NodeKind.DeleteExpr> {
 }
 
 export class ParenthesizedExpr extends BaseExpr<NodeKind.ParenthesizedExpr> {
-  constructor(readonly expr: Expr) {
-    super(NodeKind.ParenthesizedExpr, arguments);
+  constructor(
+    /**
+     * Range of text in the source file where this Node resides.
+     */
+    span: Span,
+    readonly expr: Expr
+  ) {
+    super(NodeKind.ParenthesizedExpr, span, arguments);
     this.ensure(expr, "expr", ["Expr"]);
   }
 
@@ -729,8 +980,13 @@ export class ParenthesizedExpr extends BaseExpr<NodeKind.ParenthesizedExpr> {
 }
 
 export class OmittedExpr extends BaseExpr<NodeKind.OmittedExpr> {
-  constructor() {
-    super(NodeKind.OmittedExpr, arguments);
+  constructor(
+    /**
+     * Range of text in the source file where this Node resides.
+     */
+    span: Span
+  ) {
+    super(NodeKind.OmittedExpr, span, arguments);
   }
 }
 

--- a/src/integration.ts
+++ b/src/integration.ts
@@ -306,7 +306,8 @@ export function findDeepIntegrations(
           ...integrations.map((integration) =>
             node.fork(
               new CallExpr(
-                new ReferenceExpr("", () => integration),
+                node.span,
+                new ReferenceExpr(node.expr.span, "", () => integration),
                 node.args.map((arg) => arg.clone())
               )
             )

--- a/src/node.ts
+++ b/src/node.ts
@@ -47,6 +47,7 @@ import {
 } from "./guards";
 import type { NodeCtor } from "./node-ctor";
 import { NodeKind, NodeKindName, getNodeKindName } from "./node-kind";
+import type { Span } from "./span";
 import type { BlockStmt, CatchClause, Stmt } from "./statement";
 
 export type FunctionlessNode =
@@ -88,7 +89,11 @@ export abstract class BaseNode<
 
   readonly _arguments: ConstructorParameters<NodeCtor<this["kind"]>>;
 
-  constructor(readonly kind: Kind, _arguments: IArguments) {
+  constructor(
+    readonly kind: Kind,
+    readonly span: Span,
+    _arguments: IArguments
+  ) {
     this._arguments = Array.from(_arguments) as any;
     const setParent = (node: any) => {
       if (isNode(node)) {
@@ -109,9 +114,11 @@ export abstract class BaseNode<
   }
 
   public toSExpr(): [kind: this["kind"], ...args: any[]] {
+    const [span, ...rest] = this._arguments;
     return [
       this.kind,
-      ...this._arguments.map(function toSExpr(arg: any): any {
+      span,
+      ...rest.map(function toSExpr(arg: any): any {
         if (isNode(arg)) {
           return arg.toSExpr();
         } else if (Array.isArray(arg)) {

--- a/src/s-expression.ts
+++ b/src/s-expression.ts
@@ -1,6 +1,7 @@
 import { FunctionlessNode } from "./node";
 import { getCtor, NodeInstance } from "./node-ctor";
 import { NodeKind } from "./node-kind";
+import { isSpan, Span } from "./span";
 
 /**
  * A memory-efficient representation of a serializer {@link FunctionlessNode} as an s-expression tuple.
@@ -16,6 +17,7 @@ import { NodeKind } from "./node-kind";
  */
 export type SExpr<Node extends FunctionlessNode = FunctionlessNode> = [
   kind: Node["kind"],
+  span: Span,
   ...args: any[] // we could make these more type-safe, but TS has instantiation problems because of eager evaluation of spreads on recursive tuple types
 ];
 
@@ -27,9 +29,15 @@ export type SExpr<Node extends FunctionlessNode = FunctionlessNode> = [
 export function parseSExpr<Kind extends NodeKind>(
   expr: [kind: Kind, ...args: any[]]
 ): NodeInstance<Kind> {
-  const [kind, ...args] = expr;
+  const [kind, span, ...args] = expr;
+  if (!isSpan(span)) {
+    throw new Error(
+      `The first argument in a s-expression must always be the Node's Span, but found ${span}.`
+    );
+  }
   const ctor = getCtor(kind);
   return new ctor(
+    span,
     ...(<any>args.map(function parse(item: any): any {
       if (Array.isArray(item)) {
         if (typeof item[0] === "number") {

--- a/src/span.ts
+++ b/src/span.ts
@@ -1,0 +1,30 @@
+/**
+ * A {@link Span} is a range of text within a source file, represented
+ * by two numbers, a `start` and `end` character position.
+ */
+export type Span = [
+  /**
+   * Character position where this span starts.
+   */
+  start: number,
+  /**
+   * Character position where this span ends.
+   */
+  end: number
+];
+
+/**
+ * Determines if {@link a} is a {@link Span}.
+ */
+export function isSpan(a: any): a is Span {
+  return (
+    Array.isArray(a) &&
+    a.length === 2 &&
+    typeof a[0] === "number" &&
+    typeof a[1] === "number"
+  );
+}
+
+export function emptySpan(): Span {
+  return [0, 0];
+}

--- a/src/statement.ts
+++ b/src/statement.ts
@@ -7,6 +7,7 @@ import { Expr, FunctionExpr, Identifier } from "./expression";
 import { isTryStmt } from "./guards";
 import { BaseNode, FunctionlessNode } from "./node";
 import { NodeKind } from "./node-kind";
+import { Span } from "./span";
 
 /**
  * A {@link Stmt} (Statement) is unit of execution that does not yield any value. They are translated
@@ -52,15 +53,27 @@ export abstract class BaseStmt<
 }
 
 export class ExprStmt extends BaseStmt<NodeKind.ExprStmt> {
-  constructor(readonly expr: Expr) {
-    super(NodeKind.ExprStmt, arguments);
+  constructor(
+    /**
+     * Range of text in the source file where this Node resides.
+     */
+    span: Span,
+    readonly expr: Expr
+  ) {
+    super(NodeKind.ExprStmt, span, arguments);
     this.ensure(expr, "expr", ["Expr"]);
   }
 }
 
 export class VariableStmt extends BaseStmt<NodeKind.VariableStmt> {
-  constructor(readonly declList: VariableDeclList) {
-    super(NodeKind.VariableStmt, arguments);
+  constructor(
+    /**
+     * Range of text in the source file where this Node resides.
+     */
+    span: Span,
+    readonly declList: VariableDeclList
+  ) {
+    super(NodeKind.VariableStmt, span, arguments);
     this.ensure(declList, "declList", [NodeKind.VariableDeclList]);
   }
 }
@@ -78,8 +91,14 @@ export type BlockStmtParent =
   | WhileStmt;
 
 export class BlockStmt extends BaseStmt<NodeKind.BlockStmt, BlockStmtParent> {
-  constructor(readonly statements: Stmt[]) {
-    super(NodeKind.BlockStmt, arguments);
+  constructor(
+    /**
+     * Range of text in the source file where this Node resides.
+     */
+    span: Span,
+    readonly statements: Stmt[]
+  ) {
+    super(NodeKind.BlockStmt, span, arguments);
     this.ensureArrayOf(statements, "statements", ["Stmt"]);
     statements.forEach((stmt, i) => {
       stmt.prev = i > 0 ? statements[i - 1] : undefined;
@@ -117,15 +136,29 @@ export class BlockStmt extends BaseStmt<NodeKind.BlockStmt, BlockStmtParent> {
 }
 
 export class ReturnStmt extends BaseStmt<NodeKind.ReturnStmt> {
-  constructor(readonly expr: Expr | undefined) {
-    super(NodeKind.ReturnStmt, arguments);
+  constructor(
+    /**
+     * Range of text in the source file where this Node resides.
+     */
+    span: Span,
+    readonly expr: Expr | undefined
+  ) {
+    super(NodeKind.ReturnStmt, span, arguments);
     this.ensure(expr, "expr", ["undefined", "Expr"]);
   }
 }
 
 export class IfStmt extends BaseStmt<NodeKind.IfStmt> {
-  constructor(readonly when: Expr, readonly then: Stmt, readonly _else?: Stmt) {
-    super(NodeKind.IfStmt, arguments);
+  constructor(
+    /**
+     * Range of text in the source file where this Node resides.
+     */
+    span: Span,
+    readonly when: Expr,
+    readonly then: Stmt,
+    readonly _else?: Stmt
+  ) {
+    super(NodeKind.IfStmt, span, arguments);
     this.ensure(when, "when", ["Expr"]);
     this.ensure(then, "then", ["Stmt"]);
     this.ensure(_else, "else", ["undefined", "Stmt"]);
@@ -134,6 +167,10 @@ export class IfStmt extends BaseStmt<NodeKind.IfStmt> {
 
 export class ForOfStmt extends BaseStmt<NodeKind.ForOfStmt> {
   constructor(
+    /**
+     * Range of text in the source file where this Node resides.
+     */
+    span: Span,
     readonly initializer: VariableDecl | Identifier,
     readonly expr: Expr,
     readonly body: BlockStmt,
@@ -145,7 +182,7 @@ export class ForOfStmt extends BaseStmt<NodeKind.ForOfStmt> {
      */
     readonly isAwait: boolean
   ) {
-    super(NodeKind.ForOfStmt, arguments);
+    super(NodeKind.ForOfStmt, span, arguments);
     this.ensure(initializer, "initializer", [
       NodeKind.VariableDecl,
       NodeKind.Identifier,
@@ -157,22 +194,30 @@ export class ForOfStmt extends BaseStmt<NodeKind.ForOfStmt> {
 
 export class ForInStmt extends BaseStmt<NodeKind.ForInStmt> {
   constructor(
+    /**
+     * Range of text in the source file where this Node resides.
+     */
+    span: Span,
     readonly initializer: VariableDecl | Identifier,
     readonly expr: Expr,
     readonly body: BlockStmt
   ) {
-    super(NodeKind.ForInStmt, arguments);
+    super(NodeKind.ForInStmt, span, arguments);
   }
 }
 
 export class ForStmt extends BaseStmt<NodeKind.ForStmt> {
   constructor(
+    /**
+     * Range of text in the source file where this Node resides.
+     */
+    span: Span,
     readonly body: BlockStmt,
     readonly initializer?: VariableDeclList | Expr,
     readonly condition?: Expr,
     readonly incrementor?: Expr
   ) {
-    super(NodeKind.ForStmt, arguments);
+    super(NodeKind.ForStmt, span, arguments);
     this.ensure(body, "body", [NodeKind.BlockStmt]);
     this.ensure(initializer, "initializer", [
       "undefined",
@@ -185,15 +230,27 @@ export class ForStmt extends BaseStmt<NodeKind.ForStmt> {
 }
 
 export class BreakStmt extends BaseStmt<NodeKind.BreakStmt> {
-  constructor(readonly label?: Identifier) {
-    super(NodeKind.BreakStmt, arguments);
+  constructor(
+    /**
+     * Range of text in the source file where this Node resides.
+     */
+    span: Span,
+    readonly label?: Identifier
+  ) {
+    super(NodeKind.BreakStmt, span, arguments);
     this.ensure(label, "label", ["undefined", NodeKind.Identifier]);
   }
 }
 
 export class ContinueStmt extends BaseStmt<NodeKind.ContinueStmt> {
-  constructor(readonly label?: Identifier) {
-    super(NodeKind.ContinueStmt, arguments);
+  constructor(
+    /**
+     * Range of text in the source file where this Node resides.
+     */
+    span: Span,
+    readonly label?: Identifier
+  ) {
+    super(NodeKind.ContinueStmt, span, arguments);
     this.ensure(label, "label", ["undefined", NodeKind.Identifier]);
   }
 }
@@ -206,11 +263,15 @@ export interface FinallyBlock extends BlockStmt {
 
 export class TryStmt extends BaseStmt<NodeKind.TryStmt> {
   constructor(
+    /**
+     * Range of text in the source file where this Node resides.
+     */
+    span: Span,
     readonly tryBlock: BlockStmt,
     readonly catchClause?: CatchClause,
     readonly finallyBlock?: FinallyBlock
   ) {
-    super(NodeKind.TryStmt, arguments);
+    super(NodeKind.TryStmt, span, arguments);
     this.ensure(tryBlock, "tryBlock", [NodeKind.BlockStmt]);
     this.ensure(catchClause, "catchClause", [
       "undefined",
@@ -225,10 +286,14 @@ export class TryStmt extends BaseStmt<NodeKind.TryStmt> {
 
 export class CatchClause extends BaseStmt<NodeKind.CatchClause, TryStmt> {
   constructor(
+    /**
+     * Range of text in the source file where this Node resides.
+     */
+    span: Span,
     readonly variableDecl: VariableDecl | undefined,
     readonly block: BlockStmt
   ) {
-    super(NodeKind.CatchClause, arguments);
+    super(NodeKind.CatchClause, span, arguments);
     this.ensure(variableDecl, "variableDecl", [
       "undefined",
       NodeKind.VariableDecl,
@@ -238,45 +303,84 @@ export class CatchClause extends BaseStmt<NodeKind.CatchClause, TryStmt> {
 }
 
 export class ThrowStmt extends BaseStmt<NodeKind.ThrowStmt> {
-  constructor(readonly expr: Expr) {
-    super(NodeKind.ThrowStmt, arguments);
+  constructor(
+    /**
+     * Range of text in the source file where this Node resides.
+     */
+    span: Span,
+    readonly expr: Expr
+  ) {
+    super(NodeKind.ThrowStmt, span, arguments);
     this.ensure(expr, "expr", ["Expr"]);
   }
 }
 
 export class WhileStmt extends BaseStmt<NodeKind.WhileStmt> {
-  constructor(readonly condition: Expr, readonly block: BlockStmt) {
-    super(NodeKind.WhileStmt, arguments);
+  constructor(
+    /**
+     * Range of text in the source file where this Node resides.
+     */
+    span: Span,
+    readonly condition: Expr,
+    readonly block: BlockStmt
+  ) {
+    super(NodeKind.WhileStmt, span, arguments);
     this.ensure(condition, "condition", ["Expr"]);
     this.ensure(block, "block", [NodeKind.BlockStmt]);
   }
 }
 
 export class DoStmt extends BaseStmt<NodeKind.DoStmt> {
-  constructor(readonly block: BlockStmt, readonly condition: Expr) {
-    super(NodeKind.DoStmt, arguments);
+  constructor(
+    /**
+     * Range of text in the source file where this Node resides.
+     */
+    span: Span,
+    readonly block: BlockStmt,
+    readonly condition: Expr
+  ) {
+    super(NodeKind.DoStmt, span, arguments);
     this.ensure(block, "block", [NodeKind.BlockStmt]);
     this.ensure(condition, "condition", ["Expr"]);
   }
 }
 
 export class LabelledStmt extends BaseStmt<NodeKind.LabelledStmt> {
-  constructor(readonly label: Identifier, readonly stmt: Stmt) {
-    super(NodeKind.LabelledStmt, arguments);
+  constructor(
+    /**
+     * Range of text in the source file where this Node resides.
+     */
+    span: Span,
+    readonly label: Identifier,
+    readonly stmt: Stmt
+  ) {
+    super(NodeKind.LabelledStmt, span, arguments);
     this.ensure(label, "label", [NodeKind.Identifier]);
     this.ensure(stmt, "stmt", ["Stmt"]);
   }
 }
 
 export class DebuggerStmt extends BaseStmt<NodeKind.DebuggerStmt> {
-  constructor() {
-    super(NodeKind.DebuggerStmt, arguments);
+  constructor(
+    /**
+     * Range of text in the source file where this Node resides.
+     */
+    span: Span
+  ) {
+    super(NodeKind.DebuggerStmt, span, arguments);
   }
 }
 
 export class SwitchStmt extends BaseStmt<NodeKind.SwitchStmt> {
-  constructor(readonly expr: Expr, readonly clauses: SwitchClause[]) {
-    super(NodeKind.SwitchStmt, arguments);
+  constructor(
+    /**
+     * Range of text in the source file where this Node resides.
+     */
+    span: Span,
+    readonly expr: Expr,
+    readonly clauses: SwitchClause[]
+  ) {
+    super(NodeKind.SwitchStmt, span, arguments);
     this.ensure(expr, "expr", ["Expr"]);
     this.ensureArrayOf(clauses, "clauses", NodeKind.SwitchClause);
   }
@@ -285,29 +389,54 @@ export class SwitchStmt extends BaseStmt<NodeKind.SwitchStmt> {
 export type SwitchClause = CaseClause | DefaultClause;
 
 export class CaseClause extends BaseStmt<NodeKind.CaseClause> {
-  constructor(readonly expr: Expr, readonly statements: Stmt[]) {
-    super(NodeKind.CaseClause, arguments);
+  constructor(
+    /**
+     * Range of text in the source file where this Node resides.
+     */
+    span: Span,
+    readonly expr: Expr,
+    readonly statements: Stmt[]
+  ) {
+    super(NodeKind.CaseClause, span, arguments);
     this.ensure(expr, "expr", ["Expr"]);
     this.ensureArrayOf(statements, "statements", ["Stmt"]);
   }
 }
 
 export class DefaultClause extends BaseStmt<NodeKind.DefaultClause> {
-  constructor(readonly statements: Stmt[]) {
-    super(NodeKind.DefaultClause, arguments);
+  constructor(
+    /**
+     * Range of text in the source file where this Node resides.
+     */
+    span: Span,
+    readonly statements: Stmt[]
+  ) {
+    super(NodeKind.DefaultClause, span, arguments);
     this.ensureArrayOf(statements, "statements", ["Stmt"]);
   }
 }
 
 export class EmptyStmt extends BaseStmt<NodeKind.EmptyStmt> {
-  constructor() {
-    super(NodeKind.EmptyStmt, arguments);
+  constructor(
+    /**
+     * Range of text in the source file where this Node resides.
+     */
+    span: Span
+  ) {
+    super(NodeKind.EmptyStmt, span, arguments);
   }
 }
 
 export class WithStmt extends BaseStmt<NodeKind.WithStmt> {
-  constructor(readonly expr: Expr, readonly stmt: Stmt) {
-    super(NodeKind.WithStmt, arguments);
+  constructor(
+    /**
+     * Range of text in the source file where this Node resides.
+     */
+    span: Span,
+    readonly expr: Expr,
+    readonly stmt: Stmt
+  ) {
+    super(NodeKind.WithStmt, span, arguments);
     this.ensure(expr, "expr", ["Expr"]);
     this.ensure(stmt, "stmt", ["Stmt"]);
   }

--- a/test-app/yarn.lock
+++ b/test-app/yarn.lock
@@ -1179,10 +1179,10 @@
     ts-node "^9"
     tslib "^2"
 
-"@functionless/ast-reflection@0.0.2":
-  version "0.0.2"
-  resolved "https://registry.yarnpkg.com/@functionless/ast-reflection/-/ast-reflection-0.0.2.tgz#95feb7b9051a5e4953c4806e7e819073a16cc103"
-  integrity sha512-uhhWQ/Xg18dhK2TEr5ZQ6Bvux/ztAH+d/MUW2vjTwBn2z3ecsNIUEyy66NTxhagVFQ0XGcgVw/xGmTtvlTx3JQ==
+"@functionless/ast-reflection@^0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@functionless/ast-reflection/-/ast-reflection-0.1.1.tgz#3d75cb797336e60317b8fc454346cf3d4704f8f2"
+  integrity sha512-hb1GLpwrgMrJzhTBryna9/vT3KMHTRgD3SXJiKzSU0Pb1ZEhvDx8Q+n89zuR7/lOWRO7x6LFXWQE0RSyEnDgdQ==
 
 "@functionless/language-service@^0.0.3":
   version "0.0.3"
@@ -2773,7 +2773,7 @@ function.prototype.name@^1.1.5:
 "functionless@file:..":
   version "0.0.0"
   dependencies:
-    "@functionless/ast-reflection" "0.0.2"
+    "@functionless/ast-reflection" "^0.1.1"
     "@functionless/nodejs-closure-serializer" "^0.1.2"
     "@swc/cli" "^0.1.57"
     "@swc/core" "1.2.218"

--- a/test/node.test.ts
+++ b/test/node.test.ts
@@ -12,19 +12,40 @@ import {
   VariableDecl,
   WhileStmt,
 } from "../src";
+import { emptySpan } from "../src/span";
 
 test("node.exit() from catch surrounded by while", () => {
   const catchClause = new CatchClause(
-    new VariableDecl(new Identifier("var"), new NullLiteralExpr()),
-    new BlockStmt([new ExprStmt(new CallExpr(new Identifier("task"), []))])
+    emptySpan(),
+    new VariableDecl(
+      emptySpan(),
+      new Identifier(emptySpan(), "var"),
+      new NullLiteralExpr(emptySpan())
+    ),
+    new BlockStmt(emptySpan(), [
+      new ExprStmt(
+        emptySpan(),
+        new CallExpr(emptySpan(), new Identifier(emptySpan(), "task"), [])
+      ),
+    ])
   );
 
   const whileStmt = new WhileStmt(
-    new BooleanLiteralExpr(true),
-    new BlockStmt([new TryStmt(new BlockStmt([]), catchClause)])
+    emptySpan(),
+    new BooleanLiteralExpr(emptySpan(), true),
+    new BlockStmt(emptySpan(), [
+      new TryStmt(emptySpan(), new BlockStmt(emptySpan(), []), catchClause),
+    ])
   );
 
-  new FunctionDecl("name", [], new BlockStmt([whileStmt]), false, false);
+  new FunctionDecl(
+    emptySpan(),
+    "name",
+    [],
+    new BlockStmt(emptySpan(), [whileStmt]),
+    false,
+    false
+  );
 
   const exit = catchClause.exit();
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1040,8 +1040,10 @@
     minimatch "^3.1.2"
     strip-json-comments "^3.1.1"
 
-"@functionless/ast-reflection@file:../ast-reflection":
-  version "0.0.0"
+"@functionless/ast-reflection@^0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@functionless/ast-reflection/-/ast-reflection-0.1.0.tgz#a4705fcad03d992751f993c7e3a84b459ebe0366"
+  integrity sha512-pFiO+nKkv7wksXsh5DJpME/93LQlW5bKV5VOzhASGZY0FPR47Y3KA9exwtdzJt5pWLuirK3fZH6DhEz9vrTTIQ==
 
 "@functionless/nodejs-closure-serializer@^0.1.2":
   version "0.1.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1040,10 +1040,8 @@
     minimatch "^3.1.2"
     strip-json-comments "^3.1.1"
 
-"@functionless/ast-reflection@0.0.1":
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/@functionless/ast-reflection/-/ast-reflection-0.0.1.tgz#bf025e87456449f47a62c90323e55574b5131fdc"
-  integrity sha512-flKyyHZsAlSdEn9rZuLIOsLhM+jqt0U8vIPKsc/tzJzWnVRXRMHTzubES+YoXqT5MR0dJo94MTfte5zN/YlXxg==
+"@functionless/ast-reflection@file:../ast-reflection":
+  version "0.0.0"
 
 "@functionless/nodejs-closure-serializer@^0.1.2":
   version "0.1.2"


### PR DESCRIPTION
Fixes #392 

This change adds a Node's Span information to each node.

```ts
/**
 * A {@link Span} is a range of text within a source file, represented
 * by two numbers, a `start` and `end` character position.
 */
export type Span = [
  /**
   * Character position where this span starts.
   */
  start: number,
  /**
   * Character position where this span ends.
   */
  end: number
];
```

## Positional Convention

Because a span 2-tuple looks identical to a Node's s-expression `[kind: number, ...args]`, we adopt the convention of the span always being the element directly following the `kind`, making the definition of a s-expression now:

```ts
export type SExpr = [kind: number, span: Span, ...args: any[]]
```