### PR TITLE
fix: ForOfStmt, ForInStmt, ForStmt, WhileStmt, DoStmt ES conformance

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -741,7 +741,7 @@ export class APIGatewayVTL extends VTL {
         const serviceCall = new IntegrationImpl(integration);
         return this.integrate(serviceCall, expr);
       } else if (isReferenceExpr(expr.expr) || isThisExpr(expr.expr)) {
-        const ref = expr.expr.ref();
+        const ref = expr.expr.ref?.();
         if (ref === Number) {
           // Number() = 0
           return expr.args[0] ? this.exprToJson(expr.args[0]) : "0";

--- a/src/appsync.ts
+++ b/src/appsync.ts
@@ -149,7 +149,7 @@ export class AppsyncVTL extends VTL {
 
   protected dereference(id: Identifier | ReferenceExpr | ThisExpr): string {
     if (isReferenceExpr(id) || isThisExpr(id)) {
-      const ref = id.ref();
+      const ref = id.ref?.();
       if (ref === $util) {
         return "$util";
       }
@@ -537,7 +537,8 @@ function synthesizeFunctions(api: appsync.GraphqlApi, decl: FunctionLike) {
                     emptySpan(),
                     new StringLiteralExpr(emptySpan(), "[L")
                   ),
-                ]
+                ],
+                false
               ),
               "||",
               new CallExpr(
@@ -553,7 +554,8 @@ function synthesizeFunctions(api: appsync.GraphqlApi, decl: FunctionLike) {
                     emptySpan(),
                     new StringLiteralExpr(emptySpan(), "ArrayList")
                   ),
-                ]
+                ],
+                false
               )
             ),
             new BinaryExpr(
@@ -575,7 +577,8 @@ function synthesizeFunctions(api: appsync.GraphqlApi, decl: FunctionLike) {
                 new Identifier(emptySpan(), "containsKey"),
                 false
               ),
-              [new Argument(updatedNode.left.span, updatedNode.left)]
+              [new Argument(updatedNode.left.span, updatedNode.left)],
+              false
             )
           );
         }

--- a/src/asl/synth.ts
+++ b/src/asl/synth.ts
@@ -627,9 +627,16 @@ export class ASL {
                 this.evalDecl(stmt.initializer.decls[0]!, {
                   jsonPath: `${tempArrayPath}[0]`,
                 })!
-              : this.evalAssignment(stmt.initializer, {
+              : isIdentifier(stmt.initializer)
+              ? this.evalAssignment(stmt.initializer, {
                   jsonPath: `${tempArrayPath}[0]`,
-                })!;
+                })!
+              : (() => {
+                  throw new SynthError(
+                    ErrorCodes.Unsupported_Feature,
+                    `expression ${stmt.initializer.nodeKind} is not supported as the initializer in a ForInStmt`
+                  );
+                })();
           }
         })();
 
