### PR TITLE
fix: increase assume role lifetime and CDK deploy change flags

### DIFF
--- a/test/runtime.ts
+++ b/test/runtime.ts
@@ -337,7 +337,6 @@ export function runtimeTestSuite<
             Value: v,
           })),
           hotswap: true,
-          progress: StackActivityProgress.EVENTS,
         })
       );
 

--- a/test/runtime.ts
+++ b/test/runtime.ts
@@ -572,7 +572,7 @@ async function getRuntimeClients(
         .assumeRole({
           RoleArn: testRoleArn,
           RoleSessionName: "testSession",
-          DurationSeconds: 30 * 60,
+          DurationSeconds: 60 * 60, // hour
         })
         .promise()
     : undefined;

--- a/test/runtime.ts
+++ b/test/runtime.ts
@@ -3,6 +3,7 @@ import { App, CfnOutput, Stack } from "aws-cdk-lib";
 import { ArnPrincipal, Role } from "aws-cdk-lib/aws-iam";
 import { SdkProvider } from "aws-cdk/lib/api/aws-auth";
 import { CloudFormationDeployments } from "aws-cdk/lib/api/cloudformation-deployments";
+import { StackActivityProgress } from "aws-cdk/lib/api/util/cloudformation/stack-activity-monitor";
 // eslint-disable-next-line import/no-extraneous-dependencies
 import AWS, {
   DynamoDB,
@@ -335,7 +336,8 @@ export function runtimeTestSuite<
             Key: k,
             Value: v,
           })),
-          force: true,
+          hotswap: true,
+          progress: StackActivityProgress.EVENTS,
         })
       );
 


### PR DESCRIPTION
Release is failing because the creds were set to live for 30 min and the tests were taking 40+ minutes, increasing to 1 hour.

Updated deployment flag:
1. force - false, will not try to deploy if one isn't needed, should reduce churn with multiple commits on the same branch
2. hotswap - should try to push out new lambda and sfn definitions when they are the only part that changes