### PR TITLE
fix(step-functions): fail gracefully on unsupported APIs

### DIFF
--- a/src/error-code.ts
+++ b/src/error-code.ts
@@ -1264,6 +1264,19 @@ export namespace ErrorCodes {
     type: ErrorType.WARN,
     title: "StepFunctions mismatched index type.",
   };
+
+  /**
+   * The AWS SDK being used in the current resource is unsupported by that resource.
+   *
+   * Workaround:
+   *
+   * Most of the ASK APIs will work within
+   */
+  export const Unsupported_AWS_SDK_in_Resource: ErrorCode = {
+    code: 10036,
+    type: ErrorType.ERROR,
+    title: "Unsupported AWS SDK in Resource.",
+  };
 }
 
 // to prevent the closure serializer from trying to import all of functionless.

--- a/test/step-function.localstack.test.ts
+++ b/test/step-function.localstack.test.ts
@@ -421,35 +421,6 @@ localstackTestSuite("sfnStack", (testResource, _stack, _app) => {
   );
 
   test(
-    "$AWS.SDK.ApiGatewayManagementApi.postToConnection",
-    (parent) => {
-      return {
-        sfn: new StepFunction<{}, string | undefined>(
-          parent,
-          "fn",
-          async () => {
-            await $AWS.SDK.ApiGatewayManagementApi.postToConnection(
-              {
-                ConnectionId: "",
-                Data: "some data",
-              },
-              {
-                iam: {
-                  resources: ["*"],
-                },
-              }
-            );
-
-            return "woop";
-          }
-        ),
-        outputs: { tableArn: table.tableArn },
-      };
-    },
-    ({ tableArn }) => tableArn
-  );
-
-  test(
     "conditionals",
     (parent) => {
       const func = new Function<undefined, boolean>(

--- a/test/step-function.localstack.test.ts
+++ b/test/step-function.localstack.test.ts
@@ -421,6 +421,35 @@ localstackTestSuite("sfnStack", (testResource, _stack, _app) => {
   );
 
   test(
+    "$AWS.SDK.ApiGatewayManagementApi.postToConnection",
+    (parent) => {
+      return {
+        sfn: new StepFunction<{}, string | undefined>(
+          parent,
+          "fn",
+          async () => {
+            await $AWS.SDK.ApiGatewayManagementApi.postToConnection(
+              {
+                ConnectionId: "",
+                Data: "some data",
+              },
+              {
+                iam: {
+                  resources: ["*"],
+                },
+              }
+            );
+
+            return "woop";
+          }
+        ),
+        outputs: { tableArn: table.tableArn },
+      };
+    },
+    ({ tableArn }) => tableArn
+  );
+
+  test(
     "conditionals",
     (parent) => {
       const func = new Function<undefined, boolean>(

--- a/test/step-function.test.ts
+++ b/test/step-function.test.ts
@@ -1519,6 +1519,37 @@ test("return AWS.SDK.CloudWatch.describeAlarms dynamic parameters", () => {
   expect(normalizeDefinition(definition)).toMatchSnapshot();
 });
 
+test("return AWS.SDK.ApiGatewayManagementApi.postToConnection is not supported", () => {
+  const { stack } = initStepFunctionApp();
+  expect(
+    () =>
+      new ExpressStepFunction<
+        { prefix: string | undefined },
+        AWS.CloudWatch.MetricAlarms | undefined
+      >(stack, "fn", async (input) => {
+        await $AWS.SDK.ApiGatewayManagementApi.postToConnection(
+          {
+            ConnectionId: "blah",
+            Data: "some data",
+          },
+          {
+            iam: {
+              resources: ["*"],
+            },
+          }
+        );
+
+        if (alarms.MetricAlarms === undefined) {
+          return;
+        }
+
+        return alarms.MetricAlarms;
+      })
+  ).toThrow(
+    "Step Functions does not support an API Integration with ApiGatewayManagementApi and method postToConnection."
+  );
+});
+
 test("for-loop over a list literal", () => {
   const { stack, computeScore } = initStepFunctionApp();
   const definition = new ExpressStepFunction<{ id: string }, void>(

--- a/test/validate.test.ts
+++ b/test/validate.test.ts
@@ -49,6 +49,8 @@ const skipErrorCodes: ErrorCode[] = [
   ErrorCodes.Classes_are_not_supported,
   // Deprecated - No longer used
   ErrorCodes.StepFunction_invalid_filter_syntax,
+  // will not support integration specific validation, for now.
+  ErrorCodes.Unsupported_AWS_SDK_in_Resource,
 ];
 
 const file: string | undefined = fs


### PR DESCRIPTION
Fixes #454 
Partial #443

Friendly error when unsupported SFN integration APIs are used.

https://docs.aws.amazon.com/step-functions/latest/dg/supported-services-awssdk.html