### PR TITLE
fix: infer type of Function inlined inside EventBus.pipe

### DIFF
--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -195,6 +195,9 @@
       },
       "steps": [
         {
+          "exec": "tsc -p ./tsconfig.dev.json --noEmit"
+        },
+        {
           "spawn": "test:fast"
         },
         {

--- a/.projenrc.ts
+++ b/.projenrc.ts
@@ -266,6 +266,8 @@ project.testTask.reset();
 project.testTask.env("TEST_DEPLOY_TARGET", "AWS");
 project.testTask.env("NODE_OPTIONS", "--max-old-space-size=6144");
 
+project.testTask.exec("tsc -p ./tsconfig.dev.json --noEmit");
+
 const testFast = project.addTask("test:fast", {
   exec: "jest --passWithNoTests --all --updateSnapshot --testPathIgnorePatterns '(localstack|runtime)'",
 });

--- a/src/event-bridge/event-bus.ts
+++ b/src/event-bridge/event-bus.ts
@@ -32,7 +32,6 @@ import {
   isIntegration,
   makeIntegration,
 } from "../integration";
-import type { AnyFunction } from "../util";
 import {
   RulePredicateFunction,
   Rule,
@@ -809,7 +808,7 @@ export interface EventBusTargetIntegration<
    * We use a function interface in order to satisfy the covariant relationship that we expect the super-P in as opposed to
    * returning sub-P.
    */
-  __payloadBrand: (p: Payload) => void;
+  __payloadBrand: (p: Payload) => void | Promise<void>;
 
   /**
    * Method called when an integration is passed to EventBus's `.pipe` function.
@@ -826,7 +825,9 @@ export interface EventBusTargetIntegration<
 export type IntegrationWithEventBus<
   Payload,
   Props extends object | undefined = undefined
-> = Integration<string, AnyFunction, EventBusTargetIntegration<Payload, Props>>;
+> = {
+  eventBus: EventBusTargetIntegration<Payload, Props>;
+};
 
 /**
  * @typeParam - Payload - the type which the {@link Integration} expects as an input from {@link EventBus}.
@@ -840,12 +841,6 @@ export function makeEventBusIntegration<
 ) {
   return integration as EventBusTargetIntegration<Payload, Props>;
 }
-
-export type IntegrationWithEventBusProps<
-  Integration extends IntegrationWithEventBus<any, any>
-> = Integration extends IntegrationWithEventBus<any, infer Props>
-  ? Props
-  : undefined;
 
 export type DynamicProps<Props> = Props extends never
   ? never
@@ -871,14 +866,14 @@ export function pipe<
   props: Props,
   targetInput: Target
 ) {
-  if (isIntegration<IntegrationWithEventBus<Payload, Props>>(integration)) {
+  if (isIntegration(integration)) {
     const target = new IntegrationImpl(integration).eventBus.target(
       props,
       targetInput
     );
     return rule.resource.addTarget(target);
   } else {
-    return rule.resource.addTarget(integration(targetInput));
+    return rule.resource.addTarget((integration as any)(targetInput));
   }
 }
 

--- a/src/event-bridge/event-bus.ts
+++ b/src/event-bridge/event-bus.ts
@@ -163,11 +163,7 @@ export interface IEventBus<in Evnt extends Event = Event>
       (
         event: PutEventInput<Evnt>,
         ...events: PutEventInput<Evnt>[]
-      ) => Promise<void>,
-      EventBusTargetIntegration<
-        PutEventInput<Evnt>,
-        aws_events_targets.EventBusProps | undefined
-      >
+      ) => Promise<void>
     > {
   readonly resource: aws_events.IEventBus;
   readonly eventBusArn: string;

--- a/src/event-bridge/rule.ts
+++ b/src/event-bridge/rule.ts
@@ -6,7 +6,6 @@ import {
   DynamicProps,
   pipe,
   IntegrationWithEventBus,
-  IntegrationWithEventBusProps,
 } from "./event-bus";
 import {
   andDocuments,
@@ -144,9 +143,9 @@ export interface IRule<out OutEvnt extends Event> {
    * bus.when(...).pipe(new EventBus(targetBus))
    * ```
    */
-  pipe<I extends IntegrationWithEventBus<OutEvnt, any>>(
-    integration: I,
-    ...props: Parameters<DynamicProps<IntegrationWithEventBusProps<I>>>
+  pipe<Props extends object | undefined>(
+    integration: IntegrationWithEventBus<OutEvnt, Props>,
+    ...props: Parameters<DynamicProps<Props>>
   ): void;
   pipe(callback: () => aws_events.IRuleTarget): void;
 }
@@ -186,21 +185,13 @@ abstract class RuleBase<out OutEvnt extends Event> implements IRule<OutEvnt> {
   /**
    * @inheritdoc
    */
-  public pipe<I extends IntegrationWithEventBus<OutEvnt, any>>(
-    integration: I,
-    ...props: Parameters<DynamicProps<IntegrationWithEventBusProps<I>>>
+  public pipe<Props extends object | undefined>(
+    integration: IntegrationWithEventBus<OutEvnt, Props>,
+    ...props: Parameters<DynamicProps<Props>>
   ): void;
   public pipe(callback: () => aws_events.IRuleTarget): void;
-  public pipe<I extends IntegrationWithEventBus<OutEvnt, any>>(
-    integration: I | (() => aws_events.IRuleTarget),
-    ...props: Parameters<DynamicProps<IntegrationWithEventBusProps<I>>>
-  ): void {
-    pipe(
-      this as IRule<OutEvnt>,
-      integration,
-      props[0] as IntegrationWithEventBusProps<I>,
-      undefined
-    );
+  public pipe(...[integration, ...props]: any): void {
+    pipe(this as IRule<OutEvnt>, integration, props[0], undefined);
   }
 }
 

--- a/src/event-bridge/target-input.ts
+++ b/src/event-bridge/target-input.ts
@@ -55,7 +55,7 @@ type PREDEFINED = typeof PREDEFINED_VALUES[number];
  * https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-transform-target-input.html
  */
 export const synthesizeEventBridgeTargets = (
-  maybeDecl: FunctionLike | Err | unknown
+  maybeDecl: FunctionLike | Err | undefined
 ): aws_events.RuleTargetInput => {
   const decl = validateFunctionLike(maybeDecl, "EventBridgeTarget");
 

--- a/src/event-bridge/transform.ts
+++ b/src/event-bridge/transform.ts
@@ -1,6 +1,5 @@
 import { aws_events } from "aws-cdk-lib";
 import { FunctionDecl } from "../declaration";
-import { Integration } from "../integration";
 import {
   DynamicProps,
   IEventBus,
@@ -102,8 +101,7 @@ export class EventTransform<
 /**
  * EventBus to EventBus input transform is not allowed.
  */
-export type NonEventBusIntegration<I extends Integration<any, any, any>> =
-  I extends IEventBus<any> ? never : I;
+export type NonEventBusIntegration<I> = I extends IEventBus<any> ? never : I;
 
 // to prevent the closure serializer from trying to import all of functionless.
 export const deploymentOnlyModule = true;

--- a/src/event-bridge/transform.ts
+++ b/src/event-bridge/transform.ts
@@ -5,7 +5,6 @@ import {
   DynamicProps,
   IEventBus,
   IntegrationWithEventBus,
-  IntegrationWithEventBusProps,
   pipe,
 } from "./event-bus";
 import { IRule } from "./rule";
@@ -75,27 +74,28 @@ export class EventTransform<
    *
    * @see Rule.pipe for more details on pipe.
    */
-  public pipe<I extends IntegrationWithEventBus<Out, any>>(
+  public pipe<
+    I extends IntegrationWithEventBus<Out, Props>,
+    Props extends object | undefined
+  >(
     integration: NonEventBusIntegration<I>,
-    ...props: Parameters<DynamicProps<IntegrationWithEventBusProps<I>>>
+    ...props: Parameters<DynamicProps<Props>>
   ): void;
   public pipe(
     callback: (
       targetInput: aws_events.RuleTargetInput
     ) => aws_events.IRuleTarget
   ): void;
-  public pipe<I extends IntegrationWithEventBus<Out>>(
+  public pipe<
+    I extends IntegrationWithEventBus<Out, Props>,
+    Props extends object | undefined
+  >(
     integration:
       | NonEventBusIntegration<I>
       | ((targetInput: aws_events.RuleTargetInput) => aws_events.IRuleTarget),
-    ...props: Parameters<DynamicProps<IntegrationWithEventBusProps<I>>>
+    ...props: Parameters<DynamicProps<Props>>
   ): void {
-    pipe(
-      this.rule,
-      integration,
-      props[0] as IntegrationWithEventBusProps<I>,
-      this.targetInput
-    );
+    pipe(this.rule, integration, props[0] as any, this.targetInput);
   }
 }
 

--- a/src/function.ts
+++ b/src/function.ts
@@ -131,11 +131,7 @@ export interface EventInvokeConfigOptions<Payload, Output>
  *                         empty to be inferred. ex: `Function<Payload1, Output1 | Output2>`.
  */
 export interface IFunction<in Payload, Output>
-  extends Integration<
-    "Function",
-    ConditionalFunction<Payload, Output>,
-    EventBusTargetIntegration<Payload, FunctionEventBusTargetProps | undefined>
-  > {
+  extends Integration<"Function", ConditionalFunction<Payload, Output>> {
   readonly functionlessKind: typeof Function.FunctionlessType;
   readonly kind: typeof Function.FunctionlessType;
   readonly resource: aws_lambda.IFunction;

--- a/src/integration.ts
+++ b/src/integration.ts
@@ -86,13 +86,7 @@ export const INTEGRATION_TYPE_KEYS = Object.values(INTEGRATION_TYPES);
 /**
  * All integration methods supported by functionless.
  */
-export interface IntegrationMethods<
-  F extends AnyFunction,
-  EventBusInteg extends EventBusTargetIntegration<
-    any,
-    any
-  > = EventBusTargetIntegration<any, any>
-> {
+export interface IntegrationMethods<F extends AnyFunction> {
   /**
    * Integrate with AppSync VTL applications.
    * @private
@@ -111,7 +105,7 @@ export interface IntegrationMethods<
    * @private
    */
   asl: (call: CallExpr, context: ASL) => ASLGraph.NodeResults;
-  eventBus: EventBusInteg;
+  eventBus: EventBusTargetIntegration<any, any>;
   /**
    * Native javascript code integrations that execute at runtime like Lambda.
    */
@@ -168,12 +162,8 @@ export interface IntegrationMethods<
  */
 export interface Integration<
   K extends string = string,
-  F extends AnyFunction = AnyFunction,
-  EventBus extends EventBusTargetIntegration<
-    any,
-    any
-  > = EventBusTargetIntegration<any, any>
-> extends Partial<IntegrationMethods<F, EventBus>> {
+  F extends AnyFunction = AnyFunction
+> extends Partial<IntegrationMethods<F>> {
   /**
    * Brand the Function, F, into this type so that sub-typing rules apply to the function signature.
    */

--- a/src/queue.ts
+++ b/src/queue.ts
@@ -8,7 +8,6 @@ import lambda from "aws-lambda";
 import { Construct } from "constructs";
 import { ASLGraph, Parameters } from "./asl";
 import { ErrorCodes, SynthError } from "./error-code";
-import { EventBusTargetIntegration } from "./event-bridge";
 import { makeEventBusIntegration } from "./event-bridge/event-bus";
 import { EventSource, IEventSource } from "./event-source";
 import { SQSClient } from "./function-prewarm";
@@ -297,11 +296,7 @@ abstract class BaseQueue<Message>
     Integration<
       "Queue",
       // queue is not directly invokable, only via event bridge pipe.
-      () => any,
-      EventBusTargetIntegration<
-        Message,
-        Omit<aws_events_targets.SqsQueueProps, "message"> | undefined
-      >
+      () => any
     >
 {
   /**

--- a/src/step-function.ts
+++ b/src/step-function.ts
@@ -15,10 +15,7 @@ import { assertDefined } from "./assert";
 import { FunctionLike } from "./declaration";
 import { ErrorCodes, SynthError } from "./error-code";
 import { EventBus, PredicateRuleBase, Rule } from "./event-bridge";
-import {
-  EventBusTargetIntegration,
-  makeEventBusIntegration,
-} from "./event-bridge/event-bus";
+import { makeEventBusIntegration } from "./event-bridge/event-bus";
 import { Event } from "./event-bridge/types";
 import { CallExpr, Expr } from "./expression";
 import { NativeIntegration } from "./function";
@@ -1084,15 +1081,7 @@ abstract class BaseStepFunction<
   Payload extends Record<string, any> | undefined,
   CallIn,
   CallOut
-> implements
-    Integration<
-      "StepFunction",
-      (input: CallIn) => Promise<CallOut>,
-      EventBusTargetIntegration<
-        Payload,
-        StepFunctionEventBusTargetProps | undefined
-      >
-    >
+> implements Integration<"StepFunction", (input: CallIn) => Promise<CallOut>>
 {
   readonly kind = "StepFunction";
   readonly functionlessKind = "StepFunction";
@@ -1826,11 +1815,7 @@ export interface IStepFunction<
     "StepFunction",
     (
       input: StepFunctionRequest<Payload>
-    ) => Promise<AWS.StepFunctions.StartExecutionOutput>,
-    EventBusTargetIntegration<
-      Payload,
-      StepFunctionEventBusTargetProps | undefined
-    >
+    ) => Promise<AWS.StepFunctions.StartExecutionOutput>
   > {
   describeExecution: IntegrationCall<
     "StepFunction.describeExecution",

--- a/test/__snapshots__/validate.test.ts.snap
+++ b/test/__snapshots__/validate.test.ts.snap
@@ -939,73 +939,73 @@ https://functionless.org/docs/error-codes#stepfunctions-invalid-collection-acces
 
 [7m435[0m   return obj[input.key];
 [7m   [0m [91m             ~~~~~~~~~[0m
-[96mtest/test-files/step-function.ts[0m:[93m508[0m:[93m11[0m - [91merror[0m[90m Functionless(10026): [0mStepFunction property names must be constant
+[96mtest/test-files/step-function.ts[0m:[93m507[0m:[93m11[0m - [91merror[0m[90m Functionless(10026): [0mStepFunction property names must be constant
 
 https://functionless.org/docs/error-codes#stepfunction-property-names-must-be-constant
 
-[7m508[0m   return {
+[7m507[0m   return {
 [7m   [0m [91m          [0m
-[7m509[0m     [input.key]: "",
+[7m508[0m     [input.key]: "",
 [7m   [0m [91m~~~~~~~~~~~~~~~[0m
-[96mtest/test-files/step-function.ts[0m:[93m563[0m:[93m23[0m - [91merror[0m[90m Functionless(10024): [0mStepFunctions error cause must be a constant
+[96mtest/test-files/step-function.ts[0m:[93m562[0m:[93m23[0m - [91merror[0m[90m Functionless(10024): [0mStepFunctions error cause must be a constant
 
 https://functionless.org/docs/error-codes#stepfunctions-error-cause-must-be-a-constant
 
-[7m563[0m       throw new Error(input.key);
+[7m562[0m       throw new Error(input.key);
 [7m   [0m [91m                      ~~~~~~~~~[0m
-[96mtest/test-files/step-function.ts[0m:[93m565[0m:[93m16[0m - [91merror[0m[90m Functionless(10030): [0mStepFunction throw must be Error or StepFunctionError class
+[96mtest/test-files/step-function.ts[0m:[93m564[0m:[93m16[0m - [91merror[0m[90m Functionless(10030): [0mStepFunction throw must be Error or StepFunctionError class
 
 https://functionless.org/docs/error-codes#stepfunction-throw-must-be-error-or-stepfunctionerror-class
 
-[7m565[0m       throw new CustomError("error");
+[7m564[0m       throw new CustomError("error");
 [7m   [0m [91m               ~~~~~~~~~~~~[0m
-[96mtest/test-files/step-function.ts[0m:[93m568[0m:[93m35[0m - [91merror[0m[90m Functionless(10024): [0mStepFunctions error cause must be a constant
+[96mtest/test-files/step-function.ts[0m:[93m567[0m:[93m35[0m - [91merror[0m[90m Functionless(10024): [0mStepFunctions error cause must be a constant
 
 https://functionless.org/docs/error-codes#stepfunctions-error-cause-must-be-a-constant
 
-[7m568[0m       throw new StepFunctionError(input.key, { reason: "reason" });
+[7m567[0m       throw new StepFunctionError(input.key, { reason: "reason" });
 [7m   [0m [91m                                  ~~~~~~~~~[0m
-[96mtest/test-files/step-function.ts[0m:[93m571[0m:[93m47[0m - [91merror[0m[90m Functionless(10024): [0mStepFunctions error cause must be a constant
+[96mtest/test-files/step-function.ts[0m:[93m570[0m:[93m47[0m - [91merror[0m[90m Functionless(10024): [0mStepFunctions error cause must be a constant
 
 https://functionless.org/docs/error-codes#stepfunctions-error-cause-must-be-a-constant
 
-[7m571[0m       throw new StepFunctionError("ErrorName", { reason: input.key });
+[7m570[0m       throw new StepFunctionError("ErrorName", { reason: input.key });
 [7m   [0m [91m                                              ~~~~~~~~~~~~~~~~~~~~~~[0m
-[96mtest/test-files/step-function.ts[0m:[93m573[0m:[93m47[0m - [91merror[0m[90m Functionless(10024): [0mStepFunctions error cause must be a constant
+[96mtest/test-files/step-function.ts[0m:[93m572[0m:[93m47[0m - [91merror[0m[90m Functionless(10024): [0mStepFunctions error cause must be a constant
 
 https://functionless.org/docs/error-codes#stepfunctions-error-cause-must-be-a-constant
 
-[7m573[0m       throw new StepFunctionError("ErrorName", input.key);
+[7m572[0m       throw new StepFunctionError("ErrorName", input.key);
 [7m   [0m [91m                                              ~~~~~~~~~~[0m
-[96mtest/test-files/step-function.ts[0m:[93m587[0m:[93m40[0m - [91merror[0m[90m Functionless(10033): [0mStepFunctions does not support destructuring object with rest
+[96mtest/test-files/step-function.ts[0m:[93m586[0m:[93m40[0m - [91merror[0m[90m Functionless(10033): [0mStepFunctions does not support destructuring object with rest
 
 https://functionless.org/docs/error-codes#stepfunctions-does-not-support-destructuring-object-with-rest
 
-[7m587[0m new StepFunction(stack, "sfn", async ({ ...rest }) => {
+[7m586[0m new StepFunction(stack, "sfn", async ({ ...rest }) => {
 [7m   [0m [91m                                       ~~~~~~~~[0m
-[96mtest/test-files/step-function.ts[0m:[93m591[0m:[93m10[0m - [91merror[0m[90m Functionless(10033): [0mStepFunctions does not support destructuring object with rest
+[96mtest/test-files/step-function.ts[0m:[93m590[0m:[93m10[0m - [91merror[0m[90m Functionless(10033): [0mStepFunctions does not support destructuring object with rest
 
 https://functionless.org/docs/error-codes#stepfunctions-does-not-support-destructuring-object-with-rest
 
-[7m591[0m   const { ...rest } = input;
+[7m590[0m   const { ...rest } = input;
 [7m   [0m [91m         ~~~~~~~~[0m
-[96mtest/test-files/step-function.ts[0m:[93m620[0m:[93m20[0m - [91merror[0m[90m Functionless(10027): [0mthe callback argument of filter, forEach, and map must be a function or arrow expression, found: Identifier
+[96mtest/test-files/step-function.ts[0m:[93m619[0m:[93m20[0m - [91merror[0m[90m Functionless(10027): [0mthe callback argument of filter, forEach, and map must be a function or arrow expression, found: Identifier
 
 https://functionless.org/docs/error-codes#invalid-input
 
-[7m620[0m   [1, 2, 3].filter(someFunctionReference);
+[7m619[0m   [1, 2, 3].filter(someFunctionReference);
 [7m   [0m [91m                   ~~~~~~~~~~~~~~~~~~~~~[0m
-[96mtest/test-files/step-function.ts[0m:[93m621[0m:[93m17[0m - [91merror[0m[90m Functionless(10027): [0mthe callback argument of filter, forEach, and map must be a function or arrow expression, found: Identifier
+[96mtest/test-files/step-function.ts[0m:[93m620[0m:[93m17[0m - [91merror[0m[90m Functionless(10027): [0mthe callback argument of filter, forEach, and map must be a function or arrow expression, found: Identifier
 
 https://functionless.org/docs/error-codes#invalid-input
 
-[7m621[0m   [1, 2, 3].map(someFunctionReference);
+[7m620[0m   [1, 2, 3].map(someFunctionReference);
 [7m   [0m [91m                ~~~~~~~~~~~~~~~~~~~~~[0m
-[96mtest/test-files/step-function.ts[0m:[93m622[0m:[93m21[0m - [91merror[0m[90m Functionless(10027): [0mthe callback argument of filter, forEach, and map must be a function or arrow expression, found: Identifier
+[96mtest/test-files/step-function.ts[0m:[93m621[0m:[93m21[0m - [91merror[0m[90m Functionless(10027): [0mthe callback argument of filter, forEach, and map must be a function or arrow expression, found: Identifier
 
 https://functionless.org/docs/error-codes#invalid-input
 
-[7m622[0m   [1, 2, 3].forEach(someFunctionReference);
+[7m621[0m   [1, 2, 3].forEach(someFunctionReference);
 [7m   [0m [91m                    ~~~~~~~~~~~~~~~~~~~~~[0m
 [96mtest/test-files/step-function.ts[0m:[93m660[0m:[93m7[0m - [93mwarning[0m[90m Functionless(10035): [0mString constants should be used to access objects. Other types may fail at runtime.
 

--- a/test/appsync.test.ts
+++ b/test/appsync.test.ts
@@ -4,7 +4,6 @@ import { AttributeType } from "aws-cdk-lib/aws-dynamodb";
 import {
   AppsyncContext,
   AppsyncResolver,
-  reflect,
   StepFunction,
   Function,
   Table,
@@ -25,11 +24,9 @@ describe("step function integration", () => {
   test("machine with no parameters", () => {
     const machine = new StepFunction(stack, "machine", async () => {});
 
-    const templates = appsyncTestCase(
-      reflect(async () => {
-        await machine({});
-      })
-    );
+    const templates = appsyncTestCase(async () => {
+      await machine({});
+    });
 
     testAppsyncVelocity(templates[1]!, {
       resultMatch: {
@@ -49,11 +46,9 @@ describe("step function integration", () => {
       async () => {}
     );
 
-    const templates = appsyncTestCase(
-      reflect(async () => {
-        await machine({ input: { id: "1" } });
-      })
-    );
+    const templates = appsyncTestCase(async () => {
+      await machine({ input: { id: "1" } });
+    });
 
     testAppsyncVelocity(templates[1]!, {
       resultMatch: {
@@ -74,9 +69,9 @@ describe("step function integration", () => {
     );
 
     const templates = appsyncTestCase(
-      reflect(async (context: AppsyncContext<{ id: string }>) => {
+      async (context: AppsyncContext<{ id: string }>) => {
         await machine({ input: { id: context.arguments.id } });
-      })
+      }
     );
 
     testAppsyncVelocity(templates[1]!, {
@@ -95,9 +90,9 @@ describe("step function integration", () => {
     const machine = new StepFunction(stack, "machine", async () => {});
 
     const templates = appsyncTestCase(
-      reflect(async (context: AppsyncContext<{ id: string }>) => {
+      async (context: AppsyncContext<{ id: string }>) => {
         await machine({ name: context.arguments.id });
-      })
+      }
     );
 
     testAppsyncVelocity(templates[1]!, {
@@ -132,12 +127,10 @@ describe("step function integration", () => {
   test("machine describe exec", () => {
     const machine = new StepFunction(stack, "machine", async () => {});
 
-    const templates = appsyncTestCase(
-      reflect(async () => {
-        const exec = "exec1";
-        await machine.describeExecution(exec);
-      })
-    );
+    const templates = appsyncTestCase(async () => {
+      const exec = "exec1";
+      await machine.describeExecution(exec);
+    });
 
     testAppsyncVelocity(templates[1]!);
   });
@@ -162,12 +155,10 @@ test("if first argument is a GraphQLApi, then api can be omitted from the props"
 test("machine describe exec return", () => {
   const machine = new StepFunction(stack, "machine", () => {});
 
-  const templates = appsyncTestCase(
-    reflect(() => {
-      const exec = "exec1";
-      return machine.describeExecution(exec);
-    })
-  );
+  const templates = appsyncTestCase(() => {
+    const exec = "exec1";
+    return machine.describeExecution(exec);
+  });
 
   testAppsyncVelocity(templates[1]!);
 });
@@ -175,13 +166,11 @@ test("machine describe exec return", () => {
 test("machine describe exec var", () => {
   const machine = new StepFunction(stack, "machine", () => {});
 
-  const templates = appsyncTestCase(
-    reflect(async () => {
-      const exec = "exec1";
-      const v = await machine.describeExecution(exec);
-      return v;
-    })
-  );
+  const templates = appsyncTestCase(async () => {
+    const exec = "exec1";
+    const v = await machine.describeExecution(exec);
+    return v;
+  });
 
   testAppsyncVelocity(templates[1]!);
 });
@@ -189,13 +178,11 @@ test("machine describe exec var", () => {
 test("deconstruct integration response", () => {
   const machine = new StepFunction(stack, "machine", () => {});
 
-  const templates = appsyncTestCase(
-    reflect(async () => {
-      const exec = "exec1";
-      const { executionArn } = await machine.describeExecution(exec);
-      return executionArn;
-    })
-  );
+  const templates = appsyncTestCase(async () => {
+    const exec = "exec1";
+    const { executionArn } = await machine.describeExecution(exec);
+    return executionArn;
+  });
 
   testAppsyncVelocity(templates[1]!);
 });
@@ -204,11 +191,9 @@ describe("step function describe execution", () => {
   test("machine describe exec string", () => {
     const machine = new StepFunction(stack, "machine", async () => {});
 
-    const templates = appsyncTestCase(
-      reflect(async () => {
-        await machine.describeExecution("exec1");
-      })
-    );
+    const templates = appsyncTestCase(async () => {
+      await machine.describeExecution("exec1");
+    });
 
     testAppsyncVelocity(templates[1]!);
   });
@@ -234,12 +219,12 @@ test("multiple isolated integrations", () => {
   const machine = new StepFunction(stack, "machine", () => {});
 
   const templates = appsyncTestCase(
-    reflect(async () => {
+    async () => {
       await machine.describeExecution("exec1");
       await machine.describeExecution("exec2");
       await machine.describeExecution("exec3");
       await machine.describeExecution("exec4");
-    }),
+    },
     {
       expectedTemplateCount: 10,
     }
@@ -251,13 +236,11 @@ test("multiple isolated integrations", () => {
 test("multiple linked integrations", () => {
   const machine = new StepFunction(stack, "machine", () => {});
 
-  const templates = appsyncTestCase(
-    reflect(async () => {
-      const res1 = await machine({ input: {} });
-      const res2 = await machine({ input: res1 });
-      await machine({ input: res2 });
-    })
-  );
+  const templates = appsyncTestCase(async () => {
+    const res1 = await machine({ input: {} });
+    const res2 = await machine({ input: res1 });
+    await machine({ input: res2 });
+  });
 
   testAppsyncVelocity(templates[1]!);
 });
@@ -266,12 +249,12 @@ test("multiple linked integrations pre-compute", () => {
   const machine = new StepFunction(stack, "machine", () => {});
 
   const templates = appsyncTestCase(
-    reflect(async () => {
+    async () => {
       const x = "y";
       const res1 = await machine({ input: { x } });
       const res2 = await machine({ input: res1 });
       await machine({ input: res2 });
-    }),
+    },
     {
       expectedTemplateCount: 8,
     }
@@ -283,14 +266,12 @@ test("multiple linked integrations pre-compute", () => {
 test("multiple linked integrations post-compute", () => {
   const machine = new StepFunction(stack, "machine", () => {});
 
-  const templates = appsyncTestCase(
-    reflect(async () => {
-      const res1 = await machine({ input: {} });
-      const res2 = await machine({ input: res1 });
-      const result = await machine({ input: res2 });
-      return result.startDate;
-    })
-  );
+  const templates = appsyncTestCase(async () => {
+    const res1 = await machine({ input: {} });
+    const res2 = await machine({ input: res1 });
+    const result = await machine({ input: res2 });
+    return result.startDate;
+  });
 
   testAppsyncVelocity(templates[1]!);
 });
@@ -299,11 +280,11 @@ test("multiple linked integrations with props", () => {
   const machine = new StepFunction(stack, "machine", () => {});
 
   const templates = appsyncTestCase(
-    reflect(async () => {
+    async () => {
       const res1 = await machine.describeExecution("exec1");
       const res2 = await machine.describeExecution(res1.executionArn);
       await machine.describeExecution(res2.executionArn);
-    }),
+    },
     {
       expectedTemplateCount: 8,
     }
@@ -317,11 +298,11 @@ test("multiple nested integrations", () => {
   const machine = new StepFunction(stack, "machine", () => {});
 
   const templates = appsyncTestCase(
-    reflect(async () => {
+    async () => {
       await machine({
         input: await machine({ input: await machine({ input: {} }) }),
       });
-    }),
+    },
     {
       expectedTemplateCount: 8,
     }
@@ -335,7 +316,7 @@ test("multiple nested integrations prop access", () => {
   const machine = new StepFunction(stack, "machine", () => {});
 
   const templates = appsyncTestCase(
-    reflect(async () => {
+    async () => {
       await machine.describeExecution(
         (
           await machine.describeExecution(
@@ -345,7 +326,7 @@ test("multiple nested integrations prop access", () => {
           )
         ).executionArn
       );
-    }),
+    },
     {
       expectedTemplateCount: 8,
     }
@@ -363,12 +344,12 @@ test("integrations separated by in", () => {
   });
 
   const templates = appsyncTestCase(
-    reflect(async () => {
+    async () => {
       if ((await func({})) in (await func2({}))) {
         return true;
       }
       return false;
-    }),
+    },
     {
       expectedTemplateCount: 6,
     }
@@ -380,13 +361,11 @@ test("integrations separated by in", () => {
 test("multiple linked integrations with mutation", () => {
   const machine = new StepFunction(stack, "machine", () => {});
 
-  const templates = appsyncTestCase(
-    reflect(async () => {
-      const res1 = await machine.describeExecution("exec1");
-      const formatted = `status: ${res1.status}`;
-      await machine({ input: { x: formatted } });
-    })
-  );
+  const templates = appsyncTestCase(async () => {
+    const res1 = await machine.describeExecution("exec1");
+    const formatted = `status: ${res1.status}`;
+    await machine({ input: { x: formatted } });
+  });
 
   testAppsyncVelocity(templates[1]!);
 });
@@ -410,7 +389,7 @@ test("return error", () => {
   expect(() => {
     appsyncTestCase<{ num: number }, { pk: string; sk: string }>(
       // source https://github.com/functionless/functionless/issues/266
-      reflect(async ($context) => {
+      async ($context) => {
         const identity = $context.identity;
 
         if (identity && "resolverContext" in identity) {
@@ -424,7 +403,7 @@ test("return error", () => {
         }
 
         return $util.error("Cannot find account.");
-      })
+      }
     );
   }).toThrow(
     "Appsync Integration invocations must be unidirectional and defined statically"
@@ -435,12 +414,12 @@ test("throw SynthError when for-await is used", () => {
   expect(() => {
     appsyncTestCase<{ strings: string[] }, { pk: string; sk: string }>(
       // source https://github.com/functionless/functionless/issues/266
-      reflect(async ($context) => {
+      async ($context) => {
         for await (const _ of $context.arguments.strings) {
         }
 
         return $util.error("Cannot find account.");
-      })
+      }
     );
   }).toThrow(
     "VTL does not support for-await, see https://github.com/functionless/functionless/issues/390"
@@ -451,13 +430,13 @@ test("throw SynthError when rest parameter is used", () => {
   expect(() => {
     appsyncTestCase<{ strings: string[] }, { pk: string; sk: string }>(
       // source https://github.com/functionless/functionless/issues/266
-      reflect(async ($context) => {
+      async ($context) => {
         $context.arguments.strings.forEach((...rest) => {
           return rest;
         });
 
         return $util.error("Cannot find account.");
-      })
+      }
     );
   }).toThrow();
 });

--- a/test/eventpattern.test.ts
+++ b/test/eventpattern.test.ts
@@ -1,4 +1,5 @@
 import { App, Stack } from "aws-cdk-lib";
+import { StepFunction } from "../src";
 import { Event, EventBus } from "../src/event-bridge";
 import { Function } from "../src/function";
 import { ebEventPatternTestCase, ebEventPatternTestCaseError } from "./util";
@@ -1390,6 +1391,14 @@ test("error when using rest parameters", () => {
 
   bus.all().pipe(
     new Function(stack, "F", async (event) => {
+      // event should be inferred
+      const time: string = event.detail.time;
+      time;
+    })
+  );
+
+  bus.all().pipe(
+    new StepFunction(stack, "F", async (event) => {
       // event should be inferred
       const time: string = event.detail.time;
       time;

--- a/test/eventpattern.test.ts
+++ b/test/eventpattern.test.ts
@@ -1419,4 +1419,9 @@ test("error when using rest parameters", () => {
       time;
     })
   );
+
+  bus.all().pipe(
+    // @ts-expect-error - type mismatch
+    new StepFunction(stack, "F", async (event: { key: string }) => {})
+  );
 };

--- a/test/eventpattern.test.ts
+++ b/test/eventpattern.test.ts
@@ -1394,7 +1394,22 @@ test("error when using rest parameters", () => {
       // event should be inferred
       const time: string = event.detail.time;
       time;
-    })
+    }),
+    {
+      retryAttempts: 1,
+    }
+  );
+
+  bus.all().pipe(
+    new Function(stack, "F", async (event) => {
+      // event should be inferred
+      const time: string = event.detail.time;
+      time;
+    }),
+    // @ts-expect-error
+    {
+      retryAttempts: "1",
+    }
   );
 
   bus.all().pipe(

--- a/test/eventpattern.test.ts
+++ b/test/eventpattern.test.ts
@@ -1,5 +1,6 @@
-import { reflect } from "../src";
-import { Event, RulePredicateFunction } from "../src/event-bridge";
+import { App, Stack } from "aws-cdk-lib";
+import { Event, EventBus } from "../src/event-bridge";
+import { Function } from "../src/function";
 import { ebEventPatternTestCase, ebEventPatternTestCaseError } from "./util";
 
 type TestEvent = Event<{
@@ -20,31 +21,21 @@ type TestEvent = Event<{
 describe("event pattern", () => {
   describe("equals", () => {
     test("simple", () => {
-      ebEventPatternTestCase(
-        reflect<RulePredicateFunction<TestEvent>>(
-          (event) => event.source === "lambda"
-        ),
-        {
-          source: ["lambda"],
-        }
-      );
+      ebEventPatternTestCase((event: TestEvent) => event.source === "lambda", {
+        source: ["lambda"],
+      });
     });
 
     test("no event parameter", () => {
-      ebEventPatternTestCase(
-        reflect<RulePredicateFunction<TestEvent>>(() => true),
-        {
-          source: [{ prefix: "" }],
-        }
-      );
+      ebEventPatternTestCase(() => true, {
+        source: [{ prefix: "" }],
+      });
     });
 
     test("index access", () => {
       ebEventPatternTestCase(
-        reflect<RulePredicateFunction<TestEvent>>(
-          // eslint-disable-next-line dot-notation
-          (event) => event["source"] === "lambda"
-        ),
+        // eslint-disable-next-line dot-notation
+        (event: TestEvent) => event["source"] === "lambda",
         {
           source: ["lambda"],
         }
@@ -52,32 +43,20 @@ describe("event pattern", () => {
     });
 
     test("double equals", () => {
-      ebEventPatternTestCase(
-        reflect<RulePredicateFunction<TestEvent>>(
-          (event) => event.source == "lambda"
-        ),
-        {
-          source: ["lambda"],
-        }
-      );
+      ebEventPatternTestCase((event: TestEvent) => event.source == "lambda", {
+        source: ["lambda"],
+      });
     });
 
     test("is null", () => {
-      ebEventPatternTestCase(
-        reflect<RulePredicateFunction<TestEvent>>(
-          (event) => event.source === null
-        ),
-        {
-          source: [null],
-        }
-      );
+      ebEventPatternTestCase((event: TestEvent) => event.source === null, {
+        source: [null],
+      });
     });
 
     test("detail", () => {
       ebEventPatternTestCase(
-        reflect<RulePredicateFunction<TestEvent>>(
-          (event) => event.detail.str === "something"
-        ),
+        (event: TestEvent) => event.detail.str === "something",
         {
           detail: { str: ["something"] },
         }
@@ -86,9 +65,7 @@ describe("event pattern", () => {
 
     test("detail deep", () => {
       ebEventPatternTestCase(
-        reflect<RulePredicateFunction<TestEvent>>(
-          (event) => event.detail.deep.value === "something"
-        ),
+        (event: TestEvent) => event.detail.deep.value === "something",
         {
           detail: { deep: { value: ["something"] } },
         }
@@ -97,9 +74,7 @@ describe("event pattern", () => {
 
     test("detail index accessor", () => {
       ebEventPatternTestCase(
-        reflect<RulePredicateFunction<TestEvent>>(
-          (event) => event.detail["multi-part"] === "something"
-        ),
+        (event: TestEvent) => event.detail["multi-part"] === "something",
         {
           detail: { "multi-part": ["something"] },
         }
@@ -107,56 +82,36 @@ describe("event pattern", () => {
     });
 
     test("numeric", () => {
-      ebEventPatternTestCase(
-        reflect<RulePredicateFunction<TestEvent>>(
-          (event) => event.detail.num === 50
-        ),
-        {
-          detail: { num: [50] },
-        }
-      );
+      ebEventPatternTestCase((event: TestEvent) => event.detail.num === 50, {
+        detail: { num: [50] },
+      });
     });
 
     test("negative number", () => {
-      ebEventPatternTestCase(
-        reflect<RulePredicateFunction<TestEvent>>(
-          (event) => event.detail.num === -50
-        ),
-        {
-          detail: { num: [-50] },
-        }
-      );
+      ebEventPatternTestCase((event: TestEvent) => event.detail.num === -50, {
+        detail: { num: [-50] },
+      });
     });
 
     // regression: we require explicit `bool === true`
     test.skip("boolean implicit", () => {
-      ebEventPatternTestCase(
-        reflect<RulePredicateFunction<TestEvent>>((event) => event.detail.bool),
-        {
-          detail: {
-            bool: [true],
-          },
-        }
-      );
+      ebEventPatternTestCase((event: TestEvent) => event.detail.bool, {
+        detail: {
+          bool: [true],
+        },
+      });
     });
 
     // regression: we require explicit `bool === false`
     test.skip("boolean implicit false", () => {
-      ebEventPatternTestCase(
-        reflect<RulePredicateFunction<TestEvent>>(
-          (event) => !event.detail.bool
-        ),
-        {
-          detail: { bool: [false] },
-        }
-      );
+      ebEventPatternTestCase((event: TestEvent) => !event.detail.bool, {
+        detail: { bool: [false] },
+      });
     });
 
     test("boolean explicit", () => {
       ebEventPatternTestCase(
-        reflect<RulePredicateFunction<TestEvent>>(
-          (event) => event.detail.bool === false
-        ),
+        (event: TestEvent) => event.detail.bool === false,
         {
           detail: { bool: [false] },
         }
@@ -166,9 +121,7 @@ describe("event pattern", () => {
     describe("array", () => {
       test("array", () => {
         ebEventPatternTestCase(
-          reflect<RulePredicateFunction<TestEvent>>((event) =>
-            event.detail.array.includes("something")
-          ),
+          (event: TestEvent) => event.detail.array.includes("something"),
           {
             detail: { array: ["something"] },
           }
@@ -177,9 +130,7 @@ describe("event pattern", () => {
 
       test("num array", () => {
         ebEventPatternTestCase(
-          reflect<RulePredicateFunction<TestEvent>>((event) =>
-            event.detail.numArray.includes(1)
-          ),
+          (event: TestEvent) => event.detail.numArray.includes(1),
           {
             detail: { numArray: [1] },
           }
@@ -188,9 +139,7 @@ describe("event pattern", () => {
 
       test("num array", () => {
         ebEventPatternTestCase(
-          reflect<RulePredicateFunction<TestEvent>>((event) =>
-            event.detail.numArray.includes(-1)
-          ),
+          (event: TestEvent) => event.detail.numArray.includes(-1),
           {
             detail: { numArray: [-1] },
           }
@@ -199,9 +148,7 @@ describe("event pattern", () => {
 
       test("bool array", () => {
         ebEventPatternTestCase(
-          reflect<RulePredicateFunction<TestEvent>>((event) =>
-            event.detail.boolArray.includes(true)
-          ),
+          (event: TestEvent) => event.detail.boolArray.includes(true),
           {
             detail: { boolArray: [true] },
           }
@@ -210,9 +157,7 @@ describe("event pattern", () => {
 
       test("array not includes", () => {
         ebEventPatternTestCase(
-          reflect<RulePredicateFunction<TestEvent>>(
-            (event) => !event.detail.array.includes("something")
-          ),
+          (event: TestEvent) => !event.detail.array.includes("something"),
           {
             detail: { array: [{ "anything-but": "something" }] },
           }
@@ -221,9 +166,7 @@ describe("event pattern", () => {
 
       test("num array not includes", () => {
         ebEventPatternTestCase(
-          reflect<RulePredicateFunction<TestEvent>>(
-            (event) => !event.detail.numArray.includes(1)
-          ),
+          (event: TestEvent) => !event.detail.numArray.includes(1),
           {
             detail: { numArray: [{ "anything-but": 1 }] },
           }
@@ -232,9 +175,7 @@ describe("event pattern", () => {
 
       test("bool array not includes", () => {
         ebEventPatternTestCase(
-          reflect<RulePredicateFunction<TestEvent>>(
-            (event) => !event.detail.boolArray.includes(true)
-          ),
+          (event: TestEvent) => !event.detail.boolArray.includes(true),
           {
             detail: { boolArray: [false] },
           }
@@ -243,9 +184,8 @@ describe("event pattern", () => {
 
       test("array explicit equals error", () => {
         ebEventPatternTestCaseError(
-          reflect<RulePredicateFunction<TestEvent>>(
-            (event) => event.detail.array === ["a", "b"]
-          ),
+          // @ts-ignore
+          (event: TestEvent) => event.detail.array === ["a", "b"],
           "Event Patterns can only compare primitive values"
         );
       });
@@ -255,9 +195,7 @@ describe("event pattern", () => {
   describe("prefix", () => {
     test("prefix", () => {
       ebEventPatternTestCase(
-        reflect<RulePredicateFunction<TestEvent>>((event) =>
-          event.source.startsWith("l")
-        ),
+        (event: TestEvent) => event.source.startsWith("l"),
         {
           source: [{ prefix: "l" }],
         }
@@ -266,9 +204,7 @@ describe("event pattern", () => {
 
     test("not prefix", () => {
       ebEventPatternTestCase(
-        reflect<RulePredicateFunction<TestEvent>>(
-          (event) => !event.source.startsWith("l")
-        ),
+        (event: TestEvent) => !event.source.startsWith("l"),
         {
           source: [{ "anything-but": { prefix: "l" } }],
         }
@@ -278,9 +214,7 @@ describe("event pattern", () => {
     // regression: this will be a tsc-level error now that we don't have type information in the AST
     test.skip("prefix non string", () => {
       ebEventPatternTestCaseError(
-        reflect<RulePredicateFunction<TestEvent>>((event) =>
-          (<any>event.detail.num).startsWith("l")
-        ),
+        (event: TestEvent) => (<any>event.detail.num).startsWith("l"),
         "Starts With operation only supported on strings, found number."
       );
     });
@@ -288,78 +222,46 @@ describe("event pattern", () => {
 
   describe("numeric range single", () => {
     test("numeric range single", () => {
-      ebEventPatternTestCase(
-        reflect<RulePredicateFunction<TestEvent>>(
-          (event) => event.detail.num < 100
-        ),
-        {
-          detail: { num: [{ numeric: ["<", 100] }] },
-        }
-      );
+      ebEventPatternTestCase((event: TestEvent) => event.detail.num < 100, {
+        detail: { num: [{ numeric: ["<", 100] }] },
+      });
     });
 
     test("numeric range greater than", () => {
-      ebEventPatternTestCase(
-        reflect<RulePredicateFunction<TestEvent>>(
-          (event) => event.detail.num > 100
-        ),
-        {
-          detail: { num: [{ numeric: [">", 100] }] },
-        }
-      );
+      ebEventPatternTestCase((event: TestEvent) => event.detail.num > 100, {
+        detail: { num: [{ numeric: [">", 100] }] },
+      });
     });
 
     test("numeric range greater than equals", () => {
-      ebEventPatternTestCase(
-        reflect<RulePredicateFunction<TestEvent>>(
-          (event) => event.detail.num >= 100
-        ),
-        {
-          detail: { num: [{ numeric: [">=", 100] }] },
-        }
-      );
+      ebEventPatternTestCase((event: TestEvent) => event.detail.num >= 100, {
+        detail: { num: [{ numeric: [">=", 100] }] },
+      });
     });
 
     test("numeric range inverted", () => {
-      ebEventPatternTestCase(
-        reflect<RulePredicateFunction<TestEvent>>(
-          (event) => 100 < event.detail.num
-        ),
-        {
-          detail: { num: [{ numeric: [">", 100] }] },
-        }
-      );
+      ebEventPatternTestCase((event: TestEvent) => 100 < event.detail.num, {
+        detail: { num: [{ numeric: [">", 100] }] },
+      });
     });
 
     test("numeric range inverted", () => {
-      ebEventPatternTestCase(
-        reflect<RulePredicateFunction<TestEvent>>(
-          (event) => 100 >= event.detail.num
-        ),
-        {
-          detail: { num: [{ numeric: ["<=", 100] }] },
-        }
-      );
+      ebEventPatternTestCase((event: TestEvent) => 100 >= event.detail.num, {
+        detail: { num: [{ numeric: ["<=", 100] }] },
+      });
     });
   });
 
   describe("not", () => {
     test("string", () => {
-      ebEventPatternTestCase(
-        reflect<RulePredicateFunction<TestEvent>>(
-          (event) => event.source !== "lambda"
-        ),
-        {
-          source: [{ "anything-but": "lambda" }],
-        }
-      );
+      ebEventPatternTestCase((event: TestEvent) => event.source !== "lambda", {
+        source: [{ "anything-but": "lambda" }],
+      });
     });
 
     test("not not prefix", () => {
       ebEventPatternTestCase(
-        reflect<RulePredicateFunction<TestEvent>>(
-          (event) => !!event.source.startsWith("lambda")
-        ),
+        (event: TestEvent) => !!event.source.startsWith("lambda"),
         {
           source: [{ prefix: "lambda" }],
         }
@@ -368,9 +270,7 @@ describe("event pattern", () => {
 
     test("negate string equals", () => {
       ebEventPatternTestCase(
-        reflect<RulePredicateFunction<TestEvent>>(
-          (event) => !(event.source === "lambda")
-        ),
+        (event: TestEvent) => !(event.source === "lambda"),
         {
           source: [{ "anything-but": "lambda" }],
         }
@@ -379,9 +279,7 @@ describe("event pattern", () => {
 
     test("negate not string equals", () => {
       ebEventPatternTestCase(
-        reflect<RulePredicateFunction<TestEvent>>(
-          (event) => !(event.source !== "lambda")
-        ),
+        (event: TestEvent) => !(event.source !== "lambda"),
         {
           source: ["lambda"],
         }
@@ -389,21 +287,14 @@ describe("event pattern", () => {
     });
 
     test("not bool true", () => {
-      ebEventPatternTestCase(
-        reflect<RulePredicateFunction<TestEvent>>(
-          (event) => event.detail.bool !== true
-        ),
-        {
-          detail: { bool: [false] },
-        }
-      );
+      ebEventPatternTestCase((event: TestEvent) => event.detail.bool !== true, {
+        detail: { bool: [false] },
+      });
     });
 
     test("negate not bool true", () => {
       ebEventPatternTestCase(
-        reflect<RulePredicateFunction<TestEvent>>(
-          (event) => !(event.detail.bool !== true)
-        ),
+        (event: TestEvent) => !(event.detail.bool !== true),
         {
           detail: { bool: [true] },
         }
@@ -412,9 +303,7 @@ describe("event pattern", () => {
 
     test("negate bool true", () => {
       ebEventPatternTestCase(
-        reflect<RulePredicateFunction<TestEvent>>(
-          (event) => !(event.detail.bool === true)
-        ),
+        (event: TestEvent) => !(event.detail.bool === true),
         {
           detail: { bool: [false] },
         }
@@ -423,9 +312,7 @@ describe("event pattern", () => {
 
     test("string wrapped", () => {
       ebEventPatternTestCase(
-        reflect<RulePredicateFunction<TestEvent>>(
-          (event) => !(event.source === "lambda")
-        ),
+        (event: TestEvent) => !(event.source === "lambda"),
         {
           source: [{ "anything-but": "lambda" }],
         }
@@ -433,21 +320,14 @@ describe("event pattern", () => {
     });
 
     test("number", () => {
-      ebEventPatternTestCase(
-        reflect<RulePredicateFunction<TestEvent>>(
-          (event) => event.detail.num !== 100
-        ),
-        {
-          detail: { num: [{ "anything-but": 100 }] },
-        }
-      );
+      ebEventPatternTestCase((event: TestEvent) => event.detail.num !== 100, {
+        detail: { num: [{ "anything-but": 100 }] },
+      });
     });
 
     test("array", () => {
       ebEventPatternTestCase(
-        reflect<RulePredicateFunction<TestEvent>>(
-          (event) => !event.detail.array.includes("something")
-        ),
+        (event: TestEvent) => !event.detail.array.includes("something"),
         {
           detail: { array: [{ "anything-but": "something" }] },
         }
@@ -456,9 +336,7 @@ describe("event pattern", () => {
 
     test("string prefix", () => {
       ebEventPatternTestCase(
-        reflect<RulePredicateFunction<TestEvent>>(
-          (event) => !event.detail.str.startsWith("something")
-        ),
+        (event: TestEvent) => !event.detail.str.startsWith("something"),
         {
           detail: { str: [{ "anything-but": { prefix: "something" } }] },
         }
@@ -467,37 +345,30 @@ describe("event pattern", () => {
 
     test("negate multiple fields", () => {
       ebEventPatternTestCaseError(
-        reflect<RulePredicateFunction<TestEvent>>(
-          (event) => !(event.detail.str === "hello" && event.id === "there")
-        ),
+        (event: TestEvent) =>
+          !(event.detail.str === "hello" && event.id === "there"),
         "Can only negate simple statements like equals, doesn't equals, and prefix."
       );
     });
 
     test("negate multiple", () => {
       ebEventPatternTestCaseError(
-        reflect<RulePredicateFunction<TestEvent>>(
-          (event) => !(event.detail.str || !event.detail.str)
-        ),
+        (event: TestEvent) => !(event.detail.str || !event.detail.str),
         "Impossible logic discovered."
       );
     });
 
     test("negate negate multiple", () => {
       ebEventPatternTestCase(
-        reflect<RulePredicateFunction<TestEvent>>(
-          (event) => !!(event.detail.str || !event.detail.str)
-        ),
+        (event: TestEvent) => !!(event.detail.str || !event.detail.str),
         { source: [{ prefix: "" }] }
       );
     });
 
     test("negate intrafield valid aggregate", () => {
       ebEventPatternTestCaseError(
-        reflect<RulePredicateFunction<TestEvent>>(
-          (event) =>
-            !(event.detail.str.startsWith("hello") || event.detail.str === "hi")
-        )
+        (event: TestEvent) =>
+          !(event.detail.str.startsWith("hello") || event.detail.str === "hi")
       ),
         "Can only negate simple statments like boolean and equals.";
     });
@@ -506,9 +377,7 @@ describe("event pattern", () => {
   describe("exists", () => {
     test("does", () => {
       ebEventPatternTestCase(
-        reflect<RulePredicateFunction<TestEvent>>(
-          (event) => event.detail.optional !== undefined
-        ),
+        (event: TestEvent) => event.detail.optional !== undefined,
         {
           detail: { optional: [{ exists: true }] },
         }
@@ -516,32 +385,20 @@ describe("event pattern", () => {
     });
 
     test("does in", () => {
-      ebEventPatternTestCase(
-        reflect<RulePredicateFunction<TestEvent>>(
-          (event) => "optional" in event.detail
-        ),
-        {
-          detail: { optional: [{ exists: true }] },
-        }
-      );
+      ebEventPatternTestCase((event: TestEvent) => "optional" in event.detail, {
+        detail: { optional: [{ exists: true }] },
+      });
     });
 
     test("does exist lone value", () => {
-      ebEventPatternTestCase(
-        reflect<RulePredicateFunction<TestEvent>>(
-          (event) => !!event.detail.optional
-        ),
-        {
-          detail: { optional: [{ exists: true }] },
-        }
-      );
+      ebEventPatternTestCase((event: TestEvent) => !!event.detail.optional, {
+        detail: { optional: [{ exists: true }] },
+      });
     });
 
     test("does not", () => {
       ebEventPatternTestCase(
-        reflect<RulePredicateFunction<TestEvent>>(
-          (event) => event.detail.optional === undefined
-        ),
+        (event: TestEvent) => event.detail.optional === undefined,
         {
           detail: { optional: [{ exists: false }] },
         }
@@ -550,9 +407,7 @@ describe("event pattern", () => {
 
     test("does not in", () => {
       ebEventPatternTestCase(
-        reflect<RulePredicateFunction<TestEvent>>(
-          (event) => !("optional" in event.detail)
-        ),
+        (event: TestEvent) => !("optional" in event.detail),
         {
           detail: { optional: [{ exists: false }] },
         }
@@ -560,12 +415,9 @@ describe("event pattern", () => {
     });
 
     test("exists at event level", () => {
-      ebEventPatternTestCase(
-        reflect<RulePredicateFunction<TestEvent>>((event) => "source" in event),
-        {
-          source: [{ exists: true }],
-        }
-      );
+      ebEventPatternTestCase((event: TestEvent) => "source" in event, {
+        source: [{ exists: true }],
+      });
     });
   });
 
@@ -573,9 +425,7 @@ describe("event pattern", () => {
     const myConstant = "hello";
     test("external constant", () => {
       ebEventPatternTestCase(
-        reflect<RulePredicateFunction<TestEvent>>(
-          (event) => event.detail.str === myConstant
-        ),
+        (event: TestEvent) => event.detail.str === myConstant,
         {
           detail: { str: [myConstant] },
         }
@@ -586,9 +436,7 @@ describe("event pattern", () => {
 
     test("external constant", () => {
       ebEventPatternTestCase(
-        reflect<RulePredicateFunction<TestEvent>>(
-          (event) => event.detail.str === constantObj.value
-        ),
+        (event: TestEvent) => event.detail.str === constantObj.value,
         {
           detail: { str: [constantObj.value] },
         }
@@ -597,10 +445,10 @@ describe("event pattern", () => {
 
     test("internal constant", () => {
       ebEventPatternTestCase(
-        reflect<RulePredicateFunction<TestEvent>>((event) => {
+        (event: TestEvent) => {
           const myInternalContant = "hi";
           return event.detail.str === myInternalContant;
-        }),
+        },
         {
           detail: { str: ["hi"] },
         }
@@ -609,10 +457,10 @@ describe("event pattern", () => {
 
     test("formatting", () => {
       ebEventPatternTestCase(
-        reflect<RulePredicateFunction<TestEvent>>((event) => {
+        (event: TestEvent) => {
           const myInternalContant = "hi";
           return event.detail.str === `${myInternalContant} there`;
-        }),
+        },
         {
           detail: { str: ["hi there"] },
         }
@@ -621,10 +469,10 @@ describe("event pattern", () => {
 
     test("internal property", () => {
       ebEventPatternTestCase(
-        reflect<RulePredicateFunction<TestEvent>>((event) => {
+        (event: TestEvent) => {
           const myInternalContant = { value: "hi" };
           return event.detail.str === myInternalContant.value;
-        }),
+        },
         {
           detail: { str: ["hi"] },
         }
@@ -632,30 +480,24 @@ describe("event pattern", () => {
     });
 
     test("constant function call", () => {
-      ebEventPatternTestCaseError(
-        reflect<RulePredicateFunction<TestEvent>>((event) => {
-          const myInternalContant = (() => "hi" + " " + "there")();
-          return event.detail.str === myInternalContant;
-        }),
-        "Equivalency must compare to a constant value."
-      );
+      ebEventPatternTestCaseError((event: TestEvent) => {
+        const myInternalContant = (() => "hi" + " " + "there")();
+        return event.detail.str === myInternalContant;
+      }, "Equivalency must compare to a constant value.");
     });
 
     test("constant function call", () => {
-      ebEventPatternTestCaseError(
-        reflect<RulePredicateFunction<TestEvent>>((event) => {
-          const myMethod = () => "hi" + " " + "there";
-          return event.detail.str === myMethod();
-        }),
-        "Equivalency must compare to a constant value."
-      );
+      ebEventPatternTestCaseError((event: TestEvent) => {
+        const myMethod = () => "hi" + " " + "there";
+        return event.detail.str === myMethod();
+      }, "Equivalency must compare to a constant value.");
     });
   });
 
   describe("simple invalid", () => {
     test("error on raw event in predicate", () => {
       ebEventPatternTestCaseError(
-        reflect<RulePredicateFunction<TestEvent>>((event) => !!event),
+        (event: TestEvent) => !!event,
         "Identifier is unsupported"
       );
     });
@@ -664,9 +506,8 @@ describe("event pattern", () => {
   describe("numeric aggregate", () => {
     test("numeric range aggregate", () => {
       ebEventPatternTestCase(
-        reflect<RulePredicateFunction<TestEvent>>(
-          (event) => event.detail.num >= 100 && event.detail.num < 1000
-        ),
+        (event: TestEvent) =>
+          event.detail.num >= 100 && event.detail.num < 1000,
         {
           detail: { num: [{ numeric: [">=", 100, "<", 1000] }] },
         }
@@ -675,12 +516,10 @@ describe("event pattern", () => {
 
     test("numeric range overlapping", () => {
       ebEventPatternTestCase(
-        reflect<RulePredicateFunction<TestEvent>>(
-          (event) =>
-            event.detail.num >= 100 &&
-            event.detail.num < 1000 &&
-            event.detail.num > 50
-        ),
+        (event: TestEvent) =>
+          event.detail.num >= 100 &&
+          event.detail.num < 1000 &&
+          event.detail.num > 50,
         {
           detail: { num: [{ numeric: [">=", 100, "<", 1000] }] },
         }
@@ -689,9 +528,8 @@ describe("event pattern", () => {
 
     test("numeric range negate", () => {
       ebEventPatternTestCase(
-        reflect<RulePredicateFunction<TestEvent>>(
-          (event) => !(event.detail.num >= 100 && event.detail.num < 1000)
-        ),
+        (event: TestEvent) =>
+          !(event.detail.num >= 100 && event.detail.num < 1000),
         {
           detail: { num: [{ numeric: [">=", 1000, "<", 100] }] },
         }
@@ -700,12 +538,10 @@ describe("event pattern", () => {
 
     test("numeric range overlapping", () => {
       ebEventPatternTestCase(
-        reflect<RulePredicateFunction<TestEvent>>(
-          (event) =>
-            event.detail.num >= 100 &&
-            event.detail.num < 1000 &&
-            event.detail.num < 200
-        ),
+        (event: TestEvent) =>
+          event.detail.num >= 100 &&
+          event.detail.num < 1000 &&
+          event.detail.num < 200,
         {
           detail: { num: [{ numeric: [">=", 100, "<", 200] }] },
         }
@@ -714,12 +550,10 @@ describe("event pattern", () => {
 
     test("numeric range aggregate with other fields", () => {
       ebEventPatternTestCase(
-        reflect<RulePredicateFunction<TestEvent>>(
-          (event) =>
-            event.detail.num >= 100 &&
-            event.detail.num < 1000 &&
-            event.detail.str === "something"
-        ),
+        (event: TestEvent) =>
+          event.detail.num >= 100 &&
+          event.detail.num < 1000 &&
+          event.detail.str === "something",
         {
           detail: {
             num: [{ numeric: [">=", 100, "<", 1000] }],
@@ -731,9 +565,7 @@ describe("event pattern", () => {
 
     test("numeric range or exclusive", () => {
       ebEventPatternTestCase(
-        reflect<RulePredicateFunction<TestEvent>>(
-          (event) => event.detail.num > 300 || event.detail.num < 200
-        ),
+        (event: TestEvent) => event.detail.num > 300 || event.detail.num < 200,
         {
           detail: { num: [{ numeric: [">", 300] }, { numeric: ["<", 200] }] },
         }
@@ -742,9 +574,8 @@ describe("event pattern", () => {
 
     test("numeric range or exclusive negate", () => {
       ebEventPatternTestCase(
-        reflect<RulePredicateFunction<TestEvent>>(
-          (event) => !(event.detail.num > 300 || event.detail.num < 200)
-        ),
+        (event: TestEvent) =>
+          !(event.detail.num > 300 || event.detail.num < 200),
         {
           detail: { num: [{ numeric: [">=", 200, "<=", 300] }] },
         }
@@ -754,9 +585,7 @@ describe("event pattern", () => {
     // the ranges represent infinity, so the clause is removed
     test("numeric range or aggregate empty", () => {
       ebEventPatternTestCase(
-        reflect<RulePredicateFunction<TestEvent>>(
-          (event) => event.detail.num < 300 || event.detail.num > 200
-        ),
+        (event: TestEvent) => event.detail.num < 300 || event.detail.num > 200,
         {
           source: [{ prefix: "" }],
         }
@@ -765,11 +594,9 @@ describe("event pattern", () => {
 
     test("numeric range or aggregate", () => {
       ebEventPatternTestCase(
-        reflect<RulePredicateFunction<TestEvent>>(
-          (event) =>
-            (event.detail.num > 300 && event.detail.num < 350) ||
-            event.detail.num < 200
-        ),
+        (event: TestEvent) =>
+          (event.detail.num > 300 && event.detail.num < 350) ||
+          event.detail.num < 200,
         {
           detail: {
             num: [{ numeric: [">", 300, "<", 350] }, { numeric: ["<", 200] }],
@@ -780,11 +607,9 @@ describe("event pattern", () => {
 
     test("numeric range or and AND", () => {
       ebEventPatternTestCase(
-        reflect<RulePredicateFunction<TestEvent>>(
-          (event) =>
-            (event.detail.num > 300 || event.detail.num < 200) &&
-            event.detail.num > 0
-        ),
+        (event: TestEvent) =>
+          (event.detail.num > 300 || event.detail.num < 200) &&
+          event.detail.num > 0,
         {
           detail: {
             num: [{ numeric: [">", 300] }, { numeric: [">", 0, "<", 200] }],
@@ -803,11 +628,9 @@ describe("event pattern", () => {
      */
     test("numeric range or and AND part reduced", () => {
       ebEventPatternTestCase(
-        reflect<RulePredicateFunction<TestEvent>>(
-          (event) =>
-            (event.detail.num > 300 || event.detail.num < 200) &&
-            (event.detail.num > 0 || event.detail.num < 500)
-        ),
+        (event: TestEvent) =>
+          (event.detail.num > 300 || event.detail.num < 200) &&
+          (event.detail.num > 0 || event.detail.num < 500),
         {
           detail: {
             num: [{ numeric: [">", 300] }, { numeric: ["<", 200] }],
@@ -818,11 +641,9 @@ describe("event pattern", () => {
 
     test("numeric range or and AND part reduced inverted", () => {
       ebEventPatternTestCase(
-        reflect<RulePredicateFunction<TestEvent>>(
-          (event) =>
-            (event.detail.num > 0 || event.detail.num < 500) &&
-            (event.detail.num > 300 || event.detail.num < 200)
-        ),
+        (event: TestEvent) =>
+          (event.detail.num > 0 || event.detail.num < 500) &&
+          (event.detail.num > 300 || event.detail.num < 200),
         {
           detail: {
             num: [{ numeric: [">", 300] }, { numeric: ["<", 200] }],
@@ -833,11 +654,9 @@ describe("event pattern", () => {
 
     test("numeric range or and AND part reduced both valid", () => {
       ebEventPatternTestCase(
-        reflect<RulePredicateFunction<TestEvent>>(
-          (event) =>
-            (event.detail.num > 300 || event.detail.num < 200) &&
-            (event.detail.num > 250 || event.detail.num < 100)
-        ),
+        (event: TestEvent) =>
+          (event.detail.num > 300 || event.detail.num < 200) &&
+          (event.detail.num > 250 || event.detail.num < 100),
         {
           detail: {
             num: [{ numeric: [">", 300] }, { numeric: ["<", 100] }],
@@ -848,13 +667,11 @@ describe("event pattern", () => {
 
     test("numeric range or and AND part reduced both ranges", () => {
       ebEventPatternTestCase(
-        reflect<RulePredicateFunction<TestEvent>>(
-          (event) =>
-            ((event.detail.num >= 10 && event.detail.num <= 20) ||
-              (event.detail.num >= 30 && event.detail.num <= 40)) &&
-            ((event.detail.num >= 5 && event.detail.num <= 15) ||
-              (event.detail.num >= 25 && event.detail.num <= 30))
-        ),
+        (event: TestEvent) =>
+          ((event.detail.num >= 10 && event.detail.num <= 20) ||
+            (event.detail.num >= 30 && event.detail.num <= 40)) &&
+          ((event.detail.num >= 5 && event.detail.num <= 15) ||
+            (event.detail.num >= 25 && event.detail.num <= 30)),
         {
           detail: {
             num: [{ numeric: [">=", 10, "<=", 15] }, 30],
@@ -865,13 +682,11 @@ describe("event pattern", () => {
 
     test("numeric range or and AND part reduced both losing some range", () => {
       ebEventPatternTestCase(
-        reflect<RulePredicateFunction<TestEvent>>(
-          (event) =>
-            ((event.detail.num >= 10 && event.detail.num <= 20) ||
-              (event.detail.num >= 30 && event.detail.num <= 40)) &&
-            ((event.detail.num >= 5 && event.detail.num <= 15) ||
-              (event.detail.num >= 25 && event.detail.num < 30))
-        ),
+        (event: TestEvent) =>
+          ((event.detail.num >= 10 && event.detail.num <= 20) ||
+            (event.detail.num >= 30 && event.detail.num <= 40)) &&
+          ((event.detail.num >= 5 && event.detail.num <= 15) ||
+            (event.detail.num >= 25 && event.detail.num < 30)),
         {
           detail: {
             num: [{ numeric: [">=", 10, "<=", 15] }],
@@ -882,12 +697,10 @@ describe("event pattern", () => {
 
     test("numeric range multiple distinct segments", () => {
       ebEventPatternTestCase(
-        reflect<RulePredicateFunction<TestEvent>>(
-          (event) =>
-            (event.detail.num > 300 && event.detail.num < 400) ||
-            (event.detail.num > 0 && event.detail.num < 200) ||
-            (event.detail.num > -100 && event.detail.num < -50)
-        ),
+        (event: TestEvent) =>
+          (event.detail.num > 300 && event.detail.num < 400) ||
+          (event.detail.num > 0 && event.detail.num < 200) ||
+          (event.detail.num > -100 && event.detail.num < -50),
         {
           detail: {
             num: [
@@ -902,13 +715,11 @@ describe("event pattern", () => {
 
     test("numeric range multiple distinct segments overlapped", () => {
       ebEventPatternTestCase(
-        reflect<RulePredicateFunction<TestEvent>>(
-          (event) =>
-            (event.detail.num > 300 && event.detail.num < 400) ||
-            (event.detail.num > 0 && event.detail.num < 200) ||
-            (event.detail.num > -100 && event.detail.num < -50) ||
-            event.detail.num > -200
-        ),
+        (event: TestEvent) =>
+          (event.detail.num > 300 && event.detail.num < 400) ||
+          (event.detail.num > 0 && event.detail.num < 200) ||
+          (event.detail.num > -100 && event.detail.num < -50) ||
+          event.detail.num > -200,
         {
           detail: {
             num: [{ numeric: [">", -200] }],
@@ -919,13 +730,11 @@ describe("event pattern", () => {
 
     test("numeric range multiple distinct segments merged", () => {
       ebEventPatternTestCase(
-        reflect<RulePredicateFunction<TestEvent>>(
-          (event) =>
-            (event.detail.num > 300 && event.detail.num < 400) ||
-            (event.detail.num > 0 && event.detail.num < 200) ||
-            (event.detail.num > -100 && event.detail.num < -50) ||
-            (event.detail.num > -200 && event.detail.num < 200)
-        ),
+        (event: TestEvent) =>
+          (event.detail.num > 300 && event.detail.num < 400) ||
+          (event.detail.num > 0 && event.detail.num < 200) ||
+          (event.detail.num > -100 && event.detail.num < -50) ||
+          (event.detail.num > -200 && event.detail.num < 200),
         {
           detail: {
             num: [
@@ -939,11 +748,9 @@ describe("event pattern", () => {
 
     test("numeric range or and AND dropped range", () => {
       ebEventPatternTestCase(
-        reflect<RulePredicateFunction<TestEvent>>(
-          (event) =>
-            (event.detail.num > 300 || event.detail.num < 200) &&
-            event.detail.num > 400
-        ),
+        (event: TestEvent) =>
+          (event.detail.num > 300 || event.detail.num < 200) &&
+          event.detail.num > 400,
         {
           detail: {
             num: [{ numeric: [">", 400] }],
@@ -954,25 +761,21 @@ describe("event pattern", () => {
 
     test("numeric range nil range error upper", () => {
       ebEventPatternTestCaseError(
-        reflect<RulePredicateFunction<TestEvent>>(
-          (event) =>
-            event.detail.num >= 100 &&
-            event.detail.num < 1000 &&
-            event.detail.num < 50
-        ),
+        (event: TestEvent) =>
+          event.detail.num >= 100 &&
+          event.detail.num < 1000 &&
+          event.detail.num < 50,
         "Found zero range numeric range lower 100 inclusive: true, upper 50 inclusive: false"
       );
     });
 
     test("numeric range nil range OR valid range", () => {
       ebEventPatternTestCase(
-        reflect<RulePredicateFunction<TestEvent>>(
-          (event) =>
-            event.detail.num === 10 ||
-            (event.detail.num >= 100 &&
-              event.detail.num < 1000 &&
-              event.detail.num < 50)
-        ),
+        (event: TestEvent) =>
+          event.detail.num === 10 ||
+          (event.detail.num >= 100 &&
+            event.detail.num < 1000 &&
+            event.detail.num < 50),
         {
           detail: {
             num: [10],
@@ -983,27 +786,23 @@ describe("event pattern", () => {
 
     test("numeric range nil range AND invalid range", () => {
       ebEventPatternTestCaseError(
-        reflect<RulePredicateFunction<TestEvent>>(
-          (event) =>
-            event.detail.num >= 100 &&
-            event.detail.num < 1000 &&
-            event.detail.num < 50 &&
-            event.detail.num === 10
-        ),
+        (event: TestEvent) =>
+          event.detail.num >= 100 &&
+          event.detail.num < 1000 &&
+          event.detail.num < 50 &&
+          event.detail.num === 10,
         "Impossible logic discovered: Found zero range numeric range lower 100 inclusive: true, upper 50 inclusive: false"
       );
     });
 
     test("numeric range nil range OR valid aggregate range", () => {
       ebEventPatternTestCase(
-        reflect<RulePredicateFunction<TestEvent>>(
-          (event) =>
-            event.detail.num === 10 ||
-            event.detail.num === 11 ||
-            (event.detail.num >= 100 &&
-              event.detail.num < 1000 &&
-              event.detail.num < 50)
-        ),
+        (event: TestEvent) =>
+          event.detail.num === 10 ||
+          event.detail.num === 11 ||
+          (event.detail.num >= 100 &&
+            event.detail.num < 1000 &&
+            event.detail.num < 50),
         {
           detail: {
             num: [10, 11],
@@ -1014,31 +813,25 @@ describe("event pattern", () => {
 
     test("numeric range nil range error lower", () => {
       ebEventPatternTestCaseError(
-        reflect<RulePredicateFunction<TestEvent>>(
-          (event) =>
-            event.detail.num >= 100 &&
-            event.detail.num < 1000 &&
-            event.detail.num > 1100
-        )
+        (event: TestEvent) =>
+          event.detail.num >= 100 &&
+          event.detail.num < 1000 &&
+          event.detail.num > 1100
       );
     });
 
     test("numeric range nil range illogical", () => {
       ebEventPatternTestCaseError(
-        reflect<RulePredicateFunction<TestEvent>>(
-          (event) => event.detail.num >= 100 && event.detail.num < 50
-        ),
+        (event: TestEvent) => event.detail.num >= 100 && event.detail.num < 50,
         "Found zero range numeric range lower 100 inclusive: true, upper 50 inclusive: false"
       );
     });
 
     test("numeric range nil range illogical with override", () => {
       ebEventPatternTestCase(
-        reflect<RulePredicateFunction<TestEvent>>(
-          (event) =>
-            event.detail.num === 10 ||
-            (event.detail.num >= 100 && event.detail.num < 50)
-        ),
+        (event: TestEvent) =>
+          event.detail.num === 10 ||
+          (event.detail.num >= 100 && event.detail.num < 50),
         {
           detail: {
             num: [10],
@@ -1051,10 +844,8 @@ describe("event pattern", () => {
   describe("aggregate", () => {
     test("test for optional", () => {
       ebEventPatternTestCase(
-        reflect<RulePredicateFunction<TestEvent>>(
-          (event) =>
-            !!event.detail.optional && event.detail.optional === "value"
-        ),
+        (event: TestEvent) =>
+          !!event.detail.optional && event.detail.optional === "value",
         {
           detail: {
             optional: ["value"],
@@ -1065,12 +856,10 @@ describe("event pattern", () => {
 
     test("test for optional number", () => {
       ebEventPatternTestCase(
-        reflect<RulePredicateFunction<TestEvent>>(
-          (event) =>
-            !!event.detail.optionalNum &&
-            event.detail.optionalNum > 10 &&
-            event.detail.optionalNum < 100
-        ),
+        (event: TestEvent) =>
+          !!event.detail.optionalNum &&
+          event.detail.optionalNum > 10 &&
+          event.detail.optionalNum < 100,
         {
           detail: {
             optionalNum: [{ numeric: [">", 10, "<", 100] }],
@@ -1081,9 +870,8 @@ describe("event pattern", () => {
 
     test("number and string separate fields", () => {
       ebEventPatternTestCase(
-        reflect<RulePredicateFunction<TestEvent>>(
-          (event) => event.detail.num === 10 && event.detail.str === "hello"
-        ),
+        (event: TestEvent) =>
+          event.detail.num === 10 && event.detail.str === "hello",
         {
           detail: {
             str: ["hello"],
@@ -1095,21 +883,17 @@ describe("event pattern", () => {
 
     test("same field AND string", () => {
       ebEventPatternTestCaseError(
-        reflect<RulePredicateFunction<TestEvent>>(
-          (event) =>
-            event.detail.str === "hi" && <any>event.detail.str === "hello"
-        ),
+        (event: TestEvent) =>
+          event.detail.str === "hi" && <any>event.detail.str === "hello",
         "hello"
       );
     });
 
     test("same field AND string with OR", () => {
       ebEventPatternTestCase(
-        reflect<RulePredicateFunction<TestEvent>>(
-          (event) =>
-            event.detail.str === "huh" ||
-            (event.detail.str === "hi" && <any>event.detail.str === "hello")
-        ),
+        (event: TestEvent) =>
+          event.detail.str === "huh" ||
+          (event.detail.str === "hi" && <any>event.detail.str === "hello"),
         {
           detail: {
             str: ["huh"],
@@ -1120,9 +904,8 @@ describe("event pattern", () => {
 
     test("same field AND string identical", () => {
       ebEventPatternTestCase(
-        reflect<RulePredicateFunction<TestEvent>>(
-          (event) => event.detail.str === "hi" && event.detail.str === "hi"
-        ),
+        (event: TestEvent) =>
+          event.detail.str === "hi" && event.detail.str === "hi",
         {
           detail: {
             str: ["hi"],
@@ -1133,9 +916,8 @@ describe("event pattern", () => {
 
     test("same field OR string", () => {
       ebEventPatternTestCase(
-        reflect<RulePredicateFunction<TestEvent>>(
-          (event) => event.detail.str === "hi" || event.detail.str === "hello"
-        ),
+        (event: TestEvent) =>
+          event.detail.str === "hi" || event.detail.str === "hello",
         {
           detail: {
             str: ["hi", "hello"],
@@ -1146,11 +928,9 @@ describe("event pattern", () => {
 
     test("same field OR string and AND another field ", () => {
       ebEventPatternTestCase(
-        reflect<RulePredicateFunction<TestEvent>>(
-          (event) =>
-            (event.detail.str === "hi" || event.detail.str === "hello") &&
-            event.detail.num === 100
-        ),
+        (event: TestEvent) =>
+          (event.detail.str === "hi" || event.detail.str === "hello") &&
+          event.detail.num === 100,
         {
           detail: {
             str: ["hi", "hello"],
@@ -1162,9 +942,8 @@ describe("event pattern", () => {
 
     test("same field AND another field ", () => {
       ebEventPatternTestCase(
-        reflect<RulePredicateFunction<TestEvent>>(
-          (event) => event.detail.str === "hello" && event.detail.num === 100
-        ),
+        (event: TestEvent) =>
+          event.detail.str === "hello" && event.detail.num === 100,
         {
           detail: {
             str: ["hello"],
@@ -1176,23 +955,20 @@ describe("event pattern", () => {
 
     test("same field || another field ", () => {
       ebEventPatternTestCaseError(
-        reflect<RulePredicateFunction<TestEvent>>(
-          (event) => event.detail.str === "hello" || event.detail.num === 100
-        ),
+        (event: TestEvent) =>
+          event.detail.str === "hello" || event.detail.num === 100,
         "Event bridge does not support OR logic between multiple fields, found str and num."
       );
     });
 
     test("lots of AND", () => {
       ebEventPatternTestCase(
-        reflect<RulePredicateFunction<TestEvent>>(
-          (event) =>
-            event.detail.str === "hi" &&
-            event.detail.num === 100 &&
-            event.source === "lambda" &&
-            event.region === "us-east-1" &&
-            event.id === "10"
-        ),
+        (event: TestEvent) =>
+          event.detail.str === "hi" &&
+          event.detail.num === 100 &&
+          event.source === "lambda" &&
+          event.region === "us-east-1" &&
+          event.id === "10",
         {
           detail: {
             str: ["hi"],
@@ -1207,10 +983,8 @@ describe("event pattern", () => {
 
     test("AND prefix", () => {
       ebEventPatternTestCase(
-        reflect<RulePredicateFunction<TestEvent>>(
-          (event) =>
-            event.detail.str.startsWith("hi") && event.detail.num === 100
-        ),
+        (event: TestEvent) =>
+          event.detail.str.startsWith("hi") && event.detail.num === 100,
         {
           detail: {
             str: [{ prefix: "hi" }],
@@ -1222,41 +996,33 @@ describe("event pattern", () => {
 
     test("AND not prefix", () => {
       ebEventPatternTestCaseError(
-        reflect<RulePredicateFunction<TestEvent>>(
-          (event) =>
-            !event.detail.str.startsWith("hi") && event.detail.str !== "hello"
-        ),
+        (event: TestEvent) =>
+          !event.detail.str.startsWith("hi") && event.detail.str !== "hello",
         "Event Bridge patterns do not support AND logic between NOT prefix and any other logic."
       );
     });
 
     test("AND not prefix reverse", () => {
       ebEventPatternTestCaseError(
-        reflect<RulePredicateFunction<TestEvent>>(
-          (event) =>
-            event.detail.str !== "hello" && !event.detail.str.startsWith("hi")
-        ),
+        (event: TestEvent) =>
+          event.detail.str !== "hello" && !event.detail.str.startsWith("hi"),
         "Event Bridge patterns do not support AND logic between NOT prefix and any other logic."
       );
     });
 
     test("AND not two prefix", () => {
       ebEventPatternTestCaseError(
-        reflect<RulePredicateFunction<TestEvent>>(
-          (event) =>
-            !event.detail.str.startsWith("hello") &&
-            !event.detail.str.startsWith("hi")
-        ),
+        (event: TestEvent) =>
+          !event.detail.str.startsWith("hello") &&
+          !event.detail.str.startsWith("hi"),
         "Event Bridge patterns do not support AND logic between NOT prefix and any other logic."
       );
     });
 
     test("AND list", () => {
       ebEventPatternTestCase(
-        reflect<RulePredicateFunction<TestEvent>>(
-          (event) =>
-            event.detail.array.includes("hi") && event.detail.num === 100
-        ),
+        (event: TestEvent) =>
+          event.detail.array.includes("hi") && event.detail.num === 100,
         {
           detail: {
             array: ["hi"],
@@ -1268,9 +1034,8 @@ describe("event pattern", () => {
 
     test("AND exists", () => {
       ebEventPatternTestCase(
-        reflect<RulePredicateFunction<TestEvent>>(
-          (event) => !!event.detail.optional && event.detail.num === 100
-        ),
+        (event: TestEvent) =>
+          !!event.detail.optional && event.detail.num === 100,
         {
           detail: {
             optional: [{ exists: true }],
@@ -1282,9 +1047,8 @@ describe("event pattern", () => {
 
     test("AND not exists", () => {
       ebEventPatternTestCase(
-        reflect<RulePredicateFunction<TestEvent>>(
-          (event) => !event.detail.optional && event.detail.num === 100
-        ),
+        (event: TestEvent) =>
+          !event.detail.optional && event.detail.num === 100,
         {
           detail: {
             optional: [{ exists: false }],
@@ -1296,9 +1060,8 @@ describe("event pattern", () => {
 
     test("AND not equals", () => {
       ebEventPatternTestCase(
-        reflect<RulePredicateFunction<TestEvent>>(
-          (event) => event.detail.str !== "hi" && event.detail.str !== "hello"
-        ),
+        (event: TestEvent) =>
+          event.detail.str !== "hi" && event.detail.str !== "hello",
         {
           detail: {
             str: [{ "anything-but": ["hi", "hello"] }],
@@ -1309,11 +1072,9 @@ describe("event pattern", () => {
 
     test("AND not not equals", () => {
       ebEventPatternTestCase(
-        reflect<RulePredicateFunction<TestEvent>>(
-          // str === "hi" || str === "hello"
-          (event) =>
-            !(event.detail.str !== "hi" && event.detail.str !== "hello")
-        ),
+        // str === "hi" || str === "hello"
+        (event: TestEvent) =>
+          !(event.detail.str !== "hi" && event.detail.str !== "hello"),
         {
           detail: {
             str: ["hi", "hello"],
@@ -1324,20 +1085,16 @@ describe("event pattern", () => {
 
     test("AND not exists and exists impossible", () => {
       ebEventPatternTestCaseError(
-        reflect<RulePredicateFunction<TestEvent>>(
-          (event) => !event.detail.str && <any>event.detail.str
-        ),
+        (event: TestEvent) => !event.detail.str && <any>event.detail.str,
         "Field cannot both be present and not present."
       );
     });
 
     test("AND not exists and exists impossible", () => {
       ebEventPatternTestCase(
-        reflect<RulePredicateFunction<TestEvent>>(
-          (event) =>
-            event.detail.str === "hi" ||
-            (!event.detail.str && <any>event.detail.str)
-        ),
+        (event: TestEvent) =>
+          event.detail.str === "hi" ||
+          (!event.detail.str && <any>event.detail.str),
         {
           detail: {
             str: ["hi"],
@@ -1348,9 +1105,7 @@ describe("event pattern", () => {
 
     test("AND not exists and not equals", () => {
       ebEventPatternTestCase(
-        reflect<RulePredicateFunction<TestEvent>>(
-          (event) => !event.detail.str && event.detail.str !== "x"
-        ),
+        (event: TestEvent) => !event.detail.str && event.detail.str !== "x",
         {
           detail: {
             str: [{ exists: false }],
@@ -1361,20 +1116,16 @@ describe("event pattern", () => {
 
     test("AND not exists and value", () => {
       ebEventPatternTestCaseError(
-        reflect<RulePredicateFunction<TestEvent>>(
-          (event) => !event.detail.str && event.detail.str === "x"
-        ),
+        (event: TestEvent) => !event.detail.str && event.detail.str === "x",
         "Invalid comparison: pattern cannot both be not present as a positive value"
       );
     });
 
     test("AND not exists and value", () => {
       ebEventPatternTestCase(
-        reflect<RulePredicateFunction<TestEvent>>(
-          (event) =>
-            event.detail.str === "hello" ||
-            (!event.detail.str && event.detail.str === "x")
-        ),
+        (event: TestEvent) =>
+          event.detail.str === "hello" ||
+          (!event.detail.str && event.detail.str === "x"),
         {
           detail: {
             str: ["hello"],
@@ -1385,9 +1136,8 @@ describe("event pattern", () => {
 
     test("AND not null and not value", () => {
       ebEventPatternTestCase(
-        reflect<RulePredicateFunction<TestEvent>>(
-          (event) => event.detail.str !== null && event.detail.str !== "x"
-        ),
+        (event: TestEvent) =>
+          event.detail.str !== null && event.detail.str !== "x",
         {
           detail: {
             str: [{ "anything-but": [null, "x"] }],
@@ -1398,9 +1148,7 @@ describe("event pattern", () => {
 
     test("AND not not exists and not equals", () => {
       ebEventPatternTestCase(
-        reflect<RulePredicateFunction<TestEvent>>(
-          (event) => !(!event.detail.str && event.detail.str !== "x")
-        ),
+        (event: TestEvent) => !(!event.detail.str && event.detail.str !== "x"),
         {
           detail: {
             str: [{ exists: true }],
@@ -1411,9 +1159,7 @@ describe("event pattern", () => {
 
     test("AND not exists and not equals", () => {
       ebEventPatternTestCase(
-        reflect<RulePredicateFunction<TestEvent>>(
-          (event) => event.detail.str !== "x" && !event.detail.str
-        ),
+        (event: TestEvent) => event.detail.str !== "x" && !event.detail.str,
         {
           detail: {
             str: [{ exists: false }],
@@ -1424,19 +1170,16 @@ describe("event pattern", () => {
 
     test("OR not equals", () => {
       ebEventPatternTestCase(
-        reflect<RulePredicateFunction<TestEvent>>(
-          (event) =>
-            event.detail.str !== "hi" || <any>event.detail.str !== "hello"
-        ),
+        (event: TestEvent) =>
+          event.detail.str !== "hi" || <any>event.detail.str !== "hello",
         { source: [{ prefix: "" }] }
       );
     });
 
     test("AND not eq", () => {
       ebEventPatternTestCase(
-        reflect<RulePredicateFunction<TestEvent>>(
-          (event) => event.detail.str !== "hi" && event.detail.num === 100
-        ),
+        (event: TestEvent) =>
+          event.detail.str !== "hi" && event.detail.num === 100,
         {
           detail: {
             str: [{ "anything-but": "hi" }],
@@ -1448,10 +1191,8 @@ describe("event pattern", () => {
 
     test("OR not exists", () => {
       ebEventPatternTestCase(
-        reflect<RulePredicateFunction<TestEvent>>(
-          (event) =>
-            !event.detail.optional || event.detail.optional === "cheese"
-        ),
+        (event: TestEvent) =>
+          !event.detail.optional || event.detail.optional === "cheese",
         {
           detail: {
             optional: [{ exists: false }, "cheese"],
@@ -1462,10 +1203,8 @@ describe("event pattern", () => {
 
     test("OR not exists not eq", () => {
       ebEventPatternTestCase(
-        reflect<RulePredicateFunction<TestEvent>>(
-          (event) =>
-            !event.detail.optional || event.detail.optional !== "cheese"
-        ),
+        (event: TestEvent) =>
+          !event.detail.optional || event.detail.optional !== "cheese",
         {
           detail: {
             optional: [{ exists: false }, { "anything-but": "cheese" }],
@@ -1476,10 +1215,8 @@ describe("event pattern", () => {
 
     test("OR not exists starts with", () => {
       ebEventPatternTestCase(
-        reflect<RulePredicateFunction<TestEvent>>(
-          (event) =>
-            !event.detail.optional || event.detail.optional.startsWith("cheese")
-        ),
+        (event: TestEvent) =>
+          !event.detail.optional || event.detail.optional.startsWith("cheese"),
         {
           detail: {
             optional: [{ exists: false }, { prefix: "cheese" }],
@@ -1490,11 +1227,8 @@ describe("event pattern", () => {
 
     test("OR not exists not starts with", () => {
       ebEventPatternTestCase(
-        reflect<RulePredicateFunction<TestEvent>>(
-          (event) =>
-            !event.detail.optional ||
-            !event.detail.optional.startsWith("cheese")
-        ),
+        (event: TestEvent) =>
+          !event.detail.optional || !event.detail.optional.startsWith("cheese"),
         {
           detail: {
             optional: [
@@ -1510,16 +1244,14 @@ describe("event pattern", () => {
   describe("error edge cases", () => {
     test("comparing non event values", () => {
       ebEventPatternTestCaseError(
-        reflect<RulePredicateFunction<TestEvent>>((_event) => "10" === "10"),
+        (_event) => "10" === "10",
         "Expected exactly one event reference, got zero."
       );
     });
 
     test("comparing two event values", () => {
       ebEventPatternTestCaseError(
-        reflect<RulePredicateFunction<TestEvent>>(
-          (event) => event.id === event.region
-        ),
+        (event: TestEvent) => event.id === event.region,
         "Expected exactly one event reference, got two."
       );
     });
@@ -1529,22 +1261,17 @@ describe("event pattern", () => {
 // https://github.com/functionless/functionless/issues/68
 describe.skip("destructure", () => {
   test("destructure parameter", () => {
-    ebEventPatternTestCase(
-      reflect<RulePredicateFunction<TestEvent>>(
-        ({ source }) => source === "lambda"
-      ),
-      {
-        source: ["lambda"],
-      }
-    );
+    ebEventPatternTestCase(({ source }) => source === "lambda", {
+      source: ["lambda"],
+    });
   });
 
   test("destructure variable", () => {
     ebEventPatternTestCase(
-      reflect<RulePredicateFunction<TestEvent>>((event) => {
+      (event: TestEvent) => {
         const { source } = event;
         return source === "lambda";
-      }),
+      },
       {
         source: ["lambda"],
       }
@@ -1553,12 +1280,12 @@ describe.skip("destructure", () => {
 
   test("destructure multi-layer variable", () => {
     ebEventPatternTestCase(
-      reflect<RulePredicateFunction<TestEvent>>((event) => {
+      (event: TestEvent) => {
         const {
           detail: { str },
         } = event;
         return str === "lambda";
-      }),
+      },
       {
         detail: { str: ["lambda"] },
       }
@@ -1566,36 +1293,32 @@ describe.skip("destructure", () => {
   });
 
   test("destructure array doesn't work", () => {
-    ebEventPatternTestCaseError(
-      reflect<RulePredicateFunction<TestEvent>>((event) => {
-        const {
-          detail: {
-            array: [value],
-          },
-        } = event;
-        return value === "lambda";
-      })
-    );
+    ebEventPatternTestCaseError((event: TestEvent) => {
+      const {
+        detail: {
+          array: [value],
+        },
+      } = event;
+      return value === "lambda";
+    });
   });
 
   test("destructure parameter array doesn't work", () => {
     ebEventPatternTestCaseError(
-      reflect<RulePredicateFunction<TestEvent>>(
-        ({
-          detail: {
-            array: [value],
-          },
-        }) => value === "lambda"
-      )
+      ({
+        detail: {
+          array: [value],
+        },
+      }) => value === "lambda"
     );
   });
 
   test("descture variable rename", () => {
     ebEventPatternTestCase(
-      reflect<RulePredicateFunction<TestEvent>>((event) => {
+      (event: TestEvent) => {
         const { source: src } = event;
         return src === "lambda";
-      }),
+      },
       {
         source: ["lambda"],
       }
@@ -1603,14 +1326,9 @@ describe.skip("destructure", () => {
   });
 
   test("destructure parameter rename", () => {
-    ebEventPatternTestCase(
-      reflect<RulePredicateFunction<TestEvent>>(
-        ({ source: src }) => src === "lambda"
-      ),
-      {
-        source: ["lambda"],
-      }
-    );
+    ebEventPatternTestCase(({ source: src }) => src === "lambda", {
+      source: ["lambda"],
+    });
   });
 });
 
@@ -1618,9 +1336,7 @@ describe.skip("destructure", () => {
 describe.skip("list some", () => {
   test("list starts with", () => {
     ebEventPatternTestCase(
-      reflect<RulePredicateFunction<TestEvent>>((event) =>
-        event.resources.some((r) => r.startsWith("hi"))
-      ),
+      (event: TestEvent) => event.resources.some((r) => r.startsWith("hi")),
       {
         resources: [{ prefix: "hi" }],
       }
@@ -1628,20 +1344,17 @@ describe.skip("list some", () => {
   });
 
   test("list starts with AND errors", () => {
-    ebEventPatternTestCaseError(
-      reflect<RulePredicateFunction<TestEvent>>((event) =>
-        event.resources.some((r) => r.startsWith("hi") && r === "taco")
-      )
+    ebEventPatternTestCaseError((event: TestEvent) =>
+      event.resources.some((r) => r.startsWith("hi") && r === "taco")
     );
   });
 
   test("list starts with OR is fine", () => {
     ebEventPatternTestCase(
-      reflect<RulePredicateFunction<TestEvent>>((event) =>
+      (event: TestEvent) =>
         event.resources.some(
           (r) => r.startsWith("hi") || r.startsWith("taco") || r === "cheddar"
-        )
-      ),
+        ),
       {
         resources: [{ prefix: "hi" }, { prefix: "taco" }, "cheddar"],
       }
@@ -1650,9 +1363,7 @@ describe.skip("list some", () => {
 
   test("list some instead of includes", () => {
     ebEventPatternTestCase(
-      reflect<RulePredicateFunction<TestEvent>>((event) =>
-        event.resources.some((r) => r === "cheddar")
-      ),
+      (event: TestEvent) => event.resources.some((r) => r === "cheddar"),
       {
         resources: ["cheddar"],
       }
@@ -1662,9 +1373,26 @@ describe.skip("list some", () => {
 
 test("error when using rest parameters", () => {
   ebEventPatternTestCaseError(
-    reflect<RulePredicateFunction<TestEvent>>((...event) =>
-      event[0].resources.some((r) => r.startsWith("hi") && r === "taco")
-    ),
+    (...event: [TestEvent, ...TestEvent[]]) =>
+      event[0].resources.some((r) => r.startsWith("hi") && r === "taco"),
     "Event Bridge does not yet support rest parameters"
   );
 });
+
+// type inference tests
+() => {
+  const app = new App({
+    autoSynth: false,
+  });
+  const stack = new Stack(app, "stack");
+
+  const bus = new EventBus<Event<TestEvent>>(stack, "bus");
+
+  bus.all().pipe(
+    new Function(stack, "F", async (event) => {
+      // event should be inferred
+      const time: string = event.detail.time;
+      time;
+    })
+  );
+};

--- a/test/eventtargets.test.ts
+++ b/test/eventtargets.test.ts
@@ -1,11 +1,5 @@
 import { aws_events, Stack } from "aws-cdk-lib";
-import {
-  ErrorCodes,
-  formatErrorMessage,
-  Function,
-  reflect,
-  StepFunction,
-} from "../src";
+import { ErrorCodes, formatErrorMessage, Function, StepFunction } from "../src";
 import { Event } from "../src/event-bridge";
 
 import { ebEventTargetTestCase, ebEventTargetTestCaseError } from "./util";
@@ -21,7 +15,7 @@ type testEvent = Event<{
 
 test("event path", () => {
   ebEventTargetTestCase<testEvent>(
-    reflect((event) => event.source),
+    (event) => event.source,
     aws_events.RuleTargetInput.fromEventPath("$.source")
   );
 });
@@ -29,21 +23,21 @@ test("event path", () => {
 test("event path index access", () => {
   ebEventTargetTestCase<testEvent>(
     // eslint-disable-next-line dot-notation
-    reflect((event) => event["source"]),
+    (event) => event["source"],
     aws_events.RuleTargetInput.fromEventPath("$.source")
   );
 });
 
 test("event path index access special json path", () => {
   ebEventTargetTestCase<testEvent>(
-    reflect((event) => event.detail["blah-blah"]),
+    (event) => event.detail["blah-blah"],
     aws_events.RuleTargetInput.fromEventPath("$.detail.blah-blah")
   );
 });
 
 test("event path index access spaces json path", () => {
   ebEventTargetTestCase<testEvent>(
-    reflect((event) => event.detail["blah blah"]),
+    (event) => event.detail["blah blah"],
     // Note: this doesn't look right, but it was tested with the event bridge sandbox and worked
     aws_events.RuleTargetInput.fromEventPath("$.detail.blah blah")
   );
@@ -51,7 +45,7 @@ test("event path index access spaces json path", () => {
 
 test("string formatting", () => {
   ebEventTargetTestCase<testEvent>(
-    reflect((event) => `hello ${event.source}`),
+    (event) => `hello ${event.source}`,
     aws_events.RuleTargetInput.fromText(
       `hello ${aws_events.EventField.fromPath("$.source")}`
     )
@@ -60,21 +54,21 @@ test("string formatting", () => {
 
 test("string formatting with constants", () => {
   ebEventTargetTestCase<testEvent>(
-    reflect(() => `hello ${"hi?"}`),
+    () => `hello ${"hi?"}`,
     aws_events.RuleTargetInput.fromText("hello hi?")
   );
 });
 
 test("constant value", () => {
   ebEventTargetTestCase<testEvent>(
-    reflect(() => "hello"),
+    () => "hello",
     aws_events.RuleTargetInput.fromText("hello")
   );
 });
 
 test("string concat", () => {
   ebEventTargetTestCase<testEvent>(
-    reflect((event) => "hello " + event.source),
+    (event) => "hello " + event.source,
     aws_events.RuleTargetInput.fromText(
       `hello ${aws_events.EventField.fromPath("$.source")}`
     )
@@ -83,23 +77,23 @@ test("string concat", () => {
 
 test("string concat with number", () => {
   ebEventTargetTestCase<testEvent>(
-    reflect(() => "hello " + 1),
+    () => "hello " + 1,
     aws_events.RuleTargetInput.fromText(`hello 1`)
   );
 });
 
 test("optional assert", () => {
   ebEventTargetTestCase<testEvent>(
-    reflect((event) => event.detail.optional!),
+    (event) => event.detail.optional!,
     aws_events.RuleTargetInput.fromEventPath("$.detail.optional")
   );
 });
 
 test("object with constants", () => {
   ebEventTargetTestCase<testEvent>(
-    reflect(() => ({
+    () => ({
       value: "hi",
-    })),
+    }),
     aws_events.RuleTargetInput.fromObject({
       value: "hi",
     })
@@ -108,9 +102,9 @@ test("object with constants", () => {
 
 test("object with event references", () => {
   ebEventTargetTestCase<testEvent>(
-    reflect((event) => ({
+    (event) => ({
       value: event.detail.value,
-    })),
+    }),
     aws_events.RuleTargetInput.fromObject({
       value: aws_events.EventField.fromPath("$.detail.value"),
     })
@@ -119,9 +113,9 @@ test("object with event references", () => {
 
 test("object with event template references", () => {
   ebEventTargetTestCase<testEvent>(
-    reflect((event) => ({
+    (event) => ({
       value: `hello ${event.detail.value}`,
-    })),
+    }),
     aws_events.RuleTargetInput.fromObject({
       value: `hello ${aws_events.EventField.fromPath("$.detail.value")}`,
     })
@@ -130,9 +124,9 @@ test("object with event template references", () => {
 
 test("object with event number", () => {
   ebEventTargetTestCase<testEvent>(
-    reflect((event) => ({
+    (event) => ({
       value: event.detail.num,
-    })),
+    }),
     aws_events.RuleTargetInput.fromObject({
       value: aws_events.EventField.fromPath("$.detail.num"),
     })
@@ -141,9 +135,9 @@ test("object with event number", () => {
 
 test("object with null", () => {
   ebEventTargetTestCase<testEvent>(
-    reflect(() => ({
+    () => ({
       value: null,
-    })),
+    }),
     aws_events.RuleTargetInput.fromObject({
       value: null,
     })
@@ -152,18 +146,18 @@ test("object with null", () => {
 
 test("object with null", () => {
   ebEventTargetTestCase<testEvent>(
-    reflect(() => ({
+    () => ({
       value: undefined,
-    })),
+    }),
     aws_events.RuleTargetInput.fromObject({})
   );
 });
 
 test("object with event template number references", () => {
   ebEventTargetTestCase<testEvent>(
-    reflect((event) => ({
+    (event) => ({
       value: `hello ${event.detail.num}`,
-    })),
+    }),
     aws_events.RuleTargetInput.fromObject({
       value: `hello ${aws_events.EventField.fromPath("$.detail.num")}`,
     })
@@ -172,9 +166,9 @@ test("object with event template number references", () => {
 
 test("object with event object references", () => {
   ebEventTargetTestCase<testEvent>(
-    reflect((event) => ({
+    (event) => ({
       value: event.detail,
-    })),
+    }),
     aws_events.RuleTargetInput.fromObject({
       value: aws_events.EventField.fromPath("$.detail"),
     })
@@ -183,9 +177,9 @@ test("object with event object references", () => {
 
 test("object with deep event object references", () => {
   ebEventTargetTestCase<testEvent>(
-    reflect((event) => ({
+    (event) => ({
       value: { value2: event.detail.value },
-    })),
+    }),
     aws_events.RuleTargetInput.fromObject({
       value: { value2: aws_events.EventField.fromPath("$.detail.value") },
     })
@@ -194,7 +188,7 @@ test("object with deep event object references", () => {
 
 test("template with object", () => {
   ebEventTargetTestCase<testEvent>(
-    reflect((event) => `{ value: ${{ myValue: event.source }} }`),
+    (event) => `{ value: ${{ myValue: event.source }} }`,
     aws_events.RuleTargetInput.fromText(
       `{ value: {\"myValue\":\"${aws_events.EventField.fromPath(
         "$.source"
@@ -205,9 +199,9 @@ test("template with object", () => {
 
 test("object with event array references", () => {
   ebEventTargetTestCase<testEvent>(
-    reflect((event) => ({
+    (event) => ({
       value: event.detail.array,
-    })),
+    }),
     aws_events.RuleTargetInput.fromObject({
       value: aws_events.EventField.fromPath("$.detail.array"),
     })
@@ -216,9 +210,9 @@ test("object with event array references", () => {
 
 test("object with event array literal", () => {
   ebEventTargetTestCase<testEvent>(
-    reflect((event) => ({
+    (event) => ({
       value: [event.detail.value],
-    })),
+    }),
     aws_events.RuleTargetInput.fromObject({
       value: [aws_events.EventField.fromPath("$.detail.value")],
     })
@@ -227,7 +221,7 @@ test("object with event array literal", () => {
 
 test("object with bare array literal", () => {
   ebEventTargetTestCase<testEvent>(
-    reflect((event) => [event.detail.value]),
+    (event) => [event.detail.value],
     aws_events.RuleTargetInput.fromObject([
       aws_events.EventField.fromPath("$.detail.value"),
     ])
@@ -236,28 +230,28 @@ test("object with bare array literal", () => {
 
 test("object with bare array literal with null", () => {
   ebEventTargetTestCase<testEvent>(
-    reflect(() => [null]),
+    () => [null],
     aws_events.RuleTargetInput.fromObject([null])
   );
 });
 
 test("object with bare array literal with undefined", () => {
   ebEventTargetTestCase<testEvent>(
-    reflect(() => [undefined]),
+    () => [undefined],
     aws_events.RuleTargetInput.fromObject([])
   );
 });
 
 test("object with bare null", () => {
   ebEventTargetTestCase<testEvent>(
-    reflect(() => null),
+    () => null,
     aws_events.RuleTargetInput.fromObject(null)
   );
 });
 
 test("object with bare undefined", () => {
   ebEventTargetTestCase<testEvent>(
-    reflect(() => undefined),
+    () => undefined,
     aws_events.RuleTargetInput.fromObject(undefined)
   );
 });
@@ -267,40 +261,34 @@ interface MyTest extends Event<{ s: MyString }> {}
 
 test("event field + another event field should error because there is no way to know if strings", () => {
   ebEventTargetTestCaseError<MyTest>(
-    reflect((event) => event.detail.s + event.detail.s),
+    (event) => event.detail.s + event.detail.s,
     "Addition operator is only supported to concatenate at least one string to another value."
   );
 });
 
 describe("predefined", () => {
   test("direct event", () => {
-    ebEventTargetTestCase<testEvent>(
-      reflect((event) => event),
-      {
-        bind: () => {
-          return { inputPathsMap: {}, inputTemplate: "<aws.events.event>" };
-        },
-      }
-    );
+    ebEventTargetTestCase<testEvent>((event) => event, {
+      bind: () => {
+        return { inputPathsMap: {}, inputTemplate: "<aws.events.event>" };
+      },
+    });
   });
 
   test("direct rule name", () => {
-    ebEventTargetTestCase<testEvent>(
-      reflect((_event, u) => u.context.ruleName),
-      {
-        bind: () => {
-          return {
-            inputPathsMap: {},
-            inputTemplate: '"<aws.events.rule-name>"',
-          };
-        },
-      }
-    );
+    ebEventTargetTestCase<testEvent>((_event, u) => u.context.ruleName, {
+      bind: () => {
+        return {
+          inputPathsMap: {},
+          inputTemplate: '"<aws.events.rule-name>"',
+        };
+      },
+    });
   });
 
   test("direct rule name in template", () => {
     ebEventTargetTestCase<testEvent>(
-      reflect((_event, u) => `blah ${u.context.ruleName}`),
+      (_event, u) => `blah ${u.context.ruleName}`,
       {
         bind: () => {
           return {
@@ -313,24 +301,21 @@ describe("predefined", () => {
   });
 
   test("direct event json name", () => {
-    ebEventTargetTestCase<testEvent>(
-      reflect((_event, u) => u.context.eventJson),
-      {
-        bind: () => {
-          return {
-            inputPathsMap: {},
-            inputTemplate: '"<aws.events.event.json>"',
-          };
-        },
-      }
-    );
+    ebEventTargetTestCase<testEvent>((_event, u) => u.context.eventJson, {
+      bind: () => {
+        return {
+          inputPathsMap: {},
+          inputTemplate: '"<aws.events.event.json>"',
+        };
+      },
+    });
   });
 
   test("direct event in object", () => {
     ebEventTargetTestCase<testEvent>(
-      reflect((event) => ({
+      (event) => ({
         evnt: event,
-      })),
+      }),
       {
         bind: () => ({
           inputPathsMap: {},
@@ -341,20 +326,17 @@ describe("predefined", () => {
   });
 
   test("direct event in template", () => {
-    ebEventTargetTestCase<testEvent>(
-      reflect((event) => `original: ${event}`),
-      {
-        bind: () => ({
-          inputPathsMap: {},
-          inputTemplate: '"original: <aws.events.event>"',
-        }),
-      }
-    );
+    ebEventTargetTestCase<testEvent>((event) => `original: ${event}`, {
+      bind: () => ({
+        inputPathsMap: {},
+        inputTemplate: '"original: <aws.events.event>"',
+      }),
+    });
   });
 
   test("rule name", () => {
     ebEventTargetTestCase<testEvent>(
-      reflect((_, $utils) => ({ value: $utils.context.ruleName })),
+      (_, $utils) => ({ value: $utils.context.ruleName }),
       {
         bind: () => ({
           inputPathsMap: {},
@@ -366,7 +348,7 @@ describe("predefined", () => {
 
   test("rule arn", () => {
     ebEventTargetTestCase<testEvent>(
-      reflect((_, $utils) => ({ value: $utils.context.ruleArn })),
+      (_, $utils) => ({ value: $utils.context.ruleArn }),
       {
         bind: () => ({
           inputPathsMap: {},
@@ -378,7 +360,7 @@ describe("predefined", () => {
 
   test("event json", () => {
     ebEventTargetTestCase<testEvent>(
-      reflect((_, $utils) => ({ value: $utils.context.eventJson })),
+      (_, $utils) => ({ value: $utils.context.eventJson }),
       {
         bind: () => ({
           inputPathsMap: {},
@@ -390,7 +372,7 @@ describe("predefined", () => {
 
   test("time", () => {
     ebEventTargetTestCase<testEvent>(
-      reflect((_, $utils) => ({ value: $utils.context.ingestionTime })),
+      (_, $utils) => ({ value: $utils.context.ingestionTime }),
       {
         bind: () => ({
           inputPathsMap: {},
@@ -402,7 +384,7 @@ describe("predefined", () => {
 
   test("different utils name", () => {
     ebEventTargetTestCase<testEvent>(
-      reflect((_, utils) => ({ value: utils.context.ruleName })),
+      (_, utils) => ({ value: utils.context.ruleName }),
       {
         bind: () => ({
           inputPathsMap: {},
@@ -413,28 +395,25 @@ describe("predefined", () => {
   });
 
   test("different utils name at the top", () => {
-    ebEventTargetTestCase<testEvent>(
-      reflect((_, utils) => utils.context.ruleName),
-      {
-        bind: () => {
-          return {
-            inputPathsMap: {},
-            inputTemplate: '"<aws.events.rule-name>"',
-          };
-        },
-      }
-    );
+    ebEventTargetTestCase<testEvent>((_, utils) => utils.context.ruleName, {
+      bind: () => {
+        return {
+          inputPathsMap: {},
+          inputTemplate: '"<aws.events.rule-name>"',
+        };
+      },
+    });
   });
 });
 
 describe("referencing", () => {
   test("dereference", () => {
     ebEventTargetTestCase<testEvent>(
-      reflect((event) => {
+      (event) => {
         const value = event.detail.value;
 
         return { value: value };
-      }),
+      },
       aws_events.RuleTargetInput.fromObject({
         value: aws_events.EventField.fromPath("$.detail.value"),
       })
@@ -443,11 +422,11 @@ describe("referencing", () => {
 
   test("dereference and prop access", () => {
     ebEventTargetTestCase<testEvent>(
-      reflect((event) => {
+      (event) => {
         const value = event.detail;
 
         return { value: value.value };
-      }),
+      },
       aws_events.RuleTargetInput.fromObject({
         value: aws_events.EventField.fromPath("$.detail.value"),
       })
@@ -456,11 +435,11 @@ describe("referencing", () => {
 
   test("constant", () => {
     ebEventTargetTestCase<testEvent>(
-      reflect(() => {
+      () => {
         const value = "hi";
 
         return { value: value };
-      }),
+      },
       aws_events.RuleTargetInput.fromObject({
         value: "hi",
       })
@@ -470,11 +449,11 @@ describe("referencing", () => {
   // Functionless doesn't support computed properties currently
   test("constant computed prop name", () => {
     ebEventTargetTestCase<testEvent>(
-      reflect(() => {
+      () => {
         const value = "hi";
 
         return { [value]: value };
-      }),
+      },
       aws_events.RuleTargetInput.fromObject({
         hi: "hi",
       })
@@ -483,11 +462,11 @@ describe("referencing", () => {
 
   test("constant from object", () => {
     ebEventTargetTestCase<testEvent>(
-      reflect(() => {
+      () => {
         const config = { value: "hi" };
 
         return { value: config.value };
-      }),
+      },
       aws_events.RuleTargetInput.fromObject({
         value: "hi",
       })
@@ -496,11 +475,11 @@ describe("referencing", () => {
 
   test("spread with constant object", () => {
     ebEventTargetTestCase<testEvent>(
-      reflect(() => {
+      () => {
         const config = { value: "hi" };
 
         return { ...config };
-      }),
+      },
       aws_events.RuleTargetInput.fromObject({
         value: "hi",
       })
@@ -509,11 +488,11 @@ describe("referencing", () => {
 
   test("object element access", () => {
     ebEventTargetTestCase<testEvent>(
-      reflect(() => {
+      () => {
         const config = { value: "hi" };
 
         return { val: config.value };
-      }),
+      },
       aws_events.RuleTargetInput.fromObject({
         val: "hi",
       })
@@ -522,11 +501,11 @@ describe("referencing", () => {
 
   test("object access", () => {
     ebEventTargetTestCase<testEvent>(
-      reflect(() => {
+      () => {
         const config = { value: "hi" } as any;
 
         return { val: config.value };
-      }),
+      },
       aws_events.RuleTargetInput.fromObject({
         val: "hi",
       })
@@ -535,11 +514,11 @@ describe("referencing", () => {
 
   test("constant list", () => {
     ebEventTargetTestCase<testEvent>(
-      reflect(() => {
+      () => {
         const config = ["hi"];
 
         return { values: config };
-      }),
+      },
       aws_events.RuleTargetInput.fromObject({
         values: ["hi"],
       })
@@ -548,11 +527,11 @@ describe("referencing", () => {
 
   test("spread with constant list", () => {
     ebEventTargetTestCase<testEvent>(
-      reflect(() => {
+      () => {
         const config = ["hi"];
 
         return { values: [...config, "there"] };
-      }),
+      },
       aws_events.RuleTargetInput.fromObject({
         values: ["hi", "there"],
       })
@@ -561,11 +540,11 @@ describe("referencing", () => {
 
   test("array index", () => {
     ebEventTargetTestCase<testEvent>(
-      reflect(() => {
+      () => {
         const config = ["hi"];
 
         return { values: [config[0], "there"] };
-      }),
+      },
       aws_events.RuleTargetInput.fromObject({
         values: ["hi", "there"],
       })
@@ -574,12 +553,12 @@ describe("referencing", () => {
 
   test("array index variable index", () => {
     ebEventTargetTestCase<testEvent>(
-      reflect(() => {
+      () => {
         const index = 0;
         const config = ["hi"];
 
         return { values: [config[index], "there"] };
-      }),
+      },
       aws_events.RuleTargetInput.fromObject({
         values: ["hi", "there"],
       })
@@ -590,9 +569,9 @@ describe("referencing", () => {
     const value = "hi";
 
     ebEventTargetTestCase<testEvent>(
-      reflect(() => {
+      () => {
         return { value: value };
-      }),
+      },
       aws_events.RuleTargetInput.fromObject({
         value: "hi",
       })
@@ -604,9 +583,9 @@ describe("referencing", () => {
     const value2 = "hello2";
 
     ebEventTargetTestCase<testEvent>(
-      reflect(() => {
+      () => {
         return { value2, value };
-      }),
+      },
       aws_events.RuleTargetInput.fromObject({
         value2: "hello2",
         value: "hello",
@@ -620,9 +599,9 @@ describe("referencing", () => {
     const sfn = new StepFunction(stack, "sfn", () => {});
 
     ebEventTargetTestCase<testEvent>(
-      reflect(() => {
+      () => {
         return { sfn: sfn.resource.stateMachineArn };
-      }),
+      },
       aws_events.RuleTargetInput.fromObject({
         sfn: sfn.resource.stateMachineArn,
       })
@@ -632,29 +611,24 @@ describe("referencing", () => {
   test("closure from outside into object", () => {
     const value = () => {};
 
-    ebEventTargetTestCaseError<testEvent>(
-      reflect(() => {
-        return { value: value };
-      }),
-      "Event Bridge input transforms can only output constant values."
-    );
+    ebEventTargetTestCaseError<testEvent>(() => {
+      return { value: value };
+    }, "Event Bridge input transforms can only output constant values.");
   });
 });
 
 describe("not allowed", () => {
   test("empty body", () => {
-    ebEventTargetTestCaseError<testEvent>(
-      reflect(() => {}),
-      "No return statement found in event bridge target function."
-    );
+    ebEventTargetTestCaseError<testEvent>(() => {},
+    "No return statement found in event bridge target function.");
   });
 
   // Note: this cannot happen with the type checker, but validating in case someone tries to hack around it
   test("use of deep fields outside of detail", () => {
     ebEventTargetTestCaseError<testEvent>(
-      reflect((event) => ({
+      (event) => ({
         event: (<any>event.source).blah,
-      })),
+      }),
       "Event references with depth greater than one must be on the detail property, got source,blah"
     );
   });
@@ -664,7 +638,7 @@ describe("not allowed", () => {
 
     const func = new Function(stack, "func", async () => {});
     ebEventTargetTestCaseError<testEvent>(
-      reflect(() => func("hello")),
+      () => func("hello"),
       formatErrorMessage(
         ErrorCodes.EventBus_Input_Transformers_do_not_support_Integrations
       )
@@ -675,40 +649,37 @@ describe("not allowed", () => {
   // regression: this will be a tsc-level error now that we don't have type information in the AST
   test.skip("math", () => {
     ebEventTargetTestCaseError<testEvent>(
-      reflect((event) => event.detail.num + 1),
+      (event) => event.detail.num + 1,
       "Addition operator is only supported to concatenate at least one string to another value."
     );
   });
 
   test("non-constants", () => {
     ebEventTargetTestCaseError<testEvent>(
-      reflect((event) => (() => event.detail.num)()),
+      (event) => (() => event.detail.num)(),
       "Unsupported template expression of kind: CallExpr"
     );
   });
 
   test("spread obj ref", () => {
     ebEventTargetTestCaseError<testEvent>(
-      reflect((event) => ({ ...event.detail, field: "hello" })),
+      (event) => ({ ...event.detail, field: "hello" }),
       "Event Bridge input transforms do not support object spreading non-constant objects."
     );
   });
 
   test("spread array ref", () => {
     ebEventTargetTestCaseError<testEvent>(
-      reflect((event) => [...event.detail.array]),
+      (event) => [...event.detail.array],
       "Event Bridge input transforms do not support array spreading non-constant arrays."
     );
   });
 
   test("object access missing key", () => {
-    ebEventTargetTestCaseError<testEvent>(
-      reflect(() => {
-        const obj = { val: "" } as any;
-        return { val: obj.blah };
-      }),
-      "Cannot find property blah in Object with constant keys: val"
-    );
+    ebEventTargetTestCaseError<testEvent>(() => {
+      const obj = { val: "" } as any;
+      return { val: obj.blah };
+    }, "Cannot find property blah in Object with constant keys: val");
   });
 });
 
@@ -716,9 +687,9 @@ describe("not allowed", () => {
 describe.skip("destructure", () => {
   test("destructure parameter", () => {
     ebEventTargetTestCase<testEvent>(
-      reflect(({ detail }) => {
+      ({ detail }) => {
         return { value: detail.value };
-      }),
+      },
       aws_events.RuleTargetInput.fromObject({
         value: aws_events.EventField.fromPath("$.detail.value"),
       })
@@ -727,11 +698,11 @@ describe.skip("destructure", () => {
 
   test("destructure variable", () => {
     ebEventTargetTestCase<testEvent>(
-      reflect((event) => {
+      (event) => {
         const { value } = event.detail;
 
         return { value: value };
-      }),
+      },
       aws_events.RuleTargetInput.fromObject({
         value: aws_events.EventField.fromPath("$.detail.value"),
       })
@@ -740,13 +711,13 @@ describe.skip("destructure", () => {
 
   test("destructure multi-layer variable", () => {
     ebEventTargetTestCase<testEvent>(
-      reflect((event) => {
+      (event) => {
         const {
           detail: { value },
         } = event;
 
         return { value: value };
-      }),
+      },
       aws_events.RuleTargetInput.fromObject({
         value: aws_events.EventField.fromPath("$.detail.value"),
       })
@@ -754,26 +725,22 @@ describe.skip("destructure", () => {
   });
 
   test("destructure array doesn't work", () => {
-    ebEventTargetTestCaseError<testEvent>(
-      reflect((event) => {
-        const [first] = event.detail.array;
+    ebEventTargetTestCaseError<testEvent>((event) => {
+      const [first] = event.detail.array;
 
-        return { value: first };
-      })
-    );
+      return { value: first };
+    });
   });
 
   test("destructure parameter array doesn't work", () => {
     ebEventTargetTestCase<testEvent>(
-      reflect(
-        ({
-          detail: {
-            array: [first],
-          },
-        }) => {
-          return { value: first };
-        }
-      ),
+      ({
+        detail: {
+          array: [first],
+        },
+      }) => {
+        return { value: first };
+      },
       aws_events.RuleTargetInput.fromObject({
         value: aws_events.EventField.fromPath("$.detail.value"),
       })
@@ -782,11 +749,11 @@ describe.skip("destructure", () => {
 
   test("destructure variable rename", () => {
     ebEventTargetTestCase<testEvent>(
-      reflect((event) => {
+      (event) => {
         const { value: val } = event.detail;
 
         return { value: val };
-      }),
+      },
       aws_events.RuleTargetInput.fromObject({
         value: aws_events.EventField.fromPath("$.detail.value"),
       })
@@ -795,9 +762,9 @@ describe.skip("destructure", () => {
 
   test("destructure parameter rename", () => {
     ebEventTargetTestCase<testEvent>(
-      reflect(({ source: src }) => {
+      ({ source: src }) => {
         return { value: src };
-      }),
+      },
       aws_events.RuleTargetInput.fromObject({
         value: aws_events.EventField.fromPath("$.source"),
       })

--- a/test/function.test.ts
+++ b/test/function.test.ts
@@ -11,7 +11,6 @@ import {
   $AWS,
   Table,
 } from "../src";
-import { reflect } from "../src/reflect";
 import { appsyncTestCase } from "./util";
 
 interface Item {
@@ -46,38 +45,32 @@ beforeEach(() => {
 test("call function", () => {
   const fn1 = Function.fromFunction<{ arg: string }, Item>(lambda);
 
-  appsyncTestCase(
-    reflect((context: AppsyncContext<{ arg: string }>) => {
-      return fn1(context.arguments);
-    })
-  );
+  appsyncTestCase((context: AppsyncContext<{ arg: string }>) => {
+    return fn1(context.arguments);
+  });
 });
 
 test("call function and conditional return", () => {
   const fn1 = Function.fromFunction<{ arg: string }, Item>(lambda);
 
-  appsyncTestCase(
-    reflect(async (context: AppsyncContext<{ arg: string }>) => {
-      const result = await fn1(context.arguments);
+  appsyncTestCase(async (context: AppsyncContext<{ arg: string }>) => {
+    const result = await fn1(context.arguments);
 
-      if (result.id === "sam") {
-        return true;
-      } else {
-        return false;
-      }
-    })
-  );
+    if (result.id === "sam") {
+      return true;
+    } else {
+      return false;
+    }
+  });
 });
 
 test("call function omitting optional arg", () => {
   const fn2 = Function.fromFunction<{ arg: string; optional?: string }, Item>(
     lambda
   );
-  appsyncTestCase(
-    reflect((context: AppsyncContext<{ arg: string }>) => {
-      return fn2(context.arguments);
-    })
-  );
+  appsyncTestCase((context: AppsyncContext<{ arg: string }>) => {
+    return fn2(context.arguments);
+  });
 });
 
 test("call function including optional arg", () => {
@@ -85,31 +78,25 @@ test("call function including optional arg", () => {
     lambda
   );
 
-  appsyncTestCase(
-    reflect((context: AppsyncContext<{ arg: string }>) => {
-      return fn2({ arg: context.arguments.arg, optional: "hello" });
-    })
-  );
+  appsyncTestCase((context: AppsyncContext<{ arg: string }>) => {
+    return fn2({ arg: context.arguments.arg, optional: "hello" });
+  });
 });
 
 test("call function including with no parameters", () => {
   const fn3 = Function.fromFunction<undefined, Item>(lambda);
 
-  appsyncTestCase(
-    reflect(() => {
-      return fn3();
-    })
-  );
+  appsyncTestCase(() => {
+    return fn3();
+  });
 });
 
 test("call function including with void result", () => {
   const fn4 = Function.fromFunction<{ arg: string }, void>(lambda);
 
-  appsyncTestCase(
-    reflect((context: AppsyncContext<{ arg: string }>) => {
-      return fn4(context.arguments);
-    })
-  );
+  appsyncTestCase((context: AppsyncContext<{ arg: string }>) => {
+    return fn4(context.arguments);
+  });
 });
 
 test("set on success bus", () => {

--- a/test/node.test.ts
+++ b/test/node.test.ts
@@ -25,7 +25,12 @@ test("node.exit() from catch surrounded by while", () => {
     new BlockStmt(emptySpan(), [
       new ExprStmt(
         emptySpan(),
-        new CallExpr(emptySpan(), new Identifier(emptySpan(), "task"), [])
+        new CallExpr(
+          emptySpan(),
+          new Identifier(emptySpan(), "task"),
+          [],
+          false
+        )
       ),
     ])
   );

--- a/test/step-function.localstack.test.ts
+++ b/test/step-function.localstack.test.ts
@@ -2109,6 +2109,7 @@ runtimeTestSuite<
           zeroBooleanUnaryPlus: +false,
           zeroNumberUnaryPlus: +0,
           zeroVarUnaryPlus: +input.zero,
+          // @ts-ignore
           zeroNullUnaryPlus: +null,
           nanObjectUnaryPlus: +{},
           nanStringUnaryPlus: +"{}",

--- a/test/step-function.test.ts
+++ b/test/step-function.test.ts
@@ -2273,6 +2273,7 @@ test("[1,2,3,4].filter((item, index, array) => item > 1 + 2)", () => {
 test("[1,2,3,4].filter(item => item > {})", () => {
   const { stack } = initStepFunctionApp();
   const { definition } = new ExpressStepFunction(stack, "fn", async () => {
+    // @ts-ignore
     return [{}].filter((item) => item === { a: "a" });
   });
 

--- a/test/test-files/step-function.ts
+++ b/test/test-files/step-function.ts
@@ -474,13 +474,12 @@ new StepFunction(stack, "obj ref", async (input: { key: string }) => {
  * Supported
  */
 
-const func2 = new Function<{ x: number; y: number }, string>(
-  stack,
-  "func",
-  async () => {
-    return "hello";
-  }
-);
+const func2 = new Function<
+  { x: number | undefined; y: number | undefined },
+  string
+>(stack, "func", async () => {
+  return "hello";
+});
 
 new StepFunction(stack, "obj ref", async () => {
   const arr = [1, 2, 3];
@@ -637,6 +636,7 @@ new StepFunction(stack, "fn", async (input: { value: number }) => {
     return item === value;
   });
   [{}].filter((item) => {
+    // @ts-ignore
     return item === {};
   });
 });

--- a/test/vtl.test.ts
+++ b/test/vtl.test.ts
@@ -6,136 +6,112 @@ import {
   BinaryLogicalOp,
   EqualityOp,
   RelationalOp,
-  ResolverFunction,
 } from "../src";
-import { reflect } from "../src/reflect";
 import { appsyncTestCase, testAppsyncVelocity } from "./util";
 
 test("empty function returning an argument", () => {
-  appsyncTestCase(
-    reflect((context: AppsyncContext<{ a: string }>) => {
-      return context.arguments.a;
-    })
-  );
+  appsyncTestCase((context: AppsyncContext<{ a: string }>) => {
+    return context.arguments.a;
+  });
 });
 
 test("return literal object with values", () => {
   appsyncTestCase(
-    reflect(
-      (context: AppsyncContext<{ arg: string; obj: Record<string, any> }>) => {
-        const arg = context.arguments.arg;
-        const obj = context.arguments.obj;
-        return {
-          null: null,
-          undefined: undefined,
-          string: "hello",
-          number: 1,
-          ["list"]: ["hello"],
-          obj: {
-            key: "value",
-          },
-          arg,
-          ...obj,
-        };
-      }
-    )
+    (context: AppsyncContext<{ arg: string; obj: Record<string, any> }>) => {
+      const arg = context.arguments.arg;
+      const obj = context.arguments.obj;
+      return {
+        null: null,
+        undefined: undefined,
+        string: "hello",
+        number: 1,
+        ["list"]: ["hello"],
+        obj: {
+          key: "value",
+        },
+        arg,
+        ...obj,
+      };
+    }
   );
 });
 
 test("computed property names", () => {
   appsyncTestCase(
-    reflect(
-      (context: AppsyncContext<{ arg: string; obj: Record<string, any> }>) => {
-        const name = context.arguments.arg;
-        const value = name + "_test";
-        return {
-          [name]: context.arguments.arg,
-          [value]: context.arguments.arg,
-        };
-      }
-    )
+    (context: AppsyncContext<{ arg: string; obj: Record<string, any> }>) => {
+      const name = context.arguments.arg;
+      const value = name + "_test";
+      return {
+        [name]: context.arguments.arg,
+        [value]: context.arguments.arg,
+      };
+    }
   );
 });
 
 test("null and undefined", () => {
   appsyncTestCase(
-    reflect(
-      (_context: AppsyncContext<{ arg: string; obj: Record<string, any> }>) => {
-        return {
-          name: null,
-          value: undefined,
-        };
-      }
-    )
+    (_context: AppsyncContext<{ arg: string; obj: Record<string, any> }>) => {
+      return {
+        name: null,
+        value: undefined,
+      };
+    }
   );
 });
 
 test("call function and return its value", () => {
-  appsyncTestCase(
-    reflect(() => {
-      return $util.autoId();
-    })
-  );
+  appsyncTestCase(() => {
+    return $util.autoId();
+  });
 });
 
 test("call function, assign to variable and return variable reference", () => {
-  appsyncTestCase(
-    reflect(() => {
-      const id = $util.autoId();
-      return id;
-    })
-  );
+  appsyncTestCase(() => {
+    const id = $util.autoId();
+    return id;
+  });
 });
 
 test("return in-line spread object", () => {
-  appsyncTestCase(
-    reflect((context: AppsyncContext<{ obj: { key: string } }>) => {
-      return {
-        id: $util.autoId(),
-        ...context.arguments.obj,
-      };
-    })
-  );
+  appsyncTestCase((context: AppsyncContext<{ obj: { key: string } }>) => {
+    return {
+      id: $util.autoId(),
+      ...context.arguments.obj,
+    };
+  });
 });
 
 test("return in-line list literal", () => {
-  appsyncTestCase(
-    reflect((context: AppsyncContext<{ a: string; b: string }>) => {
-      return [context.arguments.a, context.arguments.b];
-    })
-  );
+  appsyncTestCase((context: AppsyncContext<{ a: string; b: string }>) => {
+    return [context.arguments.a, context.arguments.b];
+  });
 });
 
 test("return list literal variable", () => {
-  appsyncTestCase(
-    reflect((context: AppsyncContext<{ a: string; b: string }>) => {
-      const list = [context.arguments.a, context.arguments.b];
-      return list;
-    })
-  );
+  appsyncTestCase((context: AppsyncContext<{ a: string; b: string }>) => {
+    const list = [context.arguments.a, context.arguments.b];
+    return list;
+  });
 });
 
 test("return list element", () => {
-  appsyncTestCase(
-    reflect((context: AppsyncContext<{ a: string; b: string }>) => {
-      const list = [context.arguments.a, context.arguments.b];
-      return list[0];
-    })
-  );
+  appsyncTestCase((context: AppsyncContext<{ a: string; b: string }>) => {
+    const list = [context.arguments.a, context.arguments.b];
+    return list[0];
+  });
 });
 
 test("push element to array is renamed to add", () => {
-  appsyncTestCase(
-    reflect((context: AppsyncContext<{ list: string[] }>) => {
-      context.arguments.list.push("hello");
-      return context.arguments.list;
-    })
-  );
+  appsyncTestCase((context: AppsyncContext<{ list: string[] }>) => {
+    context.arguments.list.push("hello");
+    return context.arguments.list;
+  });
 });
 
 // TODO https://github.com/functionless/functionless/issues/8
 // test("push multiple args is expanded to multiple add calls", () => {
-//   const template = reflect((context: AppsyncContext<{ list: string[] }>) => {
+//   const template = (context: AppsyncContext<{ list: string[] }>) => {
 //     list.push("hello", "world");
 //     return list;
 //   });
@@ -150,313 +126,255 @@ test("push element to array is renamed to add", () => {
 // });
 
 test("if statement", () => {
-  appsyncTestCase(
-    reflect((context: AppsyncContext<{ list: string[] }>) => {
-      if (context.arguments.list.length > 0) {
-        return true;
-      } else {
-        return false;
-      }
-    })
-  );
+  appsyncTestCase((context: AppsyncContext<{ list: string[] }>) => {
+    if (context.arguments.list.length > 0) {
+      return true;
+    } else {
+      return false;
+    }
+  });
 });
 
 test("blockless if", () => {
-  appsyncTestCase<{ num: number }, void>(
-    reflect(async ($context) => {
-      if (1 === $context.arguments.num) return;
-      if (1 === $context.arguments.num) {
-      } else return;
-    })
-  );
+  appsyncTestCase<{ num: number }, void>(async ($context) => {
+    if (1 === $context.arguments.num) return;
+    if (1 === $context.arguments.num) {
+    } else return;
+  });
 
   // https://github.com/aws-amplify/amplify-category-api/issues/592
   // testAppsyncVelocity(templates[1]!);
 });
 
 test("return conditional expression", () => {
-  appsyncTestCase(
-    reflect((context: AppsyncContext<{ list: string[] }>) => {
-      return context.arguments.list.length > 0 ? true : false;
-    })
-  );
+  appsyncTestCase((context: AppsyncContext<{ list: string[] }>) => {
+    return context.arguments.list.length > 0 ? true : false;
+  });
 });
 
 test("property assignment of conditional expression", () => {
-  appsyncTestCase(
-    reflect((context: AppsyncContext<{ list: string[] }>) => {
-      return {
-        prop: context.arguments.list.length > 0 ? true : false,
-      };
-    })
-  );
+  appsyncTestCase((context: AppsyncContext<{ list: string[] }>) => {
+    return {
+      prop: context.arguments.list.length > 0 ? true : false,
+    };
+  });
 });
 
 test("for-of loop", () => {
-  appsyncTestCase(
-    reflect((context: AppsyncContext<{ list: string[] }>) => {
-      const newList = [];
-      for (const item of context.arguments.list) {
-        newList.push(item);
-      }
-      return newList;
-    })
-  );
+  appsyncTestCase((context: AppsyncContext<{ list: string[] }>) => {
+    const newList = [];
+    for (const item of context.arguments.list) {
+      newList.push(item);
+    }
+    return newList;
+  });
 });
 
 test("break from for-loop", () => {
-  appsyncTestCase(
-    reflect((context: AppsyncContext<{ list: string[] }>) => {
-      const newList = [];
-      for (const item of context.arguments.list) {
-        if (item === "hello") {
-          break;
-        }
-        newList.push(item);
+  appsyncTestCase((context: AppsyncContext<{ list: string[] }>) => {
+    const newList = [];
+    for (const item of context.arguments.list) {
+      if (item === "hello") {
+        break;
       }
-      return newList;
-    })
-  );
+      newList.push(item);
+    }
+    return newList;
+  });
 });
 
 test("local variable inside for-of loop is declared as a local variable", () => {
-  appsyncTestCase(
-    reflect((context: AppsyncContext<{ list: string[] }>) => {
-      const newList = [];
-      for (const item of context.arguments.list) {
-        const i = item;
-        newList.push(i);
-      }
-      return newList;
-    })
-  );
+  appsyncTestCase((context: AppsyncContext<{ list: string[] }>) => {
+    const newList = [];
+    for (const item of context.arguments.list) {
+      const i = item;
+      newList.push(i);
+    }
+    return newList;
+  });
 });
 
 test("for-in loop and element access", () => {
   appsyncTestCase(
-    reflect((context: AppsyncContext<{ record: Record<string, any> }>) => {
+    (context: AppsyncContext<{ record: Record<string, any> }>) => {
       const newList = [];
       for (const key in context.arguments.record) {
         newList.push(context.arguments.record[key]);
       }
       return newList;
-    })
+    }
   );
 });
 
 test("template expression", () => {
-  appsyncTestCase(
-    reflect((context: AppsyncContext<{ a: string }>) => {
-      const local = context.arguments.a;
-      return `head ${context.arguments.a} ${local}${context.arguments.a}`;
-    })
-  );
+  appsyncTestCase((context: AppsyncContext<{ a: string }>) => {
+    const local = context.arguments.a;
+    return `head ${context.arguments.a} ${local}${context.arguments.a}`;
+  });
 });
 
 test("conditional expression in template expression", () => {
-  appsyncTestCase(
-    reflect((context: AppsyncContext<{ a: string }>) => {
-      return `head ${
-        context.arguments.a === "hello" ? "world" : context.arguments.a
-      }`;
-    })
-  );
+  appsyncTestCase((context: AppsyncContext<{ a: string }>) => {
+    return `head ${
+      context.arguments.a === "hello" ? "world" : context.arguments.a
+    }`;
+  });
 });
 
 test("map over list", () => {
-  appsyncTestCase(
-    reflect((context: AppsyncContext<{ list: string[] }>) => {
-      return context.arguments.list.map((item) => {
-        return `hello ${item}`;
-      });
-    })
-  );
+  appsyncTestCase((context: AppsyncContext<{ list: string[] }>) => {
+    return context.arguments.list.map((item) => {
+      return `hello ${item}`;
+    });
+  });
 });
 
 test("map over list without parameter", () => {
-  appsyncTestCase(
-    reflect((context: AppsyncContext<{ list: string[] }>) => {
-      return context.arguments.list.map(() => {
-        return `hello`;
-      });
-    })
-  );
+  appsyncTestCase((context: AppsyncContext<{ list: string[] }>) => {
+    return context.arguments.list.map(() => {
+      return `hello`;
+    });
+  });
 });
 
 test("map over list with in-line return", () => {
-  appsyncTestCase(
-    reflect((context: AppsyncContext<{ list: string[] }>) => {
-      return context.arguments.list.map((item) => `hello ${item}`);
-    })
-  );
+  appsyncTestCase((context: AppsyncContext<{ list: string[] }>) => {
+    return context.arguments.list.map((item) => `hello ${item}`);
+  });
 });
 
 test("chain map over list", () => {
-  appsyncTestCase(
-    reflect((context: AppsyncContext<{ list: string[] }>) => {
-      return context.arguments.list
-        .map((item) => `hello ${item}`)
-        .map((item) => `hello ${item}`);
-    })
-  );
+  appsyncTestCase((context: AppsyncContext<{ list: string[] }>) => {
+    return context.arguments.list
+      .map((item) => `hello ${item}`)
+      .map((item) => `hello ${item}`);
+  });
 });
 
 test("chain map over list multiple array", () => {
-  appsyncTestCase(
-    reflect((context: AppsyncContext<{ list: string[] }>) => {
-      return context.arguments.list
-        .map((item, _i, _arr) => `hello ${item}`)
-        .map((item, _i, _arr) => `hello ${item}`);
-    })
-  );
+  appsyncTestCase((context: AppsyncContext<{ list: string[] }>) => {
+    return context.arguments.list
+      .map((item, _i, _arr) => `hello ${item}`)
+      .map((item, _i, _arr) => `hello ${item}`);
+  });
 });
 
 test("chain map over list complex", () => {
-  appsyncTestCase(
-    reflect((context: AppsyncContext<{ list: string[] }>) => {
-      return context.arguments.list
-        .map((item, i, arr) => {
-          const x = i + 1;
-          return `hello ${item} ${x} ${arr.length}`;
-        })
-        .map((item2, ii) => `hello ${item2} ${ii}`);
-    })
-  );
+  appsyncTestCase((context: AppsyncContext<{ list: string[] }>) => {
+    return context.arguments.list
+      .map((item, i, arr) => {
+        const x = i + 1;
+        return `hello ${item} ${x} ${arr.length}`;
+      })
+      .map((item2, ii) => `hello ${item2} ${ii}`);
+  });
 });
 
 test("forEach over list", () => {
-  appsyncTestCase(
-    reflect((context: AppsyncContext<{ list: string[] }>) => {
-      return context.arguments.list.forEach((item) => {
-        $util.error(item);
-      });
-    })
-  );
+  appsyncTestCase((context: AppsyncContext<{ list: string[] }>) => {
+    return context.arguments.list.forEach((item) => {
+      $util.error(item);
+    });
+  });
 });
 
 test("reduce over list with initial value", () => {
-  appsyncTestCase(
-    reflect((context: AppsyncContext<{ list: string[] }>) => {
-      return context.arguments.list.reduce((newList: string[], item) => {
-        return [...newList, item];
-      }, []);
-    })
-  );
+  appsyncTestCase((context: AppsyncContext<{ list: string[] }>) => {
+    return context.arguments.list.reduce((newList: string[], item) => {
+      return [...newList, item];
+    }, []);
+  });
 });
 
 test("reduce over list without initial value", () => {
-  appsyncTestCase(
-    reflect((context: AppsyncContext<{ list: string[] }>) => {
-      return context.arguments.list.reduce((str: string, item) => {
-        return `${str}${item}`;
-      });
-    })
-  );
+  appsyncTestCase((context: AppsyncContext<{ list: string[] }>) => {
+    return context.arguments.list.reduce((str: string, item) => {
+      return `${str}${item}`;
+    });
+  });
 });
 
 test("map and reduce over list with initial value", () => {
-  appsyncTestCase(
-    reflect((context: AppsyncContext<{ list: string[] }>) => {
-      return context.arguments.list
-        .map((item) => `hello ${item}`)
-        .reduce((newList: string[], item) => {
-          return [...newList, item];
-        }, []);
-    })
-  );
+  appsyncTestCase((context: AppsyncContext<{ list: string[] }>) => {
+    return context.arguments.list
+      .map((item) => `hello ${item}`)
+      .reduce((newList: string[], item) => {
+        return [...newList, item];
+      }, []);
+  });
 });
 
 test("map and reduce with array over list with initial value", () => {
-  appsyncTestCase(
-    reflect((context: AppsyncContext<{ list: string[] }>) => {
-      return context.arguments.list
-        .map((item) => `hello ${item}`)
-        .reduce((newList: string[], item, _i, _arr) => {
-          return [...newList, item];
-        }, []);
-    })
-  );
+  appsyncTestCase((context: AppsyncContext<{ list: string[] }>) => {
+    return context.arguments.list
+      .map((item) => `hello ${item}`)
+      .reduce((newList: string[], item, _i, _arr) => {
+        return [...newList, item];
+      }, []);
+  });
 });
 
 test("map and reduce and map and reduce over list with initial value", () => {
-  appsyncTestCase(
-    reflect((context: AppsyncContext<{ list: string[] }>) => {
-      return context.arguments.list
-        .map((item) => `hello ${item}`)
-        .reduce((newList: string[], item) => {
-          return [...newList, item];
-        }, [])
-        .map((item) => `hello ${item}`)
-        .reduce((newList: string[], item) => {
-          return [...newList, item];
-        }, []);
-    })
-  );
+  appsyncTestCase((context: AppsyncContext<{ list: string[] }>) => {
+    return context.arguments.list
+      .map((item) => `hello ${item}`)
+      .reduce((newList: string[], item) => {
+        return [...newList, item];
+      }, [])
+      .map((item) => `hello ${item}`)
+      .reduce((newList: string[], item) => {
+        return [...newList, item];
+      }, []);
+  });
 });
 
 test("$util.time.nowISO8601", () => {
-  appsyncTestCase(
-    reflect(() => {
-      return $util.time.nowISO8601();
-    })
-  );
+  appsyncTestCase(() => {
+    return $util.time.nowISO8601();
+  });
 });
 
 test("$util.log.info(message)", () => {
-  appsyncTestCase(
-    reflect(() => {
-      return $util.log.info("hello world");
-    })
-  );
+  appsyncTestCase(() => {
+    return $util.log.info("hello world");
+  });
 });
 
 test("$util.log.info(message, ...Object)", () => {
-  appsyncTestCase(
-    reflect(() => {
-      return $util.log.info("hello world", { a: 1 }, { b: 2 });
-    })
-  );
+  appsyncTestCase(() => {
+    return $util.log.info("hello world", { a: 1 }, { b: 2 });
+  });
 });
 
 test("$util.log.error(message)", () => {
-  appsyncTestCase(
-    reflect(() => {
-      return $util.log.error("hello world");
-    })
-  );
+  appsyncTestCase(() => {
+    return $util.log.error("hello world");
+  });
 });
 
 test("$util.log.error(message, ...Object)", () => {
-  appsyncTestCase(
-    reflect(() => {
-      return $util.log.error("hello world", { a: 1 }, { b: 2 });
-    })
-  );
+  appsyncTestCase(() => {
+    return $util.log.error("hello world", { a: 1 }, { b: 2 });
+  });
 });
 
 test("BinaryExpr and UnaryExpr are evaluated to temporary variables", () => {
-  appsyncTestCase(
-    reflect(() => {
-      return {
-        x: -1,
-        y: -(1 + 1),
-        z: !(true && false),
-      };
-    })
-  );
+  appsyncTestCase(() => {
+    return {
+      x: -1,
+      y: -(1 + 1),
+      z: !(true && false),
+    };
+  });
 });
 
 test("binary expr in", () => {
-  const templates = appsyncTestCase(
-    reflect<
-      ResolverFunction<{ key: string } | { key2: string }, { out: string }, any>
-    >(($context) => {
-      if ("key" in $context.arguments) {
-        return { out: $context.arguments.key };
-      }
-      return { out: $context.arguments.key2 };
-    })
-  );
+  const templates = appsyncTestCase(($context) => {
+    if ("key" in $context.arguments) {
+      return { out: $context.arguments.key };
+    }
+    return { out: $context.arguments.key2 };
+  });
 
   testAppsyncVelocity(templates[1]!, {
     arguments: { key: "hi" },
@@ -476,19 +394,17 @@ test("binary expr in", () => {
 });
 
 test("binary expr ==", () => {
-  const templates = appsyncTestCase(
-    reflect<ResolverFunction<{ key: string }, { out: boolean[] }, any>>(
-      ($context) => {
-        return {
-          out: [
-            $context.arguments.key == "key",
-            "key" == $context.arguments.key,
-            $context.arguments.key === "key",
-            "key" === $context.arguments.key,
-          ],
-        };
-      }
-    )
+  const templates = appsyncTestCase<{ key: string }, { out: boolean[] }, any>(
+    ($context) => {
+      return {
+        out: [
+          $context.arguments.key == "key",
+          "key" == $context.arguments.key,
+          $context.arguments.key === "key",
+          "key" === $context.arguments.key,
+        ],
+      };
+    }
   );
 
   testAppsyncVelocity(templates[1]!, {
@@ -498,22 +414,20 @@ test("binary expr ==", () => {
 });
 
 test("binary expr in map", () => {
-  const templates = appsyncTestCase(
-    reflect<ResolverFunction<{}, { in: boolean; notIn: boolean }, any>>(() => {
-      const obj = {
-        key: "value",
-        // $null does not appear to work in amplify simulator
-        // keyNull: null,
-        keyEmpty: "",
-      };
-      return {
-        in: "key" in obj,
-        notIn: "otherKey" in obj,
-        // inNull: "keyNull" in obj,
-        inEmpty: "keyEmpty" in obj,
-      };
-    })
-  );
+  const templates = appsyncTestCase(() => {
+    const obj = {
+      key: "value",
+      // $null does not appear to work in amplify simulator
+      // keyNull: null,
+      keyEmpty: "",
+    };
+    return {
+      in: "key" in obj,
+      notIn: "otherKey" in obj,
+      // inNull: "keyNull" in obj,
+      inEmpty: "keyEmpty" in obj,
+    };
+  });
 
   testAppsyncVelocity(templates[1]!, {
     resultMatch: {
@@ -528,16 +442,16 @@ test("binary expr in map", () => {
 // amplify simulator does not support .class
 // https://github.com/aws-amplify/amplify-cli/issues/10575
 test.skip("binary expr in array", () => {
-  const templates = appsyncTestCase(
-    reflect<
-      ResolverFunction<{ arr: string[] }, { out: string | undefined }, any>
-    >(($context) => {
-      if (1 in $context.arguments.arr) {
-        return { out: $context.arguments.arr[1] };
-      }
-      return { out: $context.arguments.arr[0] };
-    })
-  );
+  const templates = appsyncTestCase<
+    { arr: string[] },
+    { out: string | undefined },
+    any
+  >(($context) => {
+    if (1 in $context.arguments.arr) {
+      return { out: $context.arguments.arr[1] };
+    }
+    return { out: $context.arguments.arr[0] };
+  });
 
   testAppsyncVelocity(templates[1]!, {
     arguments: { arr: ["1", "2"] },
@@ -556,35 +470,31 @@ test.skip("binary expr in array", () => {
 });
 
 test("binary exprs value comparison", () => {
-  const templates = appsyncTestCase(
-    reflect<
-      ResolverFunction<
-        { a: number; b: number },
-        Record<
-          | EqualityOp
-          | Exclude<RelationalOp, "in" | "instanceof">
-          | Exclude<BinaryLogicalOp, "??">,
-          boolean | number
-        >,
-        any
-      >
-    >(($context) => {
-      const a = $context.arguments.a;
-      const b = $context.arguments.b;
-      return {
-        "!==": a != b,
-        "!=": a != b,
-        "&&": a && b,
-        "||": a || b,
-        "<": a < b,
-        "<=": a <= b,
-        "===": a == b,
-        "==": a == b,
-        ">": a > b,
-        ">=": a >= b,
-      };
-    })
-  );
+  const templates = appsyncTestCase<
+    { a: number; b: number },
+    Record<
+      | EqualityOp
+      | Exclude<RelationalOp, "in" | "instanceof">
+      | Exclude<BinaryLogicalOp, "??">,
+      boolean | number
+    >,
+    any
+  >(($context) => {
+    const a = $context.arguments.a;
+    const b = $context.arguments.b;
+    return {
+      "!==": a != b,
+      "!=": a != b,
+      "&&": a && b,
+      "||": a || b,
+      "<": a < b,
+      "<=": a <= b,
+      "===": a == b,
+      "==": a == b,
+      ">": a > b,
+      ">=": a >= b,
+    };
+  });
 
   testAppsyncVelocity(templates[1]!, {
     arguments: { a: 1, b: 2 },
@@ -630,16 +540,14 @@ test("binary exprs value comparison", () => {
 });
 
 test("null coalescing", () => {
-  const templates = appsyncTestCase(
-    reflect(() => {
-      return {
-        "??": null ?? "a",
-        "not ??": "a" ?? "b",
-        neither: null ?? null,
-        undefined: undefined ?? "a",
-      };
-    })
-  );
+  const templates = appsyncTestCase(() => {
+    return {
+      "??": null ?? "a",
+      "not ??": "a" ?? "b",
+      neither: null ?? null,
+      undefined: undefined ?? "a",
+    };
+  });
 
   testAppsyncVelocity(templates[1]!, {
     resultMatch: {
@@ -653,23 +561,19 @@ test("null coalescing", () => {
 });
 
 test("binary exprs logical", () => {
-  const templates = appsyncTestCase(
-    reflect<
-      ResolverFunction<
-        { a: boolean; b: boolean },
-        Record<BinaryLogicalOp, boolean>,
-        any
-      >
-    >(($context) => {
-      const a = $context.arguments.a;
-      const b = $context.arguments.b;
-      return {
-        "&&": a && b,
-        "||": a || b,
-        "??": a ?? b,
-      };
-    })
-  );
+  const templates = appsyncTestCase<
+    { a: boolean; b: boolean },
+    Record<BinaryLogicalOp, boolean>,
+    any
+  >(($context) => {
+    const a = $context.arguments.a;
+    const b = $context.arguments.b;
+    return {
+      "&&": a && b,
+      "||": a || b,
+      "??": a ?? b,
+    };
+  });
 
   testAppsyncVelocity(templates[1]!, {
     arguments: { a: true, b: true },
@@ -700,25 +604,21 @@ test("binary exprs logical", () => {
 });
 
 test("binary exprs math", () => {
-  const templates = appsyncTestCase(
-    reflect<
-      ResolverFunction<
-        { a: number; b: number },
-        Record<Exclude<ArithmeticOp, "**">, number>,
-        any
-      >
-    >(($context) => {
-      const a = $context.arguments.a;
-      const b = $context.arguments.b;
-      return {
-        "+": a + b,
-        "-": a - b,
-        "*": a * b,
-        "/": a / b,
-        "%": a % b,
-      };
-    })
-  );
+  const templates = appsyncTestCase<
+    { a: number; b: number },
+    Record<Exclude<ArithmeticOp, "**">, number>,
+    any
+  >(($context) => {
+    const a = $context.arguments.a;
+    const b = $context.arguments.b;
+    return {
+      "+": a + b,
+      "-": a - b,
+      "*": a * b,
+      "/": a / b,
+      "%": a % b,
+    };
+  });
 
   testAppsyncVelocity(templates[1]!, {
     arguments: { a: 6, b: 2 },
@@ -733,18 +633,16 @@ test("binary exprs math", () => {
 });
 
 test("binary expr =", () => {
-  const templates = appsyncTestCase(
-    reflect<ResolverFunction<{ key: string }, { out: string }, any>>(
-      ($context) => {
-        if ($context.arguments.key == "help me") {
-          $context.arguments.key = "hello";
-        }
-        if ($context.arguments.key == "hello") {
-          return { out: "ohh hi" };
-        }
-        return { out: "wot" };
+  const templates = appsyncTestCase<{ key: string }, { out: string }, any>(
+    ($context) => {
+      if ($context.arguments.key == "help me") {
+        $context.arguments.key = "hello";
       }
-    )
+      if ($context.arguments.key == "hello") {
+        return { out: "ohh hi" };
+      }
+      return { out: "wot" };
+    }
   );
 
   testAppsyncVelocity(templates[1]!, {
@@ -765,24 +663,22 @@ test("binary expr =", () => {
 
 // https://github.com/functionless/functionless/issues/232
 test("binary mutation", () => {
-  const templates = appsyncTestCase(
-    reflect(() => {
-      var n = 9;
-      const plus_n = (n += 1);
-      const minus_n = (n -= 1);
-      const multi_n = (n *= 2);
-      const div_n = (n /= 3);
-      const mod_n = (n %= 2);
-      return {
-        "+=": plus_n,
-        "-=": minus_n,
-        "*=": multi_n,
-        "/=": div_n,
-        "%=": mod_n,
-        n,
-      };
-    })
-  );
+  const templates = appsyncTestCase(() => {
+    var n = 9;
+    const plus_n = (n += 1);
+    const minus_n = (n -= 1);
+    const multi_n = (n *= 2);
+    const div_n = (n /= 3);
+    const mod_n = (n %= 2);
+    return {
+      "+=": plus_n,
+      "-=": minus_n,
+      "*=": multi_n,
+      "/=": div_n,
+      "%=": mod_n,
+      n,
+    };
+  });
 
   testAppsyncVelocity(templates[1]!, {
     resultMatch: {
@@ -798,17 +694,15 @@ test("binary mutation", () => {
 
 // https://github.com/functionless/functionless/issues/232
 test("unary mutation", () => {
-  const templates = appsyncTestCase(
-    reflect(() => {
-      var n = 9;
-      return {
-        "post--": n--,
-        "--pre": --n,
-        "post++": n++,
-        "++pre": ++n,
-      };
-    })
-  );
+  const templates = appsyncTestCase(() => {
+    var n = 9;
+    return {
+      "post--": n--,
+      "--pre": --n,
+      "post++": n++,
+      "++pre": ++n,
+    };
+  });
 
   testAppsyncVelocity(templates[1]!, {
     resultMatch: {
@@ -822,15 +716,13 @@ test("unary mutation", () => {
 
 // https://github.com/functionless/functionless/issues/232
 test("unary", () => {
-  const templates = appsyncTestCase(
-    reflect(() => {
-      return {
-        "!": !false,
-        "-": -10,
-        "-(-)": -(-10),
-      };
-    })
-  );
+  const templates = appsyncTestCase(() => {
+    return {
+      "!": !false,
+      "-": -10,
+      "-(-)": -(-10),
+    };
+  });
 
   testAppsyncVelocity(templates[1]!, {
     resultMatch: {
@@ -843,12 +735,10 @@ test("unary", () => {
 
 // https://github.com/functionless/functionless/issues/150
 test("assignment in object", () => {
-  const templates = appsyncTestCase(
-    reflect(() => {
-      let y = 1;
-      return { x: (y = 2), y };
-    })
-  );
+  const templates = appsyncTestCase(() => {
+    let y = 1;
+    return { x: (y = 2), y };
+  });
 
   testAppsyncVelocity(templates[1]!, {
     resultMatch: {
@@ -859,20 +749,18 @@ test("assignment in object", () => {
 });
 
 test("var args push", () => {
-  const templates = appsyncTestCase(
-    reflect(() => {
-      const y1 = [];
-      const y2 = [];
-      const y3 = [];
-      const y4 = [];
-      const x = [1, 2, 3];
-      y1.push(...x);
-      y2.push(...x, 4);
-      y3.push(0, ...x);
-      y4.push(0, ...x, 4);
-      return { y1, y2, y3, y4 };
-    })
-  );
+  const templates = appsyncTestCase(() => {
+    const y1 = [];
+    const y2 = [];
+    const y3 = [];
+    const y4 = [];
+    const x = [1, 2, 3];
+    y1.push(...x);
+    y2.push(...x, 4);
+    y3.push(0, ...x);
+    y4.push(0, ...x, 4);
+    return { y1, y2, y3, y4 };
+  });
 
   testAppsyncVelocity(templates[1]!, {
     resultMatch: {
@@ -895,18 +783,16 @@ test("deconstruct variable", () => {
       d: string;
     },
     string
-  >(
-    reflect(($context) => {
-      const {
-        a,
-        bb: { ["value"]: b, ["a" + "b"]: z },
-        c = "what",
-        arr: [d, , e, f = "sir", ...arrRest],
-        ...objRest
-      } = $context.arguments;
-      return a + b + c + d + e + f + objRest.d + arrRest[0] + z;
-    })
-  );
+  >(($context) => {
+    const {
+      a,
+      bb: { ["value"]: b, ["a" + "b"]: z },
+      c = "what",
+      arr: [d, , e, f = "sir", ...arrRest],
+      ...objRest
+    } = $context.arguments;
+    return a + b + c + d + e + f + objRest.d + arrRest[0] + z;
+  });
 
   testAppsyncVelocity(templates[1]!, {
     arguments: {
@@ -920,31 +806,19 @@ test("deconstruct variable", () => {
 });
 
 test("deconstruct parameter", () => {
-  const templates = appsyncTestCase<
-    {
-      a: string;
-      bb: { value: string };
-      c?: string;
-      m?: string;
-      arr: string[];
-      d: string;
-    },
-    string
-  >(
-    reflect(
-      ({
-        arguments: {
-          a,
-          bb: { value: b },
-          c = "what",
-          m = c,
-          arr: [d, , e, f = "sir", ...arrRest],
-          ...objRest
-        },
-      }) => {
-        return a + b + c + d + e + f + objRest.d + arrRest[0] + m;
-      }
-    )
+  const templates = appsyncTestCase<any, string>(
+    ({
+      arguments: {
+        a,
+        bb: { value: b },
+        c = "what",
+        m = c,
+        arr: [d, , e, f = "sir", ...arrRest],
+        ...objRest
+      },
+    }) => {
+      return a + b + c + d + e + f + objRest.d + arrRest[0] + m;
+    }
   );
 
   testAppsyncVelocity(templates[1]!, {
@@ -970,20 +844,18 @@ test("deconstruct for of", () => {
       }[];
     },
     string
-  >(
-    reflect(($context) => {
-      for (const {
-        a,
-        bb: { value: b },
-        c = "what",
-        arr: [d, , e, f = "sir", ...arrRest],
-        ...objRest
-      } of $context.arguments.items) {
-        return a + b + c + d + e + f + objRest.d + arrRest[0];
-      }
-      return "";
-    })
-  );
+  >(($context) => {
+    for (const {
+      a,
+      bb: { value: b },
+      c = "what",
+      arr: [d, , e, f = "sir", ...arrRest],
+      ...objRest
+    } of $context.arguments.items) {
+      return a + b + c + d + e + f + objRest.d + arrRest[0];
+    }
+    return "";
+  });
 
   testAppsyncVelocity(templates[1]!, {
     arguments: {
@@ -1001,19 +873,21 @@ test("deconstruct for of", () => {
 });
 
 test("deconstruct map", () => {
-  const templates = appsyncTestCase<
-    {
-      items: {
-        a: string;
-        bb: { value: string };
-        c?: string;
-        arr: string[];
-        d: string;
-      }[];
-    },
-    string[]
-  >(
-    reflect(($context) => {
+  const templates = appsyncTestCase(
+    (
+      $context: AppsyncContext<
+        {
+          items: {
+            a: string;
+            bb: { value: string };
+            c?: string;
+            arr: string[];
+            d: string;
+          }[];
+        },
+        string[]
+      >
+    ) => {
       return $context.arguments.items.map(
         ({
           a,
@@ -1025,7 +899,7 @@ test("deconstruct map", () => {
           return a + b + c + d + e + f + objRest.d + arrRest[0];
         }
       );
-    })
+    }
   );
 
   testAppsyncVelocity(templates[1]!, {
@@ -1044,18 +918,20 @@ test("deconstruct map", () => {
 });
 
 test("deconstruct map chain", () => {
-  const templates = appsyncTestCase<
-    {
-      items: { a: string; b: string }[];
-    },
-    string[]
-  >(
-    reflect(($context) => {
+  const templates = appsyncTestCase(
+    (
+      $context: AppsyncContext<
+        {
+          items: { a: string; b: string }[];
+        },
+        string[]
+      >
+    ) => {
       return $context.arguments.items
         .map(({ a, b }) => ({ a: b, b: a }))
         .map(({ a, b }) => ({ a: a + b, b: b + a }))
         .map(({ a, b }) => a + b);
-    })
+    }
   );
 
   testAppsyncVelocity(templates[1]!, {
@@ -1083,25 +959,23 @@ test("deconstruct reduce", () => {
       }[];
     },
     string
-  >(
-    reflect(($context) => {
-      return $context.arguments.items.reduce(
-        (
-          acc,
-          {
-            a,
-            bb: { value: b },
-            c = "what",
-            arr: [d, , e, f = "sir", ...arrRest],
-            ...objRest
-          }
-        ) => {
-          return `${acc}${a + b + c + d + e + f + objRest.d + arrRest[0]}`;
-        },
-        ""
-      );
-    })
-  );
+  >(($context) => {
+    return $context.arguments.items.reduce(
+      (
+        acc,
+        {
+          a,
+          bb: { value: b },
+          c = "what",
+          arr: [d, , e, f = "sir", ...arrRest],
+          ...objRest
+        }
+      ) => {
+        return `${acc}${a + b + c + d + e + f + objRest.d + arrRest[0]}`;
+      },
+      ""
+    );
+  });
 
   testAppsyncVelocity(templates[1]!, {
     arguments: {


### PR DESCRIPTION
- [x] Fix `.pipe` definition to support type inference of inlined Integrations
- [x] Update tests to run `tsc` on the tests - fixed all the type errors in the tests.
- [x] Remove the auxiliary type for EventBusIntegration interface from the Integration type 