### PR TITLE
chore: update reference to $SFN symbol in docs

### DIFF
--- a/website/docs/concepts/step-function/index.md
+++ b/website/docs/concepts/step-function/index.md
@@ -16,7 +16,7 @@ const serviceCall = new Function(scope, "serviceCall", async (input: string) => 
 });
 new StepFunction(scope, "F", async (payload: { property?: string }) => {
   if (payload.property) {
-    SFN.waitFor(10);
+    $SFN.waitFor(10);
     // the lambda function `serviceCall` is invoked like an ordinary function from the state machine.
     await serviceCall(payload.property);
   } else {
@@ -74,7 +74,7 @@ const serviceCall = new Function(scope, "serviceCall", async (input: string) => 
 });
 new StepFunction(scope, "F", async (payload: { property?: string }) => {
   if (payload.property) {
-    SFN.waitFor(10);
+    $SFN.waitFor(10);
     await serviceCall(payload.property);
   } else {
     throw new Error("missing property");


### PR DESCRIPTION
Minor fix to Step Function documentation. I was following along and couldn't find the `SFN` symbol. Presume it was renamed to `$SFN` at some point and docs were not updated.