### PR TITLE
chore: increase allowed memory of node process

### DIFF
--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -84,6 +84,9 @@
     "compile": {
       "name": "compile",
       "description": "Only compile",
+      "env": {
+        "NODE_OPTIONS": "--max-old-space-size=8192"
+      },
       "steps": [
         {
           "exec": "yarn link && cd ./test-app && yarn link functionless"
@@ -183,6 +186,7 @@
       "name": "test",
       "description": "Run tests",
       "env": {
+        "NODE_OPTIONS": "--max-old-space-size=8192",
         "DEFAULT_REGION": "ap-northeast-1",
         "AWS_ACCOUNT_ID": "000000000000",
         "AWS_ACCESS_KEY_ID": "test",

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -213,6 +213,7 @@ packageJson.addOverride("lint-staged", {
 project.compileTask.prependExec(
   "yarn link && cd ./test-app && yarn link functionless"
 );
+project.compileTask.env("NODE_OPTIONS", "--max-old-space-size=8192");
 
 project.testTask.prependExec(
   "cd ./test-app && yarn && yarn build && yarn synth --quiet"
@@ -220,6 +221,7 @@ project.testTask.prependExec(
 project.testTask.prependExec("./scripts/localstack");
 project.testTask.exec("localstack stop");
 
+project.testTask.env("NODE_OPTIONS", "--max-old-space-size=8192");
 project.testTask.env("DEFAULT_REGION", "ap-northeast-1");
 project.testTask.env("AWS_ACCOUNT_ID", "000000000000");
 project.testTask.env("AWS_ACCESS_KEY_ID", "test");


### PR DESCRIPTION
Builds are failing because node is running out of memory. To mitigate, this change increases the memory from 2GB to 8GB on the compile and test tasks.