@@ -4665,7 +4672,7 @@ function toStateName(node?: FunctionlessNode): string {
         ? toStateName(node.initializer)
         : isVariableDeclList(node.initializer)
         ? toStateName(node.initializer.decls[0]!.name)
-        : toStateName(node.initializer.name)
+        : toStateName(node.initializer)
     } in ${toStateName(node.expr)})`;
   } else if (isForOfStmt(node)) {
     return `for(${toStateName(node.initializer)} of ${toStateName(node.expr)})`;

--- a/src/declaration.ts
+++ b/src/declaration.ts
@@ -487,6 +487,10 @@ export class VariableDecl<
 
 export type VariableDeclListParent = ForStmt | VariableStmt;
 
+export type SingleEntryVariableDeclList = VariableDeclList & {
+  readonly decls: [VariableDecl];
+};
+
 export class VariableDeclList extends BaseNode<
   NodeKind.VariableDeclList,
   VariableDeclListParent

--- a/src/expression.ts
+++ b/src/expression.ts
@@ -57,6 +57,7 @@ export type Expr =
   | SpreadAssignExpr
   | SpreadElementExpr
   | StringLiteralExpr
+  | SuperKeyword
   | TaggedTemplateExpr
   | TemplateExpr
   | ThisExpr
@@ -196,12 +197,37 @@ export class ReferenceExpr<
      * Range of text in the source file where this Node resides.
      */
     span: Span,
+    /**
+     * Name of the referenced variable.
+     *
+     * ```ts
+     * let i;
+     *
+     * i; // "i"
+     * ```
+     */
     readonly name: string,
-    readonly ref: () => R
+    /**
+     * A closure that produces the referred value.
+     */
+    readonly ref: () => R,
+    /**
+     * A number that uniquely identifies the variable within this AST.
+     *
+     * This is used to ensure that two ReferenceExpr's pointing to the same variable still point
+     * to the same variable after transformation.
+     */
+    readonly id: number | undefined,
+    /**
+     * Unique ID of this reference.
+     */
+    readonly referenceId: number | undefined
   ) {
     super(NodeKind.ReferenceExpr, span, arguments);
     this.ensure(name, "name", ["undefined", "string"]);
     this.ensure(ref, "ref", ["function"]);
+    this.ensure(id, "id", ["number", "undefined"]);
+    this.ensure(referenceId, "referenceId", ["number", "undefined"]);
   }
 }
 
@@ -300,10 +326,7 @@ export class Argument extends BaseExpr<NodeKind.Argument, CallExpr | NewExpr> {
 }
 
 export class CallExpr<
-  E extends Expr | SuperKeyword | ImportKeyword =
-    | Expr
-    | SuperKeyword
-    | ImportKeyword
+  E extends Expr | ImportKeyword = Expr | ImportKeyword
 > extends BaseExpr<NodeKind.CallExpr> {
   constructor(
     /**
@@ -311,9 +334,18 @@ export class CallExpr<
      */
     span: Span,
     readonly expr: E,
-    readonly args: Argument[]
+    readonly args: Argument[],
+    /**
+     * Is this an optionally chained call?
+     *
+     * a?.()
+     */
+    readonly isOptional: boolean | undefined
   ) {
     super(NodeKind.CallExpr, span, arguments);
+    this.ensure(expr, "expr", ["Expr"]);
+    this.ensureArrayOf(args, "args", [NodeKind.Argument]);
+    this.ensure(isOptional, "isOptional", ["boolean", "undefined"]);
   }
 }
 
@@ -889,19 +921,14 @@ export class ThisExpr<T = any> extends BaseExpr<NodeKind.ThisExpr> {
     /**
      * Produce the value of `this`
      */
-    readonly ref: () => T
+    readonly ref: (() => T) | undefined
   ) {
     super(NodeKind.ThisExpr, span, arguments);
-    this.ensure(ref, "ref", ["function"]);
+    this.ensure(ref, "ref", ["undefined", "function"]);
   }
 }
 
-export class SuperKeyword extends BaseNode<NodeKind.SuperKeyword> {
-  // `super` is not an expression - a reference to it does not yield a value
-  // it only supports the following interactions
-  // 1. call in a constructor - `super(..)`
-  // 2. call a method on it - `super.method(..)`.
-  readonly nodeKind = "Node";
+export class SuperKeyword extends BaseExpr<NodeKind.SuperKeyword> {
   constructor(
     /**
      * Range of text in the source file where this Node resides.

--- a/src/expression.ts
+++ b/src/expression.ts
@@ -210,24 +210,11 @@ export class ReferenceExpr<
     /**
      * A closure that produces the referred value.
      */
-    readonly ref: () => R,
-    /**
-     * A number that uniquely identifies the variable within this AST.
-     *
-     * This is used to ensure that two ReferenceExpr's pointing to the same variable still point
-     * to the same variable after transformation.
-     */
-    readonly id: number | undefined,
-    /**
-     * Unique ID of this reference.
-     */
-    readonly referenceId: number | undefined
+    readonly ref: () => R
   ) {
     super(NodeKind.ReferenceExpr, span, arguments);
     this.ensure(name, "name", ["undefined", "string"]);
     this.ensure(ref, "ref", ["function"]);
-    this.ensure(id, "id", ["number", "undefined"]);
-    this.ensure(referenceId, "referenceId", ["number", "undefined"]);
   }
 }
 

--- a/src/integration.ts
+++ b/src/integration.ts
@@ -309,8 +309,9 @@ export function findDeepIntegrations(
             node.fork(
               new CallExpr(
                 node.span,
-                new ReferenceExpr(node.expr.span, "", () => integration),
-                node.args.map((arg) => arg.clone())
+                new ReferenceExpr(node.expr.span, "", () => integration, 0, 0),
+                node.args.map((arg) => arg.clone()),
+                false
               )
             )
           )
@@ -419,7 +420,7 @@ export function tryResolveReferences(
       return tryResolveReferences(defaultValue, undefined);
     }
   } else if (isReferenceExpr(node) || isThisExpr(node)) {
-    return [node.ref()];
+    return [node.ref?.()];
   } else if (isIdentifier(node)) {
     return tryResolveReferences(node.lookup(), defaultValue);
   } else if (isBindingElem(node)) {

--- a/src/integration.ts
+++ b/src/integration.ts
@@ -309,7 +309,7 @@ export function findDeepIntegrations(
             node.fork(
               new CallExpr(
                 node.span,
-                new ReferenceExpr(node.expr.span, "", () => integration, 0, 0),
+                new ReferenceExpr(node.expr.span, "", () => integration),
                 node.args.map((arg) => arg.clone()),
                 false
               )

--- a/src/node.ts
+++ b/src/node.ts
@@ -285,7 +285,7 @@ export abstract class BaseNode<
         return self.exit();
       }
     } else if (isDoStmt(self)) {
-      return self.block.step();
+      return self.stmt.step();
     } else if (self.nodeKind === "Stmt") {
       return self;
     } else {

--- a/src/span.ts
+++ b/src/span.ts
@@ -4,13 +4,13 @@
  */
 export type Span = [
   /**
-   * Character position where this span starts.
+   * 1-based line number of the span.
    */
-  start: number,
+  line: number,
   /**
-   * Character position where this span ends.
+   * 0-based column of the span.
    */
-  end: number
+  column: number
 ];
 
 /**

--- a/src/statement.ts
+++ b/src/statement.ts
@@ -176,10 +176,7 @@ export class ForOfStmt extends BaseStmt<NodeKind.ForOfStmt> {
      * Range of text in the source file where this Node resides.
      */
     span: Span,
-    readonly initializer:
-      | SingleEntryVariableDeclList
-      | VariableDecl
-      | Identifier,
+    readonly initializer: SingleEntryVariableDeclList | VariableDecl | Expr,
     readonly expr: Expr,
     readonly stmt: Stmt,
     /**
@@ -192,9 +189,9 @@ export class ForOfStmt extends BaseStmt<NodeKind.ForOfStmt> {
   ) {
     super(NodeKind.ForOfStmt, span, arguments);
     this.ensure(initializer, "initializer", [
+      "Expr",
       NodeKind.VariableDeclList,
       NodeKind.VariableDecl,
-      NodeKind.Identifier,
     ]);
     this.ensure(expr, "expr", ["Expr"]);
     this.ensure(stmt, "stmt", ["Stmt"]);
@@ -208,10 +205,7 @@ export class ForInStmt extends BaseStmt<NodeKind.ForInStmt> {
      * Range of text in the source file where this Node resides.
      */
     span: Span,
-    readonly initializer:
-      | SingleEntryVariableDeclList
-      | VariableDecl
-      | Identifier,
+    readonly initializer: SingleEntryVariableDeclList | VariableDecl | Expr,
     readonly expr: Expr,
     readonly stmt: Stmt
   ) {

--- a/src/statement.ts
+++ b/src/statement.ts
@@ -192,6 +192,7 @@ export class ForOfStmt extends BaseStmt<NodeKind.ForOfStmt> {
   ) {
     super(NodeKind.ForOfStmt, span, arguments);
     this.ensure(initializer, "initializer", [
+      NodeKind.VariableDeclList,
       NodeKind.VariableDecl,
       NodeKind.Identifier,
     ]);
@@ -216,7 +217,6 @@ export class ForInStmt extends BaseStmt<NodeKind.ForInStmt> {
   ) {
     super(NodeKind.ForInStmt, span, arguments);
     this.ensure(initializer, "initializer", [
-      "undefined",
       "Expr",
       NodeKind.VariableDeclList,
       NodeKind.VariableDecl,

--- a/src/statement.ts
+++ b/src/statement.ts
@@ -1,5 +1,6 @@
 import type {
   FunctionDecl,
+  SingleEntryVariableDeclList,
   VariableDecl,
   VariableDeclList,
 } from "./declaration";
@@ -175,9 +176,12 @@ export class ForOfStmt extends BaseStmt<NodeKind.ForOfStmt> {
      * Range of text in the source file where this Node resides.
      */
     span: Span,
-    readonly initializer: VariableDecl | Identifier,
+    readonly initializer:
+      | SingleEntryVariableDeclList
+      | VariableDecl
+      | Identifier,
     readonly expr: Expr,
-    readonly body: BlockStmt,
+    readonly stmt: Stmt,
     /**
      * Whether this is a for-await-of statement
      * ```ts
@@ -192,6 +196,7 @@ export class ForOfStmt extends BaseStmt<NodeKind.ForOfStmt> {
       NodeKind.Identifier,
     ]);
     this.ensure(expr, "expr", ["Expr"]);
+    this.ensure(stmt, "stmt", ["Stmt"]);
     this.ensure(isAwait, "isAwait", ["boolean"]);
   }
 }
@@ -202,11 +207,22 @@ export class ForInStmt extends BaseStmt<NodeKind.ForInStmt> {
      * Range of text in the source file where this Node resides.
      */
     span: Span,
-    readonly initializer: VariableDecl | Identifier,
+    readonly initializer:
+      | SingleEntryVariableDeclList
+      | VariableDecl
+      | Identifier,
     readonly expr: Expr,
-    readonly body: BlockStmt
+    readonly stmt: Stmt
   ) {
     super(NodeKind.ForInStmt, span, arguments);
+    this.ensure(initializer, "initializer", [
+      "undefined",
+      "Expr",
+      NodeKind.VariableDeclList,
+      NodeKind.VariableDecl,
+    ]);
+    this.ensure(stmt, "stmt", ["Stmt"]);
+    this.ensure(expr, "expr", ["Expr"]);
   }
 }
 
@@ -216,13 +232,13 @@ export class ForStmt extends BaseStmt<NodeKind.ForStmt> {
      * Range of text in the source file where this Node resides.
      */
     span: Span,
-    readonly body: BlockStmt,
+    readonly stmt: Stmt,
     readonly initializer?: VariableDeclList | Expr,
     readonly condition?: Expr,
     readonly incrementor?: Expr
   ) {
     super(NodeKind.ForStmt, span, arguments);
-    this.ensure(body, "body", [NodeKind.BlockStmt]);
+    this.ensure(stmt, "stmt", ["Stmt"]);
     this.ensure(initializer, "initializer", [
       "undefined",
       "Expr",
@@ -326,11 +342,11 @@ export class WhileStmt extends BaseStmt<NodeKind.WhileStmt> {
      */
     span: Span,
     readonly condition: Expr,
-    readonly block: BlockStmt
+    readonly stmt: Stmt
   ) {
     super(NodeKind.WhileStmt, span, arguments);
     this.ensure(condition, "condition", ["Expr"]);
-    this.ensure(block, "block", [NodeKind.BlockStmt]);
+    this.ensure(stmt, "stmt", ["Stmt"]);
   }
 }
 
@@ -340,11 +356,11 @@ export class DoStmt extends BaseStmt<NodeKind.DoStmt> {
      * Range of text in the source file where this Node resides.
      */
     span: Span,
-    readonly block: BlockStmt,
+    readonly stmt: Stmt,
     readonly condition: Expr
   ) {
     super(NodeKind.DoStmt, span, arguments);
-    this.ensure(block, "block", [NodeKind.BlockStmt]);
+    this.ensure(stmt, "stmt", ["Stmt"]);
     this.ensure(condition, "condition", ["Expr"]);
   }
 }

--- a/src/vtl.ts
+++ b/src/vtl.ts
@@ -5,6 +5,7 @@ import {
   Decl,
   ParameterDecl,
   VariableDecl,
+  VariableDeclList,
 } from "./declaration";
 import { ErrorCodes, SynthError } from "./error-code";
 import {
@@ -87,6 +88,7 @@ import {
   isUnaryExpr,
   isUndefinedLiteralExpr,
   isVariableDecl,
+  isVariableDeclList,
   isVariableStmt,
   isVoidExpr,
   isWhileStmt,
@@ -257,20 +259,21 @@ export abstract class VTL {
   }
 
   public foreach(
-    iterVar: string | Expr | VariableDecl,
+    iterVar: string | Expr | VariableDecl | VariableDeclList,
     iterValue: string | Expr,
     body: string | Stmt | (() => void)
   ) {
-    if (isVariableDecl(iterVar)) {
-      if (isBindingPattern(iterVar.name)) {
+    if (isVariableDecl(iterVar) || isVariableDeclList(iterVar)) {
+      const varDecl = isVariableDeclList(iterVar) ? iterVar.decls[0]! : iterVar;
+      if (isBindingPattern(varDecl.name)) {
         // iterate into a temp variable
         const tempVar = this.newLocalVarName();
         this.add(`#foreach(${tempVar} in ${this.printExpr(iterValue)})`);
         // deconstruct from the temp variable
-        this.evaluateBindingPattern(iterVar.name, tempVar);
+        this.evaluateBindingPattern(varDecl.name, tempVar);
       } else {
         this.add(
-          `#foreach($${iterVar.name.name} in ${this.printExpr(iterValue)})`
+          `#foreach($${varDecl.name.name} in ${this.printExpr(iterValue)})`
         );
       }
     } else {
@@ -597,7 +600,7 @@ export abstract class VTL {
       this.foreach(
         node.initializer,
         `${this.eval(node.expr)}${isForInStmt(node) ? ".keySet()" : ""}`,
-        node.body
+        node.stmt
       );
       return undefined;
     } else if (isFunctionExpr(node) || isArrowFunctionExpr(node)) {


### PR DESCRIPTION
Partial https://github.com/functionless/functionless/issues/374

- [x] change `block: BlockStmt` to `stmt: Stmt` - our prior AST was too narrow, requiring everything be a BlockSmt
```ts
while (true) <stmt>
``` 
- [x] support optional chaining on calls
```ts
call.?(..args)
```
- [x] Update `initializer` in for-loops to allow `VariableDeclList` - this is because `const | let | var` is stored on the `VariableDeclList`, not a `VariableDecl`. For backwards compatibility purposes, we will continue to allow VariableDecl until ast-reflection is updated to always write VariableDeclList.