### PR TITLE
chore(projen): add skipLibCheck to tsconfigs

### DIFF
--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -154,6 +154,7 @@ const project = new CustomTypescriptProject({
       declarationMap: true,
       noUncheckedIndexedAccess: true,
       lib: ["dom", "ES2019"],
+      skipLibCheck: true,
     },
   },
   tsconfigDev: {
@@ -162,6 +163,7 @@ const project = new CustomTypescriptProject({
         "@fnls": ["lib/index"],
       },
       baseUrl: ".",
+      skipLibCheck: true,
     },
   },
   gitignore: [".DS_Store", ".dccache", ".swc"],

--- a/tsconfig.dev.json
+++ b/tsconfig.dev.json
@@ -26,6 +26,7 @@
     "target": "ES2019",
     "declarationMap": true,
     "noUncheckedIndexedAccess": true,
+    "skipLibCheck": true,
     "paths": {
       "@fnls": [
         "lib/index"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -27,7 +27,8 @@
     "stripInternal": true,
     "target": "ES2019",
     "declarationMap": true,
-    "noUncheckedIndexedAccess": true
+    "noUncheckedIndexedAccess": true,
+    "skipLibCheck": true
   },
   "include": [
     "src/**/*.ts"


### PR DESCRIPTION
Decreases memory consumption and type checking execution time:

**Before:**

```
> functionless git:(tyler/api-gateway) time npx tsc --noEmit --extendedDiagnostics
Files:                         2091
Lines of Library:             26877
Lines of Definitions:       1082757
Lines of TypeScript:         112999
Lines of JavaScript:              0
Lines of JSON:                    0
Lines of Other:                   0
Nodes of Library:            117549
Nodes of Definitions:       2827454
Nodes of TypeScript:         375598
Nodes of JavaScript:              0
Nodes of JSON:                    0
Nodes of Other:                   0
Identifiers:                1215345
Symbols:                     980049
Types:                       484854
Instantiations:              239430
Memory used:               1551969K
Assignability cache size:    331249
Identity cache size:           8757
Subtype cache size:           18188
Strict subtype cache size:    19825
I/O Read time:                0.53s
Parse time:                   6.19s
ResolveModule time:           0.45s
ResolveTypeReference time:    0.02s
Program time:                 7.69s
Bind time:                    1.93s
Check time:                  24.12s
printTime time:               0.00s
Emit time:                    0.00s
Total time:                  33.75s
npx tsc --noEmit --extendedDiagnostics  44.21s user 2.36s system 133% cpu 34.825 total
```

**After:**

```
>  functionless git:(tyler/api-gateway) ✗ npx tsc --noEmit -p tsconfig.json --extendedDiagnostics
Files:                         2091
Lines of Library:             26877
Lines of Definitions:       1082757
Lines of TypeScript:         112999
Lines of JavaScript:              0
Lines of JSON:                    0
Lines of Other:                   0
Nodes of Library:            117549
Nodes of Definitions:       2827454
Nodes of TypeScript:         375598
Nodes of JavaScript:              0
Nodes of JSON:                    0
Nodes of Other:                   0
Identifiers:                1215345
Symbols:                     781720
Types:                       130091
Instantiations:              162355
Memory used:               1144331K
Assignability cache size:     37025
Identity cache size:           8734
Subtype cache size:           20017
Strict subtype cache size:    21196
I/O Read time:                0.54s
Parse time:                   6.19s
ResolveModule time:           0.49s
ResolveTypeReference time:    0.02s
Program time:                 7.77s
Bind time:                    2.09s
Check time:                   9.08s
printTime time:               0.00s
Emit time:                    0.00s
Total time:                  18.94s
```