### PR TITLE
chore: remove private dependencies from aggregate packages

### DIFF
--- a/apps/test-app/package.json
+++ b/apps/test-app/package.json
@@ -16,7 +16,7 @@
     "@graphql-codegen/typescript-resolvers": "^2.6.1",
     "@graphql-codegen/typescript": "^2.4.8",
     "@types/node": "^16",
-    "functionless": "^0.27.1",
+    "functionless": "*",
     "aws-cdk-lib": "2.44.0",
     "aws-cdk": "2.44.0",
     "constructs": "10.0.0",

--- a/apps/test-app/package.json
+++ b/apps/test-app/package.json
@@ -16,7 +16,7 @@
     "@graphql-codegen/typescript-resolvers": "^2.6.1",
     "@graphql-codegen/typescript": "^2.4.8",
     "@types/node": "^16",
-    "functionless": "*",
+    "functionless": "^0.28.0",
     "aws-cdk-lib": "2.44.0",
     "aws-cdk": "2.44.0",
     "constructs": "10.0.0",

--- a/apps/website/package.json
+++ b/apps/website/package.json
@@ -63,7 +63,6 @@
     "@functionless/serde": "*",
     "@functionless/serialize-closure": "*",
     "@functionless/swc-config": "*",
-    "@functionless/test": "*",
     "@functionless/util": "*",
     "@functionless/validate": "*",
     "@functionless/vtl": "*"
@@ -104,7 +103,11 @@
     "@types/react": "^17.0.0"
   },
   "browserslist": {
-    "production": [">0.5%", "not dead", "not op_mini all"],
+    "production": [
+      ">0.5%",
+      "not dead",
+      "not op_mini all"
+    ],
     "development": [
       "last 1 chrome version",
       "last 1 firefox version",

--- a/apps/website/tsconfig.json
+++ b/apps/website/tsconfig.json
@@ -121,9 +121,6 @@
       "path": "../../packages/@functionless/swc-config"
     },
     {
-      "path": "../../packages/@functionless/test"
-    },
-    {
       "path": "../../packages/@functionless/util"
     },
     {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "doctor:references": "node ./scripts/doctor-ts-references.mjs",
     "doctor": "yarn doctor:references && yarn doctor:readmes && yarn doctor:aggregate-packages",
     "lint": "turbo run lint",
-    "prepare": "husky install && yarn doctor",
+    "prepare": "husky install",
     "test:aws": "AWS_SDK_LOAD_CONFIG=1 TEST_DEPLOY_TARGET=AWS yarn test",
     "test:localstack": "TEST_DEPLOY_TARGET=LOCALSTACK yarn test",
     "test": "turbo run test",

--- a/packages/functionless/package.json
+++ b/packages/functionless/package.json
@@ -33,7 +33,6 @@
     "@functionless/serde": "^0.28.0",
     "@functionless/serialize-closure": "^0.28.0",
     "@functionless/swc-config": "^0.28.0",
-    "@functionless/test": "*",
     "@functionless/util": "^0.28.0",
     "@functionless/validate": "^0.28.0",
     "@functionless/vtl": "^0.28.0"

--- a/packages/functionless/tsconfig.json
+++ b/packages/functionless/tsconfig.json
@@ -91,9 +91,6 @@
       "path": "../@functionless/swc-config"
     },
     {
-      "path": "../@functionless/test"
-    },
-    {
       "path": "../@functionless/util"
     },
     {

--- a/scripts/doctor-aggregate-packages.mjs
+++ b/scripts/doctor-aggregate-packages.mjs
@@ -68,6 +68,7 @@ async function patch(pkgJsonPath, pkgJson, packages, dependenciesKey) {
     ...(pkgJson[dependenciesKey] ?? {}),
     ...Object.fromEntries(
       packages
+        .filter((pkg) => pkg.private !== true)
         .sort((pkgA, pkgB) => pkgA.name < pkgB.name)
         .map((pkg) => {
           return [pkg.name, pkgJson[dependenciesKey][pkg.name] ?? "*"];


### PR DESCRIPTION
@functionless/test (which is a private package) was in our public package's dependencies

- [x] remove `@functionles/test`
- [x] stop running doctor scripts on `yarn install` 