### PR TITLE
chore: force pyOpenSSL to upgrade

### DIFF
--- a/scripts/localstack
+++ b/scripts/localstack
@@ -3,7 +3,7 @@
 # Installs and runs localstack
 
 # install LocalStack cli and awslocal
-pip install localstack --upgrade awscli-local[ver1]
+pip install localstack pyOpenSSL awscli-local[ver1] --upgrade
 # install CDK Local
 npm install -g aws-cdk-local aws-cdk
 # Make sure to pull the latest version of the image


### PR DESCRIPTION
Localstack is failing to start due to changes in pip that github actions has not patched yet.

https://askubuntu.com/questions/1428181/module-lib-has-no-attribute-x509-v-flag-cb-issuer-check