### PR TITLE
fix: update PreWarm to require individual clients to minimize memory usage

### DIFF
--- a/src/function-prewarm.ts
+++ b/src/function-prewarm.ts
@@ -33,19 +33,23 @@ export const PrewarmClients: Record<
     key: "Lambda",
     init: (key, props) =>
       // eslint-disable-next-line @typescript-eslint/no-require-imports, import/no-extraneous-dependencies
-      new (require("aws-sdk").Lambda)(props?.clientConfigRetriever?.(key)),
+      new (require("aws-sdk/clients/lambda"))(
+        props?.clientConfigRetriever?.(key)
+      ),
   },
   EventBridge: {
     key: "EventBridge",
     init: (key, props) =>
       // eslint-disable-next-line @typescript-eslint/no-require-imports, import/no-extraneous-dependencies
-      new (require("aws-sdk").EventBridge)(props?.clientConfigRetriever?.(key)),
+      new (require("aws-sdk/clients/eventbridge"))(
+        props?.clientConfigRetriever?.(key)
+      ),
   },
   StepFunctions: {
     key: "StepFunctions",
     init: (key, props) =>
       // eslint-disable-next-line @typescript-eslint/no-require-imports, import/no-extraneous-dependencies
-      new (require("aws-sdk").StepFunctions)(
+      new (require("aws-sdk/clients/stepfunctions"))(
         props?.clientConfigRetriever?.(key)
       ),
   },
@@ -53,13 +57,15 @@ export const PrewarmClients: Record<
     key: "DynamoDB",
     init: (key, props) =>
       // eslint-disable-next-line @typescript-eslint/no-require-imports, import/no-extraneous-dependencies
-      new (require("aws-sdk").DynamoDB)(props?.clientConfigRetriever?.(key)),
+      new (require("aws-sdk/clients/dynamodb"))(
+        props?.clientConfigRetriever?.(key)
+      ),
   },
   SecretsManager: {
     key: "SecretsManager",
     init: (key, props) =>
       // eslint-disable-next-line @typescript-eslint/no-require-imports, import/no-extraneous-dependencies
-      new (require("aws-sdk").SecretsManager)(
+      new (require("aws-sdk/clients/secretsmanager"))(
         props?.clientConfigRetriever?.(key)
       ),
   },

--- a/test/__snapshots__/serialize.test.ts.snap
+++ b/test/__snapshots__/serialize.test.ts.snap
@@ -12509,11 +12509,11 @@ Object.defineProperty(__fnls, \\"$AWS\\", { enumerable: true, get: __f21 });
 var __bus = {eventBusName: process.env.env__functionless0};
 function __f3(__0, __1) {
   return (function() {
-    return ((key, props) => { var _a; return new (require(\\"aws-sdk\\")).DynamoDB((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key)); });;
+    return ((key, props) => { var _a; return new (require(\\"aws-sdk/clients/dynamodb\\"))((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key)); });;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f4(__0, __1) {
   return (function() {
-    return ((key, props) => { var _a; return new (require(\\"aws-sdk\\")).EventBridge((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key)); });;
+    return ((key, props) => { var _a; return new (require(\\"aws-sdk/clients/eventbridge\\"))((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key)); });;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f2(__0, __1) {
   return (function() {
@@ -12686,7 +12686,7 @@ function __f3(__0, __1) {
   return function() {
     return (key, props) => {
       var _a;
-      return new (require(\\"aws-sdk\\")).DynamoDB((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key));
+      return new (require(\\"aws-sdk/clients/dynamodb\\"))((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key));
     };
     ;
   }.apply(void 0, void 0).apply(this, arguments);
@@ -12695,7 +12695,7 @@ function __f4(__0, __1) {
   return function() {
     return (key, props) => {
       var _a;
-      return new (require(\\"aws-sdk\\")).EventBridge((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key));
+      return new (require(\\"aws-sdk/clients/eventbridge\\"))((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key));
     };
     ;
   }.apply(void 0, void 0).apply(this, arguments);
@@ -12933,7 +12933,7 @@ __f1.kind = \\"EventBus.putEvents\\";
 var __bus = {putEvents: __f1};
 function __f3(__0, __1) {
   return (function() {
-    return ((key, props) => { var _a; return new (require(\\"aws-sdk\\")).EventBridge((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key)); });;
+    return ((key, props) => { var _a; return new (require(\\"aws-sdk/clients/eventbridge\\"))((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key)); });;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f2(__0, __1) {
   return (function() {
@@ -12995,7 +12995,7 @@ function __f3(__0, __1) {
   return function() {
     return (key, props) => {
       var _a;
-      return new (require(\\"aws-sdk\\")).EventBridge((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key));
+      return new (require(\\"aws-sdk/clients/eventbridge\\"))((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key));
     };
     ;
   }.apply(void 0, void 0).apply(this, arguments);
@@ -13082,7 +13082,7 @@ __f1.kind = \\"Function\\";
 __f1.functionlessKind = \\"Function\\";
 function __f3(__0, __1) {
   return (function() {
-    return ((key, props) => { var _a; return new (require(\\"aws-sdk\\")).Lambda((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key)); });;
+    return ((key, props) => { var _a; return new (require(\\"aws-sdk/clients/lambda\\"))((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key)); });;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f2(__0, __1) {
   return (function() {
@@ -13144,7 +13144,7 @@ function __f3(__0, __1) {
   return function() {
     return (key, props) => {
       var _a;
-      return new (require(\\"aws-sdk\\")).Lambda((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key));
+      return new (require(\\"aws-sdk/clients/lambda\\"))((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key));
     };
     ;
   }.apply(void 0, void 0).apply(this, arguments);
@@ -13259,15 +13259,15 @@ __f23.kind = \\"Function\\";
 __f23.functionlessKind = \\"Function\\";
 function __f3(__0, __1) {
   return (function() {
-    return ((key, props) => { var _a; return new (require(\\"aws-sdk\\")).DynamoDB((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key)); });;
+    return ((key, props) => { var _a; return new (require(\\"aws-sdk/clients/dynamodb\\"))((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key)); });;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f4(__0, __1) {
   return (function() {
-    return ((key, props) => { var _a; return new (require(\\"aws-sdk\\")).EventBridge((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key)); });;
+    return ((key, props) => { var _a; return new (require(\\"aws-sdk/clients/eventbridge\\"))((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key)); });;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f5(__0, __1) {
   return (function() {
-    return ((key, props) => { var _a; return new (require(\\"aws-sdk\\")).Lambda((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key)); });;
+    return ((key, props) => { var _a; return new (require(\\"aws-sdk/clients/lambda\\"))((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key)); });;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f2(__0, __1) {
   return (function() {
@@ -13457,7 +13457,7 @@ function __f3(__0, __1) {
   return function() {
     return (key, props) => {
       var _a;
-      return new (require(\\"aws-sdk\\")).DynamoDB((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key));
+      return new (require(\\"aws-sdk/clients/dynamodb\\"))((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key));
     };
     ;
   }.apply(void 0, void 0).apply(this, arguments);
@@ -13466,7 +13466,7 @@ function __f4(__0, __1) {
   return function() {
     return (key, props) => {
       var _a;
-      return new (require(\\"aws-sdk\\")).EventBridge((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key));
+      return new (require(\\"aws-sdk/clients/eventbridge\\"))((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key));
     };
     ;
   }.apply(void 0, void 0).apply(this, arguments);
@@ -13475,7 +13475,7 @@ function __f5(__0, __1) {
   return function() {
     return (key, props) => {
       var _a;
-      return new (require(\\"aws-sdk\\")).Lambda((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key));
+      return new (require(\\"aws-sdk/clients/lambda\\"))((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key));
     };
     ;
   }.apply(void 0, void 0).apply(this, arguments);
@@ -13763,7 +13763,7 @@ __f1_definition.States = __f1_definition_States;
 __f1.definition = __f1_definition;
 function __f3(__0, __1) {
   return (function() {
-    return ((key, props) => { var _a; return new (require(\\"aws-sdk\\")).StepFunctions((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key)); });;
+    return ((key, props) => { var _a; return new (require(\\"aws-sdk/clients/stepfunctions\\"))((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key)); });;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f2(__0, __1) {
   return (function() {
@@ -13871,7 +13871,7 @@ function __f3(__0, __1) {
   return function() {
     return (key, props) => {
       var _a;
-      return new (require(\\"aws-sdk\\")).StepFunctions((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key));
+      return new (require(\\"aws-sdk/clients/stepfunctions\\"))((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key));
     };
     ;
   }.apply(void 0, void 0).apply(this, arguments);
@@ -14046,11 +14046,11 @@ var __f22_appsync = {getItem: __f23, putItem: __f24, updateItem: __f25, deleteIt
 __f22.appsync = __f22_appsync;
 function __f3(__0, __1) {
   return (function() {
-    return ((key, props) => { var _a; return new (require(\\"aws-sdk\\")).DynamoDB((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key)); });;
+    return ((key, props) => { var _a; return new (require(\\"aws-sdk/clients/dynamodb\\"))((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key)); });;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f4(__0, __1) {
   return (function() {
-    return ((key, props) => { var _a; return new (require(\\"aws-sdk\\")).EventBridge((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key)); });;
+    return ((key, props) => { var _a; return new (require(\\"aws-sdk/clients/eventbridge\\"))((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key)); });;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f2(__0, __1) {
   return (function() {
@@ -14257,7 +14257,7 @@ function __f3(__0, __1) {
   return function() {
     return (key, props) => {
       var _a;
-      return new (require(\\"aws-sdk\\")).DynamoDB((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key));
+      return new (require(\\"aws-sdk/clients/dynamodb\\"))((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key));
     };
     ;
   }.apply(void 0, void 0).apply(this, arguments);
@@ -14266,7 +14266,7 @@ function __f4(__0, __1) {
   return function() {
     return (key, props) => {
       var _a;
-      return new (require(\\"aws-sdk\\")).EventBridge((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key));
+      return new (require(\\"aws-sdk/clients/eventbridge\\"))((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key));
     };
     ;
   }.apply(void 0, void 0).apply(this, arguments);
@@ -14584,11 +14584,11 @@ var __f22_appsync = {getItem: __f23, putItem: __f24, updateItem: __f25, deleteIt
 __f22.appsync = __f22_appsync;
 function __f3(__0, __1) {
   return (function() {
-    return ((key, props) => { var _a; return new (require(\\"aws-sdk\\")).DynamoDB((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key)); });;
+    return ((key, props) => { var _a; return new (require(\\"aws-sdk/clients/dynamodb\\"))((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key)); });;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f4(__0, __1) {
   return (function() {
-    return ((key, props) => { var _a; return new (require(\\"aws-sdk\\")).EventBridge((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key)); });;
+    return ((key, props) => { var _a; return new (require(\\"aws-sdk/clients/eventbridge\\"))((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key)); });;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f2(__0, __1) {
   return (function() {
@@ -14795,7 +14795,7 @@ function __f3(__0, __1) {
   return function() {
     return (key, props) => {
       var _a;
-      return new (require(\\"aws-sdk\\")).DynamoDB((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key));
+      return new (require(\\"aws-sdk/clients/dynamodb\\"))((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key));
     };
     ;
   }.apply(void 0, void 0).apply(this, arguments);
@@ -14804,7 +14804,7 @@ function __f4(__0, __1) {
   return function() {
     return (key, props) => {
       var _a;
-      return new (require(\\"aws-sdk\\")).EventBridge((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key));
+      return new (require(\\"aws-sdk/clients/eventbridge\\"))((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key));
     };
     ;
   }.apply(void 0, void 0).apply(this, arguments);
@@ -15100,7 +15100,7 @@ var __f7_appsync = {getItem: __f8, putItem: __f9, updateItem: __f10, deleteItem:
 __f7.appsync = __f7_appsync;
 function __f3(__0, __1) {
   return (function() {
-    return ((key, props) => { var _a; return new (require(\\"aws-sdk\\")).DynamoDB((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key)); });;
+    return ((key, props) => { var _a; return new (require(\\"aws-sdk/clients/dynamodb\\"))((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key)); });;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f2(__0, __1) {
   return (function() {
@@ -15196,7 +15196,7 @@ function __f3(__0, __1) {
   return function() {
     return (key, props) => {
       var _a;
-      return new (require(\\"aws-sdk\\")).DynamoDB((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key));
+      return new (require(\\"aws-sdk/clients/dynamodb\\"))((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key));
     };
     ;
   }.apply(void 0, void 0).apply(this, arguments);
@@ -15366,11 +15366,11 @@ var __f22_appsync = {getItem: __f23, putItem: __f24, updateItem: __f25, deleteIt
 __f22.appsync = __f22_appsync;
 function __f3(__0, __1) {
   return (function() {
-    return ((key, props) => { var _a; return new (require(\\"aws-sdk\\")).DynamoDB((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key)); });;
+    return ((key, props) => { var _a; return new (require(\\"aws-sdk/clients/dynamodb\\"))((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key)); });;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f4(__0, __1) {
   return (function() {
-    return ((key, props) => { var _a; return new (require(\\"aws-sdk\\")).EventBridge((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key)); });;
+    return ((key, props) => { var _a; return new (require(\\"aws-sdk/clients/eventbridge\\"))((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key)); });;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f2(__0, __1) {
   return (function() {
@@ -15577,7 +15577,7 @@ function __f3(__0, __1) {
   return function() {
     return (key, props) => {
       var _a;
-      return new (require(\\"aws-sdk\\")).DynamoDB((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key));
+      return new (require(\\"aws-sdk/clients/dynamodb\\"))((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key));
     };
     ;
   }.apply(void 0, void 0).apply(this, arguments);
@@ -15586,7 +15586,7 @@ function __f4(__0, __1) {
   return function() {
     return (key, props) => {
       var _a;
-      return new (require(\\"aws-sdk\\")).EventBridge((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key));
+      return new (require(\\"aws-sdk/clients/eventbridge\\"))((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key));
     };
     ;
   }.apply(void 0, void 0).apply(this, arguments);
@@ -15904,11 +15904,11 @@ var __f22_appsync = {getItem: __f23, putItem: __f24, updateItem: __f25, deleteIt
 __f22.appsync = __f22_appsync;
 function __f3(__0, __1) {
   return (function() {
-    return ((key, props) => { var _a; return new (require(\\"aws-sdk\\")).DynamoDB((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key)); });;
+    return ((key, props) => { var _a; return new (require(\\"aws-sdk/clients/dynamodb\\"))((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key)); });;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f4(__0, __1) {
   return (function() {
-    return ((key, props) => { var _a; return new (require(\\"aws-sdk\\")).EventBridge((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key)); });;
+    return ((key, props) => { var _a; return new (require(\\"aws-sdk/clients/eventbridge\\"))((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key)); });;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f2(__0, __1) {
   return (function() {
@@ -16115,7 +16115,7 @@ function __f3(__0, __1) {
   return function() {
     return (key, props) => {
       var _a;
-      return new (require(\\"aws-sdk\\")).DynamoDB((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key));
+      return new (require(\\"aws-sdk/clients/dynamodb\\"))((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key));
     };
     ;
   }.apply(void 0, void 0).apply(this, arguments);
@@ -16124,7 +16124,7 @@ function __f4(__0, __1) {
   return function() {
     return (key, props) => {
       var _a;
-      return new (require(\\"aws-sdk\\")).EventBridge((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key));
+      return new (require(\\"aws-sdk/clients/eventbridge\\"))((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key));
     };
     ;
   }.apply(void 0, void 0).apply(this, arguments);
@@ -16442,11 +16442,11 @@ var __f22_appsync = {getItem: __f23, putItem: __f24, updateItem: __f25, deleteIt
 __f22.appsync = __f22_appsync;
 function __f3(__0, __1) {
   return (function() {
-    return ((key, props) => { var _a; return new (require(\\"aws-sdk\\")).DynamoDB((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key)); });;
+    return ((key, props) => { var _a; return new (require(\\"aws-sdk/clients/dynamodb\\"))((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key)); });;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f4(__0, __1) {
   return (function() {
-    return ((key, props) => { var _a; return new (require(\\"aws-sdk\\")).EventBridge((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key)); });;
+    return ((key, props) => { var _a; return new (require(\\"aws-sdk/clients/eventbridge\\"))((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key)); });;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f2(__0, __1) {
   return (function() {
@@ -16653,7 +16653,7 @@ function __f3(__0, __1) {
   return function() {
     return (key, props) => {
       var _a;
-      return new (require(\\"aws-sdk\\")).DynamoDB((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key));
+      return new (require(\\"aws-sdk/clients/dynamodb\\"))((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key));
     };
     ;
   }.apply(void 0, void 0).apply(this, arguments);
@@ -16662,7 +16662,7 @@ function __f4(__0, __1) {
   return function() {
     return (key, props) => {
       var _a;
-      return new (require(\\"aws-sdk\\")).EventBridge((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key));
+      return new (require(\\"aws-sdk/clients/eventbridge\\"))((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key));
     };
     ;
   }.apply(void 0, void 0).apply(this, arguments);
@@ -16980,11 +16980,11 @@ var __f22_appsync = {getItem: __f23, putItem: __f24, updateItem: __f25, deleteIt
 __f22.appsync = __f22_appsync;
 function __f3(__0, __1) {
   return (function() {
-    return ((key, props) => { var _a; return new (require(\\"aws-sdk\\")).DynamoDB((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key)); });;
+    return ((key, props) => { var _a; return new (require(\\"aws-sdk/clients/dynamodb\\"))((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key)); });;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f4(__0, __1) {
   return (function() {
-    return ((key, props) => { var _a; return new (require(\\"aws-sdk\\")).EventBridge((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key)); });;
+    return ((key, props) => { var _a; return new (require(\\"aws-sdk/clients/eventbridge\\"))((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key)); });;
   }).apply(undefined, undefined).apply(this, arguments);
 }function __f2(__0, __1) {
   return (function() {
@@ -17191,7 +17191,7 @@ function __f3(__0, __1) {
   return function() {
     return (key, props) => {
       var _a;
-      return new (require(\\"aws-sdk\\")).DynamoDB((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key));
+      return new (require(\\"aws-sdk/clients/dynamodb\\"))((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key));
     };
     ;
   }.apply(void 0, void 0).apply(this, arguments);
@@ -17200,7 +17200,7 @@ function __f4(__0, __1) {
   return function() {
     return (key, props) => {
       var _a;
-      return new (require(\\"aws-sdk\\")).EventBridge((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key));
+      return new (require(\\"aws-sdk/clients/eventbridge\\"))((_a = props === null || props === void 0 ? void 0 : props.clientConfigRetriever) === null || _a === void 0 ? void 0 : _a.call(props, key));
     };
     ;
   }.apply(void 0, void 0).apply(this, arguments);


### PR DESCRIPTION
Running Functions with 128MB of memory was failing because `require("aws-sdk")` uses 150MB of memory. This change updates the pre-warm to import specific clients, e.g. `require("aws-sdk/clients/dynamodb")` which significantly reduces the memory usage. It should also make cold starts faster.