### PR TITLE
chore: remove auxillary EventBusIntegration type argument from Integration type

### DIFF
--- a/src/event-bridge/event-bus.ts
+++ b/src/event-bridge/event-bus.ts
@@ -163,11 +163,7 @@ export interface IEventBus<in Evnt extends Event = Event>
       (
         event: PutEventInput<Evnt>,
         ...events: PutEventInput<Evnt>[]
-      ) => Promise<void>,
-      EventBusTargetIntegration<
-        PutEventInput<Evnt>,
-        aws_events_targets.EventBusProps | undefined
-      >
+      ) => Promise<void>
     > {
   readonly resource: aws_events.IEventBus;
   readonly eventBusArn: string;

--- a/src/function.ts
+++ b/src/function.ts
@@ -131,11 +131,7 @@ export interface EventInvokeConfigOptions<Payload, Output>
  *                         empty to be inferred. ex: `Function<Payload1, Output1 | Output2>`.
  */
 export interface IFunction<in Payload, Output>
-  extends Integration<
-    "Function",
-    ConditionalFunction<Payload, Output>,
-    EventBusTargetIntegration<Payload, FunctionEventBusTargetProps | undefined>
-  > {
+  extends Integration<"Function", ConditionalFunction<Payload, Output>> {
   readonly functionlessKind: typeof Function.FunctionlessType;
   readonly kind: typeof Function.FunctionlessType;
   readonly resource: aws_lambda.IFunction;

--- a/src/integration.ts
+++ b/src/integration.ts
@@ -86,13 +86,7 @@ export const INTEGRATION_TYPE_KEYS = Object.values(INTEGRATION_TYPES);
 /**
  * All integration methods supported by functionless.
  */
-export interface IntegrationMethods<
-  F extends AnyFunction,
-  EventBusInteg extends EventBusTargetIntegration<
-    any,
-    any
-  > = EventBusTargetIntegration<any, any>
-> {
+export interface IntegrationMethods<F extends AnyFunction> {
   /**
    * Integrate with AppSync VTL applications.
    * @private
@@ -111,7 +105,7 @@ export interface IntegrationMethods<
    * @private
    */
   asl: (call: CallExpr, context: ASL) => ASLGraph.NodeResults;
-  eventBus: EventBusInteg;
+  eventBus: EventBusTargetIntegration<any, any>;
   /**
    * Native javascript code integrations that execute at runtime like Lambda.
    */
@@ -168,12 +162,8 @@ export interface IntegrationMethods<
  */
 export interface Integration<
   K extends string = string,
-  F extends AnyFunction = AnyFunction,
-  EventBus extends EventBusTargetIntegration<
-    any,
-    any
-  > = EventBusTargetIntegration<any, any>
-> extends Partial<IntegrationMethods<F, EventBus>> {
+  F extends AnyFunction = AnyFunction
+> extends Partial<IntegrationMethods<F>> {
   /**
    * Brand the Function, F, into this type so that sub-typing rules apply to the function signature.
    */

--- a/src/queue.ts
+++ b/src/queue.ts
@@ -8,7 +8,6 @@ import lambda from "aws-lambda";
 import { Construct } from "constructs";
 import { ASLGraph, Parameters } from "./asl";
 import { ErrorCodes, SynthError } from "./error-code";
-import { EventBusTargetIntegration } from "./event-bridge";
 import { makeEventBusIntegration } from "./event-bridge/event-bus";
 import { EventSource, IEventSource } from "./event-source";
 import { SQSClient } from "./function-prewarm";
@@ -297,11 +296,7 @@ abstract class BaseQueue<Message>
     Integration<
       "Queue",
       // queue is not directly invokable, only via event bridge pipe.
-      () => any,
-      EventBusTargetIntegration<
-        Message,
-        Omit<aws_events_targets.SqsQueueProps, "message"> | undefined
-      >
+      () => any
     >
 {
   /**

--- a/src/step-function.ts
+++ b/src/step-function.ts
@@ -15,10 +15,7 @@ import { assertDefined } from "./assert";
 import { FunctionLike } from "./declaration";
 import { ErrorCodes, SynthError } from "./error-code";
 import { EventBus, PredicateRuleBase, Rule } from "./event-bridge";
-import {
-  EventBusTargetIntegration,
-  makeEventBusIntegration,
-} from "./event-bridge/event-bus";
+import { makeEventBusIntegration } from "./event-bridge/event-bus";
 import { Event } from "./event-bridge/types";
 import { CallExpr, Expr } from "./expression";
 import { NativeIntegration } from "./function";
@@ -1084,15 +1081,7 @@ abstract class BaseStepFunction<
   Payload extends Record<string, any> | undefined,
   CallIn,
   CallOut
-> implements
-    Integration<
-      "StepFunction",
-      (input: CallIn) => Promise<CallOut>,
-      EventBusTargetIntegration<
-        Payload,
-        StepFunctionEventBusTargetProps | undefined
-      >
-    >
+> implements Integration<"StepFunction", (input: CallIn) => Promise<CallOut>>
 {
   readonly kind = "StepFunction";
   readonly functionlessKind = "StepFunction";
@@ -1826,11 +1815,7 @@ export interface IStepFunction<
     "StepFunction",
     (
       input: StepFunctionRequest<Payload>
-    ) => Promise<AWS.StepFunctions.StartExecutionOutput>,
-    EventBusTargetIntegration<
-      Payload,
-      StepFunctionEventBusTargetProps | undefined
-    >
+    ) => Promise<AWS.StepFunctions.StartExecutionOutput>
   > {
   describeExecution: IntegrationCall<
     "StepFunction.describeExecution",

--- a/test/eventpattern.test.ts
+++ b/test/eventpattern.test.ts
@@ -1419,4 +1419,9 @@ test("error when using rest parameters", () => {
       time;
     })
   );
+
+  bus.all().pipe(
+    // @ts-expect-error - type mismatch
+    new StepFunction(stack, "F", async (event: { key: string }) => {})
+  );
 };


### PR DESCRIPTION
Remove the hacky EventBusIntegration type argument from the Integration type.