### PR TITLE
feat(ast): update ClassDecl.name and ClassExpr.name to be an Identifier

### DIFF
--- a/src/compile.ts
+++ b/src/compile.ts
@@ -828,7 +828,8 @@ export function compile(
             node,
             [
               // name
-              node.name ?? ts.factory.createIdentifier("undefined"),
+              toExpr(node.name, scope) ??
+                ts.factory.createIdentifier("undefined"),
               // extends
               node.heritageClauses?.flatMap((clause) =>
                 clause.token === ts.SyntaxKind.ExtendsKeyword &&

--- a/src/declaration.ts
+++ b/src/declaration.ts
@@ -59,7 +59,7 @@ export class ClassDecl<C extends AnyClass = AnyClass> extends BaseDecl<
   ) {
     super(NodeKind.ClassDecl, span, arguments);
     this.ensure(name, "name", [NodeKind.Identifier]);
-    this.ensure(heritage, "name", ["undefined", NodeKind.Identifier]);
+    this.ensure(heritage, "heritage", ["undefined", "Expr"]);
     this.ensureArrayOf(members, "members", NodeKind.ClassMember);
     this.ensure(filename, "filename", ["undefined", "string"]);
   }

--- a/src/declaration.ts
+++ b/src/declaration.ts
@@ -47,7 +47,7 @@ export class ClassDecl<C extends AnyClass = AnyClass> extends BaseDecl<
      * Range of text in the source file where this Node resides.
      */
     span: Span,
-    readonly name: string,
+    readonly name: Identifier,
     readonly heritage: Expr | undefined,
     readonly members: ClassMember[],
     /**
@@ -58,7 +58,7 @@ export class ClassDecl<C extends AnyClass = AnyClass> extends BaseDecl<
     readonly filename?: string
   ) {
     super(NodeKind.ClassDecl, span, arguments);
-    this.ensure(name, "name", ["string"]);
+    this.ensure(name, "name", [NodeKind.Identifier]);
     this.ensureArrayOf(members, "members", NodeKind.ClassMember);
     this.ensure(filename, "filename", ["undefined", "string"]);
   }

--- a/src/declaration.ts
+++ b/src/declaration.ts
@@ -59,6 +59,7 @@ export class ClassDecl<C extends AnyClass = AnyClass> extends BaseDecl<
   ) {
     super(NodeKind.ClassDecl, span, arguments);
     this.ensure(name, "name", [NodeKind.Identifier]);
+    this.ensure(heritage, "name", ["undefined", NodeKind.Identifier]);
     this.ensureArrayOf(members, "members", NodeKind.ClassMember);
     this.ensure(filename, "filename", ["undefined", "string"]);
   }

--- a/src/expression.ts
+++ b/src/expression.ts
@@ -170,7 +170,7 @@ export class ClassExpr<C extends AnyClass = AnyClass> extends BaseExpr<
      * Range of text in the source file where this Node resides.
      */
     span: Span,
-    readonly name: string | undefined,
+    readonly name: Identifier | undefined,
     readonly heritage: Expr | undefined,
     readonly members: ClassMember[],
     /**
@@ -181,7 +181,7 @@ export class ClassExpr<C extends AnyClass = AnyClass> extends BaseExpr<
     readonly filename?: string
   ) {
     super(NodeKind.ClassExpr, span, arguments);
-    this.ensure(name, "name", ["undefined", "string"]);
+    this.ensure(name, "name", ["undefined", NodeKind.Identifier]);
     this.ensure(heritage, "heritage", ["undefined", "Expr"]);
     this.ensureArrayOf(members, "members", NodeKind.ClassMember);
     this.ensure(filename, "filename", ["undefined", "string"]);


### PR DESCRIPTION
For consistency, we will use `Identifier` instead of `string` for all names in the AST. This change updates ClassDecl and ClassExpr. They are not used so the change is not impactful on any existing code.