### PR TITLE
chore: add @swc/core as a peer depdendency

### DIFF
--- a/packages/@functionless/register/package.json
+++ b/packages/@functionless/register/package.json
@@ -15,6 +15,9 @@
     "@functionless/swc-config": "^0.28.0",
     "@swc/register": "^0.1.10"
   },
+  "peerDependencies": {
+    "@swc/core": "~1.2.245"
+  },
   "devDependencies": {
     "functionless-build-utils": "*",
     "typescript": "^4.8.3"

--- a/packages/create-functionless/src/util.ts
+++ b/packages/create-functionless/src/util.ts
@@ -42,30 +42,23 @@ export type PackageManager = "yarn" | "pnpm" | "npm";
 export function getPackageManager(): PackageManager {
   const packageManager = process.env.npm_config_user_agent;
 
-  if (packageManager?.startsWith("yarn")) {
-    return "yarn";
-  } else if (packageManager?.startsWith("pnpm")) {
-    return "pnpm";
-  } else {
-    return "npm";
-  }
+  return packageManager?.startsWith("yarn")
+    ? "yarn"
+    : packageManager?.startsWith("pnpm")
+    ? "pnpm"
+    : "npm";
 }
 
 export function installPackages(
   manager: PackageManager,
   dependencies: string[]
 ) {
-  let executable = "npm";
-  let command = "install";
-
-  if (manager === "yarn") {
-    executable = "yarn";
-    command = "add";
-  }
-
-  if (manager == "pnpm") {
-    executable = "pnpm";
-  }
+  const [executable, command = "install"] =
+    manager === "yarn"
+      ? ["yarn", "add"]
+      : manager === "pnpm"
+      ? ["pnpm"]
+      : ["npm"];
 
   failOnError(
     spawn.sync(executable, [command, "-D", ...dependencies], {

--- a/packages/create-functionless/templates/base/.gitignore.template
+++ b/packages/create-functionless/templates/base/.gitignore.template
@@ -1,3 +1,4 @@
+.fl/
 .swc/
 cdk.out/
 node_modules/

--- a/packages/create-functionless/templates/base/manifest.json
+++ b/packages/create-functionless/templates/base/manifest.json
@@ -1,5 +1,6 @@
 {
   "devDependencies": [
+    "@swc/core@~1.2",
     "@aws-cdk/aws-appsync-alpha",
     "@functionless/ast-reflection",
     "@functionless/language-service",


### PR DESCRIPTION
`create-functionless` does not add @swc/core by default.

```
thread '<unnamed>' panicked at 'called Result::unwrap() on an Err value: LayoutError', /home/runner/.cargo/registry/src/github.com-1ecc6299db9ec823/rkyv-0.7.37/src/impls/core/mod.rs:265:67
note: run with RUST_BACKTRACE=1 environment variable to display a backtrace
thread '<unnamed>' panicked at 'failed to invoke plugin: failed to invoke plugin on 'Some("/home/sussmans/functionless-bot/src/create-todo.ts")'
```

Also added `.fl/` to the default git ignore.