### PR TITLE
chore: remove backwards compatible VariableDecl in ForOfStmt and ForInStmt

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -223,7 +223,7 @@
     },
     {
       "name": "@functionless/ast-reflection",
-      "version": "^0.2.2",
+      "version": "^0.3.1",
       "type": "runtime"
     },
     {

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -85,7 +85,7 @@ const project = new CustomTypescriptProject({
     "fs-extra",
     "minimatch",
     "@functionless/nodejs-closure-serializer",
-    "@functionless/ast-reflection@^0.2.2",
+    "@functionless/ast-reflection@^0.3.1",
     "@swc/cli",
     "@swc/core@1.2.245",
     "@swc/register",

--- a/package.json
+++ b/package.json
@@ -143,10 +143,6 @@
     ]
   },
   "types": "lib/index.d.ts",
-  "resolutions": {
-    "@types/responselike": "1.0.0",
-    "got": "12.3.1"
-  },
   "lint-staged": {
     "*.{tsx,jsx,ts,js,json,md,css}": [
       "eslint --fix"

--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "@aws-cdk/aws-appsync-alpha": "*"
   },
   "dependencies": {
-    "@functionless/ast-reflection": "^0.2.2",
+    "@functionless/ast-reflection": "^0.3.1",
     "@functionless/nodejs-closure-serializer": "^0.1.2",
     "@swc/cli": "^0.1.57",
     "@swc/core": "1.2.245",
@@ -143,6 +143,10 @@
     ]
   },
   "types": "lib/index.d.ts",
+  "resolutions": {
+    "@types/responselike": "1.0.0",
+    "got": "12.3.1"
+  },
   "lint-staged": {
     "*.{tsx,jsx,ts,js,json,md,css}": [
       "eslint --fix"

--- a/src/asl/synth.ts
+++ b/src/asl/synth.ts
@@ -584,13 +584,6 @@ export class ASL {
           if (isForInStmt(stmt)) {
             const initializerName = isIdentifier(stmt.initializer)
               ? this.getIdentifierName(stmt.initializer)
-              : isVariableDecl(stmt.initializer) &&
-                isIdentifier(stmt.initializer.name)
-              ? this.getDeclarationName(
-                  stmt.initializer as VariableDecl & {
-                    name: Identifier;
-                  }
-                )
               : isVariableDeclList(stmt.initializer) &&
                 isIdentifier(stmt.initializer.decls[0].name)
               ? this.getDeclarationName(
@@ -626,12 +619,7 @@ export class ASL {
               },
             };
           } else {
-            return isVariableDecl(stmt.initializer)
-              ? this.evalDecl(stmt.initializer, {
-                  jsonPath: `${tempArrayPath}[0]`,
-                })!
-              : // TODO: deprecate ^ VariableDecl in favor of VariableDeclList
-              isVariableDeclList(stmt.initializer)
+            return isVariableDeclList(stmt.initializer)
               ? this.evalDecl(stmt.initializer.decls[0]!, {
                   jsonPath: `${tempArrayPath}[0]`,
                 })!
@@ -3782,9 +3770,6 @@ export class ASL {
             } else if (isVariableDeclList(parent.initializer)) {
               // for (let i in ..)
               return parent.initializer.decls[0] === element;
-            } else if (isVariableDecl(parent.initializer)) {
-              // for (let i in ..)
-              return parent.initializer === element;
             }
           }
           return false;

--- a/src/statement.ts
+++ b/src/statement.ts
@@ -176,7 +176,7 @@ export class ForOfStmt extends BaseStmt<NodeKind.ForOfStmt> {
      * Range of text in the source file where this Node resides.
      */
     span: Span,
-    readonly initializer: SingleEntryVariableDeclList | VariableDecl | Expr,
+    readonly initializer: SingleEntryVariableDeclList | Expr,
     readonly expr: Expr,
     readonly stmt: Stmt,
     /**
@@ -191,7 +191,6 @@ export class ForOfStmt extends BaseStmt<NodeKind.ForOfStmt> {
     this.ensure(initializer, "initializer", [
       "Expr",
       NodeKind.VariableDeclList,
-      NodeKind.VariableDecl,
     ]);
     this.ensure(expr, "expr", ["Expr"]);
     this.ensure(stmt, "stmt", ["Stmt"]);
@@ -205,7 +204,7 @@ export class ForInStmt extends BaseStmt<NodeKind.ForInStmt> {
      * Range of text in the source file where this Node resides.
      */
     span: Span,
-    readonly initializer: SingleEntryVariableDeclList | VariableDecl | Expr,
+    readonly initializer: SingleEntryVariableDeclList | Expr,
     readonly expr: Expr,
     readonly stmt: Stmt
   ) {
@@ -213,7 +212,6 @@ export class ForInStmt extends BaseStmt<NodeKind.ForInStmt> {
     this.ensure(initializer, "initializer", [
       "Expr",
       NodeKind.VariableDeclList,
-      NodeKind.VariableDecl,
     ]);
     this.ensure(stmt, "stmt", ["Stmt"]);
     this.ensure(expr, "expr", ["Expr"]);

--- a/src/vtl.ts
+++ b/src/vtl.ts
@@ -259,12 +259,12 @@ export abstract class VTL {
   }
 
   public foreach(
-    iterVar: string | Expr | VariableDecl | VariableDeclList,
+    iterVar: string | Expr | VariableDeclList,
     iterValue: string | Expr,
     body: string | Stmt | (() => void)
   ) {
-    if (isVariableDecl(iterVar) || isVariableDeclList(iterVar)) {
-      const varDecl = isVariableDeclList(iterVar) ? iterVar.decls[0]! : iterVar;
+    if (isVariableDeclList(iterVar)) {
+      const varDecl = iterVar.decls[0]!;
       if (isBindingPattern(varDecl.name)) {
         // iterate into a temp variable
         const tempVar = this.newLocalVarName();

--- a/test-app/yarn.lock
+++ b/test-app/yarn.lock
@@ -1179,10 +1179,10 @@
     ts-node "^9"
     tslib "^2"
 
-"@functionless/ast-reflection@^0.2.2":
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/@functionless/ast-reflection/-/ast-reflection-0.2.2.tgz#976ec73af75028cb6216d70fa5266db368b0590a"
-  integrity sha512-YtvaEnorKparTOOIXmEbUXEfN4vOGl9jyXY7tvCDAgDpGMdJI2xAs108nHjNa6gabL9Xvojm6I1SuPC+EAsBvg==
+"@functionless/ast-reflection@^0.3.1":
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/@functionless/ast-reflection/-/ast-reflection-0.3.1.tgz#5823249bbe3c9a57eb7b3471cff222577652cb38"
+  integrity sha512-to/pjwiN2KzZKY/ypTf4njFQ/dbFw+d9nfbpbjzBDwetFd+2b7KRjuI2c/FkiXlTrKTKNNYP9nyypocRk8q1bg==
 
 "@functionless/language-service@^0.0.3":
   version "0.0.3"
@@ -2800,7 +2800,7 @@ function.prototype.name@^1.1.5:
 "functionless@file:..":
   version "0.0.0"
   dependencies:
-    "@functionless/ast-reflection" "^0.2.2"
+    "@functionless/ast-reflection" "^0.3.1"
     "@functionless/nodejs-closure-serializer" "^0.1.2"
     "@swc/cli" "^0.1.57"
     "@swc/core" "1.2.245"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1040,10 +1040,10 @@
     minimatch "^3.1.2"
     strip-json-comments "^3.1.1"
 
-"@functionless/ast-reflection@^0.2.2":
-  version "0.2.2"
-  resolved "https://registry.yarnpkg.com/@functionless/ast-reflection/-/ast-reflection-0.2.2.tgz#976ec73af75028cb6216d70fa5266db368b0590a"
-  integrity sha512-YtvaEnorKparTOOIXmEbUXEfN4vOGl9jyXY7tvCDAgDpGMdJI2xAs108nHjNa6gabL9Xvojm6I1SuPC+EAsBvg==
+"@functionless/ast-reflection@^0.3.1":
+  version "0.3.1"
+  resolved "https://registry.yarnpkg.com/@functionless/ast-reflection/-/ast-reflection-0.3.1.tgz#5823249bbe3c9a57eb7b3471cff222577652cb38"
+  integrity sha512-to/pjwiN2KzZKY/ypTf4njFQ/dbFw+d9nfbpbjzBDwetFd+2b7KRjuI2c/FkiXlTrKTKNNYP9nyypocRk8q1bg==
 
 "@functionless/nodejs-closure-serializer@^0.1.2":
   version "0.1.2"
@@ -1868,7 +1868,7 @@
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.7.0.tgz#ea03e9f0376a4446f44797ca19d9c46c36e352dc"
   integrity sha512-RI1L7N4JnW5gQw2spvL7Sllfuf1SaHdrZpCHiBlCXjIlufi1SMNnbu2teze3/QE67Fg2tBlH7W+mi4hVNk4p0A==
 
-"@types/responselike@*", "@types/responselike@^1.0.0":
+"@types/responselike@*", "@types/responselike@1.0.0", "@types/responselike@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@types/responselike/-/responselike-1.0.0.tgz#251f4fe7d154d2bad125abe1b429b23afd262e29"
   integrity sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==
@@ -4415,7 +4415,7 @@ globby@^11.0.4, globby@^11.1.0:
     merge2 "^1.4.1"
     slash "^3.0.0"
 
-got@^12.1.0:
+got@12.3.1, got@^12.1.0:
   version "12.3.1"
   resolved "https://registry.yarnpkg.com/got/-/got-12.3.1.tgz#79d6ebc0cb8358c424165698ddb828be56e74684"
   integrity sha512-tS6+JMhBh4iXMSXF6KkIsRxmloPln31QHDlcb6Ec3bzxjjFJFr/8aXdpyuLmVc9I4i2HyBHYw1QU5K1ruUdpkw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1868,7 +1868,7 @@
   resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.7.0.tgz#ea03e9f0376a4446f44797ca19d9c46c36e352dc"
   integrity sha512-RI1L7N4JnW5gQw2spvL7Sllfuf1SaHdrZpCHiBlCXjIlufi1SMNnbu2teze3/QE67Fg2tBlH7W+mi4hVNk4p0A==
 
-"@types/responselike@*", "@types/responselike@1.0.0", "@types/responselike@^1.0.0":
+"@types/responselike@*", "@types/responselike@^1.0.0":
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/@types/responselike/-/responselike-1.0.0.tgz#251f4fe7d154d2bad125abe1b429b23afd262e29"
   integrity sha512-85Y2BjiufFzaMIlvJDvTTB8Fxl2xfLo4HgmHzVBz08w4wDePCTjYw66PdrolO0kzli3yam/YCgRufyo1DdQVTA==
@@ -4415,7 +4415,7 @@ globby@^11.0.4, globby@^11.1.0:
     merge2 "^1.4.1"
     slash "^3.0.0"
 
-got@12.3.1, got@^12.1.0:
+got@^12.1.0:
   version "12.3.1"
   resolved "https://registry.yarnpkg.com/got/-/got-12.3.1.tgz#79d6ebc0cb8358c424165698ddb828be56e74684"
   integrity sha512-tS6+JMhBh4iXMSXF6KkIsRxmloPln31QHDlcb6Ec3bzxjjFJFr/8aXdpyuLmVc9I4i2HyBHYw1QU5K1ruUdpkw==


### PR DESCRIPTION
Upgrade to ast-reflection@0.3.1 and remove VariableDecl from ForOfStmt and ForInStmt

BREAKING CHANGE: ForOfStmt and ForInStmt now only accept VariableDeclList for the initializer.