### PR TITLE
chore: upgrade typescript to 4.8, improve compile performance

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -186,7 +186,7 @@
     },
     {
       "name": "typescript",
-      "version": "4.7.2",
+      "version": "4.8.2",
       "type": "build"
     },
     {
@@ -218,7 +218,7 @@
     },
     {
       "name": "typescript",
-      "version": "^4.7.2",
+      "version": "^4.8.2",
       "type": "peer"
     },
     {

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -141,7 +141,7 @@ const project = new CustomTypescriptProject({
     "constructs@^10.0.0",
     "esbuild",
     "typesafe-dynamodb@^0.1.5",
-    "typescript@^4.7.2",
+    "typescript@^4.8.2",
   ],
   eslintOptions: {
     dirs: ["src", "test"],

--- a/package.json
+++ b/package.json
@@ -72,17 +72,17 @@
     "ts-node": "^10.9.1",
     "ts-patch": "^2.0.2",
     "typesafe-dynamodb": "0.1.5",
-    "typescript": "^4.8.2",
+    "typescript": "4.8.2",
     "uuid": "^8.3.2"
   },
   "peerDependencies": {
-    "@aws-cdk/aws-appsync-alpha": "*",
     "aws-cdk-lib": "^2.28.1",
     "aws-sdk": "^2",
     "constructs": "^10.0.0",
     "esbuild": "^0.15.6",
     "typesafe-dynamodb": "^0.1.5",
-    "typescript": "^4.7.2"
+    "typescript": "^4.8.2",
+    "@aws-cdk/aws-appsync-alpha": "*"
   },
   "dependencies": {
     "@functionless/ast-reflection": "^0.2.2",

--- a/package.json
+++ b/package.json
@@ -72,17 +72,17 @@
     "ts-node": "^10.9.1",
     "ts-patch": "^2.0.2",
     "typesafe-dynamodb": "0.1.5",
-    "typescript": "4.7.2",
+    "typescript": "^4.8.2",
     "uuid": "^8.3.2"
   },
   "peerDependencies": {
+    "@aws-cdk/aws-appsync-alpha": "*",
     "aws-cdk-lib": "^2.28.1",
     "aws-sdk": "^2",
     "constructs": "^10.0.0",
     "esbuild": "^0.15.6",
     "typesafe-dynamodb": "^0.1.5",
-    "typescript": "^4.7.2",
-    "@aws-cdk/aws-appsync-alpha": "*"
+    "typescript": "^4.7.2"
   },
   "dependencies": {
     "@functionless/ast-reflection": "^0.2.2",

--- a/src/expression.ts
+++ b/src/expression.ts
@@ -771,7 +771,10 @@ export class TaggedTemplateExpr extends BaseExpr<NodeKind.TaggedTemplateExpr> {
  * // TemplateHead is "".
  * ```
  */
-export class TemplateHead extends BaseNode<NodeKind.TemplateHead> {
+export class TemplateHead extends BaseNode<
+  NodeKind.TemplateHead,
+  TemplateExpr
+> {
   readonly nodeKind = "Node";
 
   constructor(
@@ -795,7 +798,7 @@ export class TemplateHead extends BaseNode<NodeKind.TemplateHead> {
  */
 export class TemplateSpan<
   Literal extends TemplateMiddle | TemplateTail = TemplateMiddle | TemplateTail
-> extends BaseNode<NodeKind.TemplateSpan> {
+> extends BaseNode<NodeKind.TemplateSpan, TemplateExpr> {
   readonly nodeKind = "Node";
 
   constructor(
@@ -815,7 +818,10 @@ export class TemplateSpan<
   }
 }
 
-export class TemplateMiddle extends BaseNode<NodeKind.TemplateMiddle> {
+export class TemplateMiddle extends BaseNode<
+  NodeKind.TemplateMiddle,
+  TemplateSpan
+> {
   readonly nodeKind = "Node";
 
   constructor(
@@ -830,7 +836,10 @@ export class TemplateMiddle extends BaseNode<NodeKind.TemplateMiddle> {
   }
 }
 
-export class TemplateTail extends BaseNode<NodeKind.TemplateTail> {
+export class TemplateTail extends BaseNode<
+  NodeKind.TemplateTail,
+  TemplateSpan
+> {
   readonly nodeKind = "Node";
 
   constructor(

--- a/src/node.ts
+++ b/src/node.ts
@@ -16,7 +16,6 @@ import type { Err } from "./error";
 import type {
   Expr,
   ImportKeyword,
-  NoSubstitutionTemplateLiteralExpr,
   SuperKeyword,
   TemplateHead,
   TemplateMiddle,
@@ -57,7 +56,6 @@ export type FunctionlessNode =
   | Err
   | BindingPattern
   | ImportKeyword
-  | NoSubstitutionTemplateLiteralExpr
   | SuperKeyword
   | TemplateHead
   | TemplateMiddle
@@ -187,7 +185,7 @@ export abstract class BaseNode<
     if (this.parent === undefined) {
       return undefined;
     } else if (is(this.parent)) {
-      return this.parent;
+      return this.parent as unknown as N;
     } else {
       return this.parent.findParent(is);
     }
@@ -212,7 +210,7 @@ export abstract class BaseNode<
    */
   public findCatchClause(): CatchClause | undefined {
     if (isBlockStmt(this) && (this as unknown as BlockStmt).isFinallyBlock()) {
-      return this.parent!.findCatchClause();
+      return this.parent.findCatchClause();
     }
     const scope = this.parent;
     if (scope === undefined) {

--- a/src/step-function.ts
+++ b/src/step-function.ts
@@ -554,9 +554,10 @@ function makeStepFunctionIntegration<K extends string, F extends AnyFunction>(
   });
 }
 
-export function isStepFunction<P = any, O = any>(
-  a: any
-): a is StepFunction<P, O> | ExpressStepFunction<P, O> {
+export function isStepFunction<
+  P extends Record<string, any> | undefined,
+  O = any
+>(a: any): a is StepFunction<P, O> | ExpressStepFunction<P, O> {
   return a?.kind === "StepFunction";
 }
 

--- a/src/table.ts
+++ b/src/table.ts
@@ -13,9 +13,7 @@ import {
 import { TableKey } from "typesafe-dynamodb/lib/key";
 import { Narrow } from "typesafe-dynamodb/lib/narrow";
 import {
-  // @ts-expect-error - AppsyncResolver is imported for tsdoc
   AppsyncResolver,
-  // @ts-expect-error - AppsyncField is imported for tsdoc
   AppsyncField,
   AppSyncVtlIntegration,
 } from "./appsync";

--- a/website/package.json
+++ b/website/package.json
@@ -40,7 +40,7 @@
     "react-hook-form": "^7.31.3",
     "typedoc": "^0.23.13",
     "typedoc-plugin-markdown": "^3.12.1",
-    "typescript": "4.7"
+    "typescript": "^4.8.2"
   },
   "browserslist": {
     "production": [

--- a/website/yarn.lock
+++ b/website/yarn.lock
@@ -7939,10 +7939,10 @@ typedoc@^0.23.13:
     minimatch "^5.1.0"
     shiki "^0.11.1"
 
-typescript@4.7:
-  version "4.7.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.4.tgz#1a88596d1cf47d59507a1bcdfb5b9dfe4d488235"
-  integrity sha512-C0WQT0gezHuw6AdY1M2jxUO83Rjf0HP7Sk1DtXj6j1EwkQNZrHAg2XPWlq62oqEhYvONq5pkC2Y9oPljWToLmQ==
+typescript@^4.8.2:
+  version "4.8.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.2.tgz#e3b33d5ccfb5914e4eeab6699cf208adee3fd790"
+  integrity sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==
 
 ua-parser-js@^0.7.30:
   version "0.7.31"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7884,7 +7884,7 @@ typesafe-dynamodb@0.1.5:
     "@types/aws-lambda" "^8.10.92"
     aws-sdk "^2.1079.0"
 
-typescript@^4.8.2:
+typescript@4.8.2:
   version "4.8.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.2.tgz#e3b33d5ccfb5914e4eeab6699cf208adee3fd790"
   integrity sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1816,11 +1816,6 @@
     expect "^28.0.0"
     pretty-format "^28.0.0"
 
-"@types/json-buffer@~3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@types/json-buffer/-/json-buffer-3.0.0.tgz#85c1ff0f0948fc159810d4b5be35bf8c20875f64"
-  integrity sha512-3YP80IxxFJB4b5tYC2SUPwkg0XQLiu0nWvhRgEatgjf+29IcWO9X1k8xRv5DGssJ/lCrjYTjQPcobJr2yWIVuQ==
-
 "@types/json-schema@^7.0.9":
   version "7.0.11"
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.11.tgz#d421b6c527a3037f7c84433fd2c4229e016863d3"
@@ -1873,7 +1868,7 @@
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.7.0.tgz#ea03e9f0376a4446f44797ca19d9c46c36e352dc"
   integrity sha512-RI1L7N4JnW5gQw2spvL7Sllfuf1SaHdrZpCHiBlCXjIlufi1SMNnbu2teze3/QE67Fg2tBlH7W+mi4hVNk4p0A==
 
-"@types/responselike@*", "@types/responselike@^1.0.0":
+"@types/responselike@*":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@types/responselike/-/responselike-1.0.0.tgz#251f4fe7d154d2bad125abe1b429b23afd262e29"
   integrity sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==
@@ -2350,9 +2345,9 @@ aws-cdk@2.28.1:
     fsevents "2.3.2"
 
 aws-sdk@^2, aws-sdk@^2.1079.0, aws-sdk@^2.1093.0, aws-sdk@^2.1113.0:
-  version "2.1208.0"
-  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.1208.0.tgz#7dc8c877652d2b1ea126a3c256157c1cbd2e20e2"
-  integrity sha512-Wyq9TJyvRZMcHmcGwmOJag5/94m+Gq3BHcK2klwFvgUf1OWWJc4OYqmi90d7qJ09ydTeGGMeodNJildQdkOrYQ==
+  version "2.1209.0"
+  resolved "https://registry.yarnpkg.com/aws-sdk/-/aws-sdk-2.1209.0.tgz#fd7b9efd4047ab6b45bba2c890529d4c296a4b85"
+  integrity sha512-m4Dd0HtyKeKBjwzP9rhe+NcmsRKR0wW+QXfpepu6vgXYhmcJuOB9TLUoeB7jiNDPimmwU+KxtL6eonRfeFhANw==
   dependencies:
     buffer "4.9.2"
     events "1.1.1"
@@ -2654,9 +2649,9 @@ camelcase@^7.0.0:
   integrity sha512-JToIvOmz6nhGsUhAYScbo2d6Py5wojjNfoxoc2mEVLUdJ70gJK2gnd+ABY1Tc3sVMyK7QDPtN0T/XdlCQWITyQ==
 
 caniuse-lite@^1.0.30001370:
-  version "1.0.30001387"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001387.tgz#90d2b9bdfcc3ab9a5b9addee00a25ef86c9e2e1e"
-  integrity sha512-fKDH0F1KOJvR+mWSOvhj8lVRr/Q/mc5u5nabU2vi1/sgvlSqEsE8dOq0Hy/BqVbDkCYQPRRHB1WRjW6PGB/7PA==
+  version "1.0.30001388"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001388.tgz#88e01f4591cbd81f9f665f3f078c66b509fbe55d"
+  integrity sha512-znVbq4OUjqgLxMxoNX2ZeeLR0d7lcDiE5uJ4eUiWdml1J1EkxbnQq6opT9jb9SMfJxB0XA16/ziHwni4u1I3GQ==
 
 case@1.6.3, case@^1.6.3:
   version "1.6.3"
@@ -2824,14 +2819,6 @@ compare-func@^2.0.0:
   dependencies:
     array-ify "^1.0.0"
     dot-prop "^5.1.0"
-
-compress-brotli@^1.3.8:
-  version "1.3.8"
-  resolved "https://registry.yarnpkg.com/compress-brotli/-/compress-brotli-1.3.8.tgz#0c0a60c97a989145314ec381e84e26682e7b38db"
-  integrity sha512-lVcQsjhxhIXsuupfy9fmZUFtAIdBmXA7EGY6GBdgZ++qkM9zG4YFT8iU7FoBxzryNDMOpD1HIFHUSX4D87oqhQ==
-  dependencies:
-    "@types/json-buffer" "~3.0.0"
-    json-buffer "~3.0.1"
 
 compress-commons@^4.1.0:
   version "4.1.1"
@@ -3369,9 +3356,9 @@ ee-first@1.1.1:
   integrity sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==
 
 electron-to-chromium@^1.4.202:
-  version "1.4.240"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.240.tgz#b11fb838f2e79f34fbe8b57eec55e7e5d81ee6ea"
-  integrity sha512-r20dUOtZ4vUPTqAajDGonIM1uas5tf85Up+wPdtNBNvBSqGCfkpvMVvQ1T8YJzPV9/Y9g3FbUDcXb94Rafycow==
+  version "1.4.241"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.4.241.tgz#5aa03ab94db590d8269f4518157c24b1efad34d6"
+  integrity sha512-e7Wsh4ilaioBZ5bMm6+F4V5c11dh56/5Jwz7Hl5Tu1J7cnB+Pqx5qIF2iC7HPpfyQMqGSvvLP5bBAIDd2gAtGw==
 
 emittery@^0.10.2:
   version "0.10.2"
@@ -4106,7 +4093,7 @@ for-each@^0.3.3:
   dependencies:
     is-callable "^1.1.3"
 
-form-data-encoder@^2.0.1:
+form-data-encoder@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/form-data-encoder/-/form-data-encoder-2.1.0.tgz#ee9afc735186a2c897005431c13b624cede616da"
   integrity sha512-njK60LnfhfDWy+AEUIf9ZQNRAcmXCdDfiNOm2emuPtzwh7U9k/mo9F3S54aPiaZ3vhqUjikVLfcPg2KuBddskQ==
@@ -4429,23 +4416,22 @@ globby@^11.0.4, globby@^11.1.0:
     slash "^3.0.0"
 
 got@^12.1.0:
-  version "12.3.1"
-  resolved "https://registry.yarnpkg.com/got/-/got-12.3.1.tgz#79d6ebc0cb8358c424165698ddb828be56e74684"
-  integrity sha512-tS6+JMhBh4iXMSXF6KkIsRxmloPln31QHDlcb6Ec3bzxjjFJFr/8aXdpyuLmVc9I4i2HyBHYw1QU5K1ruUdpkw==
+  version "12.4.1"
+  resolved "https://registry.yarnpkg.com/got/-/got-12.4.1.tgz#8598311b42591dfd2ed3ca4cdb9a591e2769a0bd"
+  integrity sha512-Sz1ojLt4zGNkcftIyJKnulZT/yEDvifhUjccHA8QzOuTgPs/+njXYNMFE3jR4/2OODQSSbH8SdnoLCkbh41ieA==
   dependencies:
     "@sindresorhus/is" "^5.2.0"
     "@szmarczak/http-timer" "^5.0.1"
     "@types/cacheable-request" "^6.0.2"
-    "@types/responselike" "^1.0.0"
     cacheable-lookup "^6.0.4"
     cacheable-request "^7.0.2"
     decompress-response "^6.0.0"
-    form-data-encoder "^2.0.1"
+    form-data-encoder "^2.1.0"
     get-stream "^6.0.1"
     http2-wrapper "^2.1.10"
     lowercase-keys "^3.0.0"
     p-cancelable "^3.0.0"
-    responselike "^2.0.0"
+    responselike "^3.0.0"
 
 graceful-fs@4.2.10, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.6, graceful-fs@^4.2.9:
   version "4.2.10"
@@ -5448,7 +5434,7 @@ jsesc@^2.5.1:
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-2.5.2.tgz#80564d2e483dacf6e8ef209650a67df3f0c283a4"
   integrity sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==
 
-json-buffer@3.0.1, json-buffer@~3.0.1:
+json-buffer@3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/json-buffer/-/json-buffer-3.0.1.tgz#9338802a30d3b6605fbe0613e094008ca8c05a13"
   integrity sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==
@@ -5544,11 +5530,10 @@ jwt-decode@^2.2.0:
   integrity sha512-86GgN2vzfUu7m9Wcj63iUkuDzFNYFVmjeDm2GzWpUk+opB0pEpMsw6ePCMrhYkumz2C1ihqtZzOMAg7FiXcNoQ==
 
 keyv@^4.0.0:
-  version "4.4.1"
-  resolved "https://registry.yarnpkg.com/keyv/-/keyv-4.4.1.tgz#5d97bae8dfbb6788ebc9330daf5eb6582e2d3d1c"
-  integrity sha512-PzByhNxfBLnSBW2MZi1DF+W5+qB/7BMpOokewqIvqS8GFtP7xHm2oeGU72Y1fhtfOv/FiEnI4+nyViYDmUChnw==
+  version "4.5.0"
+  resolved "https://registry.yarnpkg.com/keyv/-/keyv-4.5.0.tgz#dbce9ade79610b6e641a9a65f2f6499ba06b9bc6"
+  integrity sha512-2YvuMsA+jnFGtBareKqgANOEKe1mk3HKiXu2fRmAfyxG0MJAywNhi5ttWA3PMjl4NmpyjZNbFifR2vNjW1znfA==
   dependencies:
-    compress-brotli "^1.3.8"
     json-buffer "3.0.1"
 
 kind-of@^6.0.2, kind-of@^6.0.3:
@@ -7117,6 +7102,13 @@ responselike@^2.0.0:
   dependencies:
     lowercase-keys "^2.0.0"
 
+responselike@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/responselike/-/responselike-3.0.0.tgz#20decb6c298aff0dbee1c355ca95461d42823626"
+  integrity sha512-40yHxbNcl2+rzXvZuVkrYohathsSJlMTXKryG5y8uciHv1+xDLHQpgjG64JUO9nrEq2jGLH6IZ8BcZyw3wrweg==
+  dependencies:
+    lowercase-keys "^3.0.0"
+
 retimer@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/retimer/-/retimer-2.0.0.tgz#e8bd68c5e5a8ec2f49ccb5c636db84c04063bbca"
@@ -7954,9 +7946,9 @@ upath@^2.0.1:
   integrity sha512-1uEe95xksV1O0CYKXo8vQvN1JEbtJp7lb7C5U9HMsIp6IVwntkH/oNUzyVNQSd4S1sYk2FpSSW44FqMc8qee5w==
 
 update-browserslist-db@^1.0.5:
-  version "1.0.6"
-  resolved "https://registry.yarnpkg.com/update-browserslist-db/-/update-browserslist-db-1.0.6.tgz#044fddb5c26989628da5cff7a82ce1472152bce6"
-  integrity sha512-We7BqM9XFlcW94Op93uW8+2LXvGezs7QA0WY+f1H7RR1q46B06W6hZF6LbmOlpCS1HU22q/6NOGTGW5sCm7NJQ==
+  version "1.0.7"
+  resolved "https://registry.yarnpkg.com/update-browserslist-db/-/update-browserslist-db-1.0.7.tgz#16279639cff1d0f800b14792de43d97df2d11b7d"
+  integrity sha512-iN/XYesmZ2RmmWAiI4Z5rq0YqSiv0brj9Ce9CfhNE4xIW2h+MFxcgkxIzZ+ShkFPUkjU3gQ+3oypadD3RAMtrg==
   dependencies:
     escalade "^3.1.1"
     picocolors "^1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7892,10 +7892,10 @@ typesafe-dynamodb@0.1.5:
     "@types/aws-lambda" "^8.10.92"
     aws-sdk "^2.1079.0"
 
-typescript@4.7.2:
-  version "4.7.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.7.2.tgz#1f9aa2ceb9af87cca227813b4310fff0b51593c4"
-  integrity sha512-Mamb1iX2FDUpcTRzltPxgWMKy3fhg0TN378ylbktPGPK/99KbDtMQ4W1hwgsbPAsG3a0xKa1vmw4VKZQbkvz5A==
+typescript@^4.8.2:
+  version "4.8.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.2.tgz#e3b33d5ccfb5914e4eeab6699cf208adee3fd790"
+  integrity sha512-C0I1UsrrDHo2fYI5oaCGbSejwX4ch+9Y5jTQELvovfmFkK3HHSZJB8MSJcWLmCUBzQBchCrZ9rMRV6GuNrvGtw==
 
 uglify-js@^3.1.4:
   version "3.17.0"


### PR DESCRIPTION
Fixes type issues which broke in TS 4.8.

Resolved a complex type that was causing an extra second of processing.

### Before
Total time:                  16.91s

```ts
    if (this.parent === undefined) {
      return undefined;
    } else if (is(this.parent)) {
      return this.parent;
    } else {
      return this.parent.findParent(is);
    }
```

### After
Total time:                  16.03s

```ts
    if (this.parent === undefined) {
      return undefined;
    } else if (is(this.parent)) {
      return this.parent as unknown as N;
    } else {
      return this.parent.findParent(is);
    }
```

Evaluating `Parent & {} & N` was taking a second

```
Hot Spots
├─ Check file /home/sussmans/functionless/src/node.ts (1741ms)
│  └─ Compare types 7794 and 1985 (1125ms)
│     └─ Compare types 7794 and 9 (1125ms)
│        ├─ {"id":7794,"kind":"Intersection","count":3,"types":[838,33,1979]}
│        │  ├─ {"id":838,"kind":"TypeParameter","name":"Parent","location":{"path":"/home/sussmans/functionless/src/node.ts","line":76,"char":3}}
│        │  ├─ {"id":33,"kind":"Other","display":"{}"}
│        │  └─ {"id":1979,"kind":"TypeParameter","name":"N","location":{"path":"/home/sussmans/functionless/src/node.ts","line":182,"char":21}}
│        └─ {"id":9,"kind":"Intrinsic","name":"undefined"}
└─ Check file /home/sussmans/functionless/src/asl/synth.ts (1267ms)
```