### PR TITLE
chore: reduce computational complexity of types

### DIFF
--- a/src/asl/asl-graph.ts
+++ b/src/asl/asl-graph.ts
@@ -51,7 +51,7 @@ export namespace ASLGraph {
   export interface SubState {
     startState: string;
     node?: FunctionlessNode;
-    states: { [stateName: string]: ASLGraph.NodeState | ASLGraph.SubState };
+    states: Record<string, ASLGraph.NodeState | ASLGraph.SubState>;
   }
 
   export const isStateOrSubState = anyOf(isState, ASLGraph.isSubState);
@@ -61,7 +61,7 @@ export namespace ASLGraph {
    *
    * The node is used to name the state.
    */
-  export type NodeState<S extends State = State> = S & {
+  export type NodeState = State & {
     node?: FunctionlessNode;
   };
 
@@ -832,7 +832,7 @@ export namespace ASLGraph {
    * {@link ASLGraph.ConditionOutput} must be first turned into a {@link ASLGraph.JsonPath}.
    */
   export function passWithInput(
-    pass: Omit<NodeState<Pass>, "Parameters" | "InputPath" | "Result"> &
+    pass: Omit<NodeState & Pass, "Parameters" | "InputPath" | "Result"> &
       CommonFields,
     value: Exclude<ASLGraph.Output, ASLGraph.ConditionOutput>
   ): Pass {

--- a/src/asl/synth.ts
+++ b/src/asl/synth.ts
@@ -4561,7 +4561,6 @@ function toStateName(node?: FunctionlessNode): string {
     isPropDecl(node) ||
     isSetAccessorDecl(node) ||
     isSuperKeyword(node) ||
-    isSuperKeyword(node) ||
     isSwitchStmt(node) ||
     isWithStmt(node) ||
     isYieldExpr(node)

--- a/src/aws.ts
+++ b/src/aws.ts
@@ -4,8 +4,6 @@ import type {
   EventBridge as AWSEventBridge,
   Lambda as AWSLambda,
 } from "aws-sdk";
-// eslint-disable-next-line import/no-extraneous-dependencies
-import * as AWS from "aws-sdk";
 import { JsonFormat } from "typesafe-dynamodb";
 import { TypeSafeDynamoDBv2 } from "typesafe-dynamodb/lib/client-v2";
 import {
@@ -483,8 +481,8 @@ export namespace $AWS {
     export const putEvents = makeIntegration<
       "$AWS.EventBridge.putEvent",
       (
-        request: AWS.EventBridge.Types.PutEventsRequest
-      ) => Promise<AWS.EventBridge.Types.PutEventsResponse>
+        request: AWSEventBridge.Types.PutEventsRequest
+      ) => Promise<AWSEventBridge.Types.PutEventsResponse>
     >({
       kind: "$AWS.EventBridge.putEvent",
       native: {

--- a/src/checker.ts
+++ b/src/checker.ts
@@ -1,5 +1,4 @@
-import * as ts from "typescript";
-import * as tsserver from "typescript/lib/tsserverlibrary";
+import ts from "typescript";
 import { ApiMethod, ApiMethodKind, isApiMethodKind } from "./api";
 import { AppsyncField, AppsyncResolver } from "./appsync";
 import { EventBus, Rule } from "./event-bridge";
@@ -88,9 +87,7 @@ export type NewAppsyncFieldInterface = ts.NewExpression & {
 
 export type FunctionlessChecker = ReturnType<typeof makeFunctionlessChecker>;
 
-export function makeFunctionlessChecker(
-  checker: ts.TypeChecker | tsserver.TypeChecker
-) {
+export function makeFunctionlessChecker(checker: ts.TypeChecker) {
   return {
     ...checker,
     getApiMethodKind,

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -1,3 +1,4 @@
+import ts from "typescript";
 import {
   EventBusMapInterface,
   EventBusWhenInterface,


### PR DESCRIPTION
Shaved a second off of `tsc` compile time with minor changes.

Before
```
Files:                         2091
Lines of Library:             26877
Lines of Definitions:       1082757
Lines of TypeScript:         112992
Lines of JavaScript:              0
Lines of JSON:                    0
Lines of Other:                   0
Nodes of Library:            117549
Nodes of Definitions:       2827454
Nodes of TypeScript:         375577
Nodes of JavaScript:              0
Nodes of JSON:                    0
Nodes of Other:                   0
Identifiers:                1215338
Symbols:                     781809
Types:                       130148
Instantiations:              164248
Memory used:               1188875K
Assignability cache size:     37718
Identity cache size:           8734
Subtype cache size:           20020
Strict subtype cache size:    21196
I/O Read time:                0.19s
Parse time:                   4.59s
ResolveModule time:           0.16s
ResolveTypeReference time:    0.01s
Program time:                 5.09s
Bind time:                    1.57s
Check time:                   5.09s
transformTime time:           1.95s
Source Map time:              0.22s
commentTime time:             0.31s
I/O Write time:               0.08s
printTime time:               4.01s
Emit time:                    4.01s
Total time:                  15.76s
```

After
```
Files:                         2090
Lines of Library:             26877
Lines of Definitions:       1071184
Lines of TypeScript:         112987
Lines of JavaScript:              0
Lines of JSON:                    0
Lines of Other:                   0
Nodes of Library:            117549
Nodes of Definitions:       2767427
Nodes of TypeScript:         375549
Nodes of JavaScript:              0
Nodes of JSON:                    0
Nodes of Other:                   0
Identifiers:                1192397
Symbols:                     755545
Types:                       124067
Instantiations:              146140
Memory used:               1157221K
Assignability cache size:     33776
Identity cache size:           8258
Subtype cache size:           14109
Strict subtype cache size:    16660
I/O Read time:                0.18s
Parse time:                   4.47s
ResolveModule time:           0.17s
ResolveTypeReference time:    0.01s
Program time:                 4.97s
Bind time:                    1.47s
Check time:                   4.72s
transformTime time:           1.10s
Source Map time:              0.22s
commentTime time:             0.30s
I/O Write time:               0.07s
printTime time:               3.14s
Emit time:                    3.14s
Total time:                  14.30s
```