### PR TITLE
fix: improve error when function is undefined

### DIFF
--- a/src/reflect.ts
+++ b/src/reflect.ts
@@ -120,7 +120,12 @@ function validateFunctionlessNode<Node extends FunctionlessNode>(
   functionLocation: string,
   validate: (e: FunctionlessNode) => e is Node
 ): Node {
-  if (validate(a)) {
+  if (a === undefined) {
+    throw new SynthError(
+      ErrorCodes.Invalid_Input,
+      `Expected input function to ${functionLocation} to be present, received undefined.`
+    );
+  } else if (validate(a)) {
     return validateFunctionlessNodeSemantics(a);
   } else if (isErr(a)) {
     throw a.error;


### PR DESCRIPTION
Undefined function declarations would throw a confusing error

> Expected input function to [] to be compiled by Functionless

Instead return a more friendly message that the function is undefined.

> Expected input function to [] to be present, received undefined